### PR TITLE
Broken Links in Podfile Docs

### DIFF
--- a/lib/cocoapods-core/podfile/dsl.rb
+++ b/lib/cocoapods-core/podfile/dsl.rb
@@ -452,7 +452,7 @@ module Pod
       # been downloaded but before they are installed.
       #
       # It receives the
-      # `[Pod::Hooks::InstallerRepresentation](http://docs.cocoapods.org/cocoapods/pod/hooks/installerrepresentation/)`
+      # [`Pod::Hooks::InstallerRepresentation`](http://docs.cocoapods.org/cocoapods/pod/hooks/installerrepresentation/)
       # as its only argument.
       #
       # @example  Defining a pre install hook in a Podfile.
@@ -471,7 +471,7 @@ module Pod
       # to perform.
       #
       # It receives the
-      # `[Pod::Hooks::InstallerRepresentation](http://docs.cocoapods.org/cocoapods/pod/hooks/installerrepresentation/)`
+      # [`Pod::Hooks::InstallerRepresentation`](http://docs.cocoapods.org/cocoapods/pod/hooks/installerrepresentation/)
       # as its only argument.
       #
       # @example  Customizing the `OTHER_LDFLAGS` of all targets


### PR DESCRIPTION
This fixes Markdown in the Podfile docs that was breaking links in the `pre_install` and `post_install` descriptions.
