### PR TITLE
Add support for the specification of dependencies by configuration

### DIFF
--- a/lib/cocoapods-core/podfile/target_definition.rb
+++ b/lib/cocoapods-core/podfile/target_definition.rb
@@ -332,13 +332,13 @@ module Pod
       #
       def is_pod_whitelisted_for_configuration?(pod_name, configuration_name)
         found = false
-        configuration_pod_whitelist.each { |configuration, pods|
+        configuration_pod_whitelist.each do |configuration, pods|
           if pods.include?(pod_name)
             found = true
             return true if configuration.to_s == configuration_name.to_s
           end
-        }
-        return !found
+        end
+        !found
       end
 
       # Whitelists a pod for a specific configuration. If a pod is whitelisted
@@ -693,9 +693,9 @@ module Pod
 
         configurations_to_whitelist_in = options.delete(:configurations)
         if configurations_to_whitelist_in
-          configurations_to_whitelist_in.each{ |configuration|
+          configurations_to_whitelist_in.each do |configuration|
             whitelist_pod_for_configuration(name, configuration)
-          }
+          end
         end
 
         requirements.pop if options.empty?

--- a/spec/podfile/target_definition_spec.rb
+++ b/spec/podfile/target_definition_spec.rb
@@ -230,6 +230,25 @@ module Pod
 
       #--------------------------------------#
 
+      it "whitelists pods by default" do
+        @root.store_pod("ObjectiveSugar")
+        @root.should.is_pod_whitelisted_for_configuration?("ObjectiveSugar", "Release")
+      end
+
+      it "does not enable pods for un-whitelisted configurations if it is whitelisted for another" do
+        @root.store_pod("ObjectiveSugar")
+        @root.whitelist_pod_for_configuration("ObjectiveSugar", "Release")
+        @root.should.not.is_pod_whitelisted_for_configuration?("ObjectiveSugar", "Debug")
+      end
+
+      it "enables pods for configurations they are whitelisted for" do
+        @root.store_pod("ObjectiveSugar")
+        @root.whitelist_pod_for_configuration("ObjectiveSugar", "Release")
+        @root.should.is_pod_whitelisted_for_configuration?("ObjectiveSugar", "Release")
+      end
+
+      #--------------------------------------#
+
       it "returns its platform" do
         @root.platform.should == Pod::Platform.new(:ios, '6.0')
       end


### PR DESCRIPTION
Podfile parsing of the functionality for https://github.com/CocoaPods/CocoaPods/pull/1668 .

@irrationalfab has opinions on the syntax. I built what @alloy suggested. I think @alloy's syntax is easier for beginners (I'm thinking from the perspective of being the author of http://lookback.io/docs/install-using-cocoapods , where I want to make step #2 as short as possible). I also agree that it's weird to overload a hash whose primary usage is to specify where the code is, with linker settings. I think the usability argument is stronger, though. Both syntaxes could easily be supported.

I've written the code so it should be easy to switch to @irrationalfab's syntax, or to support both. Where do we go from here? (Also, what should I fix in my PR before it's mergeable? :) )
