### PR TITLE
Remove dependency on /Users/fabio home directory

### DIFF
--- a/spec/podfile/dsl_spec.rb
+++ b/spec/podfile/dsl_spec.rb
@@ -90,8 +90,9 @@ module Pod
           stub_spec = Spec.new do |s|
             s.dependency 'monkey'
           end
-          expaded = Pathname.new("/Users/fabio/BananaLib.podspec")
-          Pod::Specification.expects(:from_file).with(expaded).returns(stub_spec)
+          home_dir = File.expand_path("~")
+          expanded = Pathname.new("#{home_dir}/BananaLib.podspec")
+          Pod::Specification.expects(:from_file).with(expanded).returns(stub_spec)
           podfile = Podfile.new(fixture('Podfile')) do
             platform :ios
             podspec :path => '~/BananaLib.podspec'


### PR DESCRIPTION
Updated the test to use a generic home directory, rather than '/Users/fabio'.  This allows other developers/machines to run tests that pass.

Used File::expand_path rather than Dir::home to maintain 1.8.7 compatibility.
