### PR TITLE
Fix a minor typo in resource_bundles documentation

### DIFF
--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -988,7 +988,7 @@ module Pod
       #   attribute.
       #
       #   The names of the bundles should at least include the name of the Pod
-      #   to minimize the change of name collisions.
+      #   to minimize the chance of name collisions.
       #
       #   To provide different resources per platform namespaced bundles *must*
       #   be used.


### PR DESCRIPTION
About as straight-forward as it gets — just noticed a wrong word when reading the documentation on using resource bundles.
