### PR TITLE
Don't validate vendored_libraries path

### DIFF
--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -284,14 +284,6 @@ module Pod
         end
       end
 
-      # Performs validations related to the `vendored_libraries` attribute.
-      #
-      def _validate_vendored_libraries(libs)
-        if libraries_invalid?(libs)
-          error "A vendored library should only be specified by its name"
-        end
-      end
-
       # Performs validations related to the `license` attribute.
       #
       def _validate_license(l)

--- a/spec/specification/linter_spec.rb
+++ b/spec/specification/linter_spec.rb
@@ -310,23 +310,6 @@ module Pod
         @spec.libraries = %w{libz libssl}
         message_should_include('library', 'name')
       end
-
-      #------------------#
-
-      it "checks that vendored libraries do not end with a .a extension" do
-        @spec.vendored_libraries = %w{magic.a foo.a}
-        message_should_include('library', 'name')
-      end
-
-      it "checks that vendored libraries do not end with a .dylib extension" do
-        @spec.vendored_libraries = %w{magic.dylib foo.dylib}
-        message_should_include('library', 'name')
-      end
-
-      it "checks that vendored libraries do not begin with lib" do
-        @spec.vendored_libraries = %w{libfoo libbar}
-        message_should_include('library', 'name')
-      end
     end
 
     #--------------------------------------#


### PR DESCRIPTION
This removes the validation for vendored libraries to be identified with `foo` instead of `libfoo.a`. Since `libfoo.a` is the library's file path it makes sense to allow that directly. Invalid libraries will still be caught with https://github.com/CocoaPods/CocoaPods/blob/0dc6fa95b3636fa5923a401e2fea52e2f40c0e1e/lib/cocoapods/validator.rb#L293
