### PR TITLE
Adding a warning for leaving the homepage as default in a podspec.

### DIFF
--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -223,6 +223,10 @@ module Pod
         warning "The description is shorter than the summary." if d.length < spec.summary.length
       end
 
+      def _validate_homepage(h)
+        warning "The homepage has not been updated from default" if h =~ /http:\/\/EXAMPLE/
+      end
+
       # Performs validations related to the `license` attribute.
       #
       def _validate_license(l)

--- a/spec/specification/linter_spec.rb
+++ b/spec/specification/linter_spec.rb
@@ -211,6 +211,13 @@ module Pod
 
       #------------------#
 
+      it "checks if the homepage has been changed from default" do
+        @spec.stubs(:homepage).returns('http://EXAMPLE/test')
+        message_should_include('homepage', 'default')
+      end
+
+      #------------------#
+
       it "checks whether the license type" do
         @spec.stubs(:license).returns({ :file => 'License' })
         message_should_include('license', 'type')


### PR DESCRIPTION
Adding functionality requested in CocoaPods/CocoaPods#1265 in the main repository to the linter.
