### PR TITLE
Add validation to frameworks to make sure they are only names

### DIFF
--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -258,6 +258,14 @@ module Pod
         end
       end
 
+      def _validate_frameworks(frameworks)
+        check_frameworks(frameworks)
+      end
+
+      def _validate_weak_frameworks(frameworks)
+        check_frameworks(frameworks)
+      end
+
       # Performs validations related to the `license` attribute.
       #
       def _validate_license(l)
@@ -394,6 +402,13 @@ module Pod
               " `prepare_command` attributes."
         end
       end
+
+      def check_frameworks(frameworks)
+        if frameworks.any? { |framework| framework.end_with?('.framework')}
+          error "Frameworks should be specified by their name only."
+        end
+      end
+
 
       #-----------------------------------------------------------------------#
 

--- a/spec/specification/linter_spec.rb
+++ b/spec/specification/linter_spec.rb
@@ -281,6 +281,18 @@ module Pod
         @spec.stubs(:source).returns({:git => 'www.banana-empire.git'})
         message_should_include('sources', 'specify a tag.')
       end
+
+      #------------------#
+
+      it "checks that frameworks do not end with a .framework extension" do
+        @spec.stubs(:frameworks).returns(['AddressBook.framework', 'QuartzCore.framework'])
+        message_should_include('framework', 'name only')
+      end
+
+      it "checks that weak frameworks do not end with a .framework extension" do
+        @spec.stubs(:weak_frameworks).returns(['AddressBook.framework', 'QuartzCore.framework'])
+        message_should_include('framework', 'name only')
+      end
     end
 
     #--------------------------------------#


### PR DESCRIPTION
The tests are failing and I can't figure out why (something mock related maybe?) but I believe this fixes [Cocoapods#1336](https://github.com/CocoaPods/CocoaPods/issues/1336).

In terms of logic I think I'm on the right track but I think another set of eyes might be useful.
