### PR TITLE
Add more descriptive error message for invalid string specification

### DIFF
--- a/lib/cocoapods-core/specification.rb
+++ b/lib/cocoapods-core/specification.rb
@@ -127,7 +127,9 @@ module Pod
       match_data = string_representation.match(/(\S*) \((.*)\)/)
       unless match_data
         raise Informative, "Invalid string representation for a " \
-          "Specification: `#{string_representation}`."
+          "Specification: `#{string_representation}`." \
+          "String representation should include the name and " \
+          "the version of a pod."
       end
       name = match_data[1]
       vers = Version.new(match_data[2])


### PR DESCRIPTION
Had a local Pod w/ a name but no version #. Everything worked fine on first `pod install`, but subsequent `pod install`s would result in the "invalid string representation" error message that doesn't shed any light on what's going on.
