### PR TITLE
removed inhibit_all_warnings? and merged with inhibit_warnings_for_pod?

### DIFF
--- a/lib/cocoapods-core/podfile/target_definition.rb
+++ b/lib/cocoapods-core/podfile/target_definition.rb
@@ -267,17 +267,13 @@ module Pod
 
       #--------------------------------------#
 
-      # @return [Bool] whether the target definition should silence all the
-      #         warnings with a compiler flag.
-      #
-      def inhibit_all_warnings?
-        inhibit_warnings_hash['all'] || (parent.inhibit_all_warnings? unless root?)
-      end
-
       # @return [Bool] whether the target definition should inhibit warnings
-      #         for a single pod
+      #         for a single pod. If inhibit_all_warnings is true, it will
+      #         return true for any asked pod.
       #
       def inhibits_warnings_for_pod?(pod_name)
+        return true if inhibit_warnings_hash['all'] || (parent.inhibits_warnings_for_pod?(name) unless root?)
+
         inhibit_warnings_hash['for_pods'] ||= []
         inhibit_warnings_hash['for_pods'].include? pod_name
       end

--- a/spec/podfile/dsl_spec.rb
+++ b/spec/podfile/dsl_spec.rb
@@ -108,8 +108,8 @@ module Pod
       end
 
       it "allows to inhibit all the warnings of a Target definition" do
-        podfile = Podfile.new { inhibit_all_warnings! }
-        podfile.target_definitions["Pods"].inhibit_all_warnings?.should.be.true
+        podfile = Podfile.new { pod 'ObjectiveRecord'; inhibit_all_warnings! }
+        podfile.target_definitions["Pods"].inhibits_warnings_for_pod?('ObjectiveRecord').should.be.true
       end
     end
 

--- a/spec/podfile/target_definition_spec.rb
+++ b/spec/podfile/target_definition_spec.rb
@@ -192,7 +192,8 @@ module Pod
       #--------------------------------------#
 
       it "doesn't inhibit all warnings by default" do
-        @root.should.not.inhibit_all_warnings?
+        @root.store_pod("ObjectiveSugar")
+        @root.should.not.inhibits_warnings_for_pod?("ObjectiveSugar")
       end
 
       it "doesn't inhibit warnings per pod by default" do
@@ -213,12 +214,13 @@ module Pod
 
       it "returns if it should inhibit all warnings" do
         @root.inhibit_all_warnings = true
-        @root.should.inhibit_all_warnings?
+        @root.should.inhibits_warnings_for_pod?('ObjectiveSugar')
       end
 
       it "inherits the option to inhibit all warnings from the parent" do
         @root.inhibit_all_warnings = true
-        @child.should.inhibit_all_warnings?
+        @child.store_pod('ASIHTTPRequest')
+        @child.should.inhibits_warnings_for_pod?('ASIHTTPRequest')
       end
 
       #--------------------------------------#

--- a/spec/podfile_spec.rb
+++ b/spec/podfile_spec.rb
@@ -397,10 +397,10 @@ module Pod
         @podfile.target_definitions[:nested_osx_target].should.not.be.exclusive
       end
 
-      it "specifies that the inhibit all warnings flag should be added to the target's build settings" do
-        @podfile.target_definitions["Pods"].should.not.inhibit_all_warnings
-        @podfile.target_definitions[:test].should.inhibit_all_warnings
-        @podfile.target_definitions[:subtarget].should.inhibit_all_warnings
+      it "inhibits warnings for any asked pod if inhibit_all_warnings! is called" do
+        @podfile.target_definitions["Pods"].inhibits_warnings_for_pod?('SSZipArchive').should.not.be.true
+        @podfile.target_definitions[:test].inhibits_warnings_for_pod?('JSONKit').should.be.true
+        @podfile.target_definitions[:subtarget].inhibits_warnings_for_pod?('Reachability').should.be.true
       end
 
       it "returns the Xcode project that contains the target to link with" do


### PR DESCRIPTION
Probably not ready to be merged yet;
First checkpoint from https://github.com/CocoaPods/CocoaPods/issues/942 solved.
