### PR TITLE
[Podfile::DSL] Allow link_with targets to be passed as the arg list instead of an array

### DIFF
--- a/lib/cocoapods-core/podfile/dsl.rb
+++ b/lib/cocoapods-core/podfile/dsl.rb
@@ -345,18 +345,18 @@ module Pod
       # @param    [String, Array<String>] targets
       #           the target or the targets to link with.
       #
-      # @example  Link with an user project target
+      # @example  Link with a user project target
       #
       #           link_with 'MyApp'
       #
-      # @example  Link with a more user project targets
+      # @example  Link with multiple user project targets
       #
-      #           link_with ['MyApp', 'MyOtherApp']
+      #           link_with 'MyApp', 'MyOtherApp'
       #
       # @return   [void]
       #
-      def link_with(targets)
-        current_target_definition.link_with = targets
+      def link_with(*targets)
+        current_target_definition.link_with = targets.flatten
       end
 
       # Inhibits **all** the warnings from the CocoaPods libraries.

--- a/spec/podfile/dsl_spec.rb
+++ b/spec/podfile/dsl_spec.rb
@@ -107,6 +107,16 @@ module Pod
         podfile.target_definitions["Pods"].link_with.should == ['app_target']
       end
 
+      it "allows to specify multiple user targets a Target definition should link with" do
+        podfile = Podfile.new { link_with 'app_target', 'test_target' }
+        podfile.target_definitions["Pods"].link_with.should == ['app_target', 'test_target']
+      end
+
+      it "allows to specify an array of user targets a Target definition should link with" do
+        podfile = Podfile.new { link_with ['app_target'] }
+        podfile.target_definitions["Pods"].link_with.should == ['app_target']
+      end
+
       it "allows to inhibit all the warnings of a Target definition" do
         podfile = Podfile.new { pod 'ObjectiveRecord'; inhibit_all_warnings! }
         podfile.target_definitions["Pods"].inhibits_warnings_for_pod?('ObjectiveRecord').should.be.true

--- a/spec/podfile/target_definition_spec.rb
+++ b/spec/podfile/target_definition_spec.rb
@@ -134,6 +134,11 @@ module Pod
         @root.link_with.should.be == ['appTarget1']
       end
 
+      it "allows targets to be passed in the argument list instead of as an array" do
+        @root.link_with = 'appTarget1', 'appTarget2'
+        @root.link_with.should.be == ['appTarget1', 'appTarget2']
+      end
+
       it "returns nil if the link_with array is empty" do
         @root.link_with = []
         @root.link_with.should.be.nil


### PR DESCRIPTION
Seemed like it would be a nice API not to be required to wrap the target
list in an array explicitly. Hope you like it!
