### PR TITLE
Minor typographical fixes

### DIFF
--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -212,12 +212,12 @@ module Pod
       #
       #   @example Specifying a Git source with a tag.
       #
-      #     spec.source = { :git => "git://github.com/AFNetworking/AFNetworking.git",
+      #     spec.source = { :git => 'git://github.com/AFNetworking/AFNetworking.git',
       #                     :tag => 'v0.0.1' }
       #
       #   @example Using the version of the Pod to identify the Git tag.
       #
-      #     spec.source = { :git => "git://github.com/AFNetworking/AFNetworking.git",
+      #     spec.source = { :git => 'git://github.com/AFNetworking/AFNetworking.git',
       #                     :tag => "v#{spec.version}" }
       #
       #   @param  [Hash{Symbol=>String}] source


### PR DESCRIPTION
On the CocoaPods website's [main specification page](http://docs.cocoapods.org/specification.html), single quotes are used for the source URL and the tag. This pull request aims to make that consistent in the [`source` documentation](http://docs.cocoapods.org/specification.html#source).
