### PR TITLE
Add possibility for Podfile.local

### DIFF
--- a/lib/cocoapods-core/podfile.rb
+++ b/lib/cocoapods-core/podfile.rb
@@ -219,7 +219,7 @@ module Pod
       end
 
       case path.extname
-      when ''
+      when '', '.local'
         Podfile.from_ruby(string, path)
       when '.yaml', '.cocoapods'
         Podfile.from_yaml(string, path)


### PR DESCRIPTION
We wanna have a local developer only Podfile to handle for example this case:

Normally all developers should use the project specific Podfile which is in our git repo. But if a single developer now wants to work on a dependency of that project, we wanna create a "local" Podfile which is include in the .gitignore. In this local Podfile the developer can then for example specify something like this:

pod "blabla", :local => '......'
