### PR TITLE
Update version.rb to support Semantic Versioning prerelease version strings

### DIFF
--- a/lib/cocoapods-core/vendor/version.rb
+++ b/lib/cocoapods-core/vendor/version.rb
@@ -147,7 +147,7 @@ module Pod::Vendor
 
     include Comparable
 
-    VERSION_PATTERN = '[0-9]+(\.[0-9a-zA-Z]+)*' # :nodoc:
+    VERSION_PATTERN = '[0-9]+(\.[0-9a-zA-Z\-]+)*' # :nodoc:
     ANCHORED_VERSION_PATTERN = /\A\s*(#{VERSION_PATTERN})*\s*\z/ # :nodoc:
 
     ##
@@ -251,10 +251,9 @@ module Pod::Vendor
     end
 
     ##
-    # A version is considered a prerelease if it contains a letter.
-
+    # Prerelease Pods can contain a hyphen and/or a letter (conforms to Semantic Versioning instead of RubyGems)
     def prerelease?
-      @prerelease ||= @version =~ /[a-zA-Z]/
+      @prerelease ||= @version =~ /[a-zA-Z\-]/
     end
 
     def pretty_print q # :nodoc:

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -43,6 +43,24 @@ module Pod
         version.should.be.head
         version.to_s.should == 'HEAD based on 1.2.3'
       end
+      
+      it "identifies release versions" do
+        version = Version.new('1.0.0')
+        version.should.not.be.prerelease
+      end
+    
+      it "matches Semantic Version pre-release versions" do
+        version = Version.new('1.0.0a1')
+        version.should.be.prerelease
+        version = Version.new('1.0.0-alpha')
+        version.should.be.prerelease
+        version = Version.new('1.0.0-alpha.1')
+        version.should.be.prerelease
+        version = Version.new('1.0.0-0.3.7')
+        version.should.be.prerelease
+        version = Version.new('1.0.0-x.7.z.92')
+        version.should.be.prerelease
+      end
     end
   end
 end


### PR DESCRIPTION
Title says it all. Fix for issue #4
