### PR TITLE
Fix incorrect errors when linting specs

### DIFF
--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -302,11 +302,11 @@ module Pod
       # Check empty subspec attributes
       #
       def check_if_spec_is_empty
-        methods = %w[ source_files resources preserve_paths dependencies ]
+        methods = %w[ source_files resources preserve_paths dependencies vendored_libraries ]
         empty_patterns = methods.all? { |m| consumer.send(m).empty? }
         empty = empty_patterns && consumer.spec.subspecs.empty?
         if empty
-          error "The #{consumer.spec} spec is empty (no source files, resources, preserve paths, dependencies or subspecs)."
+          error "The #{consumer.spec} spec is empty (no source files, resources, preserve paths, vendored_libraries, dependencies or subspecs)."
         end
       end
 

--- a/spec/specification/linter_spec.rb
+++ b/spec/specification/linter_spec.rb
@@ -310,6 +310,7 @@ module Pod
         consumer.any_instance.stubs(:preserve_paths).returns([])
         consumer.any_instance.stubs(:subspecs).returns([])
         consumer.any_instance.stubs(:dependencies).returns([])
+        consumer.any_instance.stubs(:vendored_libraries).returns([])
         @linter.lint
         message = @linter.results.first.message
         message.should.include('spec is empty')


### PR DESCRIPTION
Fixes #36 and #37. Gists use https now for downloading and therefore shouldn't throw errors when they do. Vendored Libraries should also be considered when checking for empty.
