### PR TITLE
Fixed default_subspec for nested subspec

### DIFF
--- a/lib/cocoapods-core/specification.rb
+++ b/lib/cocoapods-core/specification.rb
@@ -232,7 +232,7 @@ module Pod
     #
     def subspec_dependencies(platform = nil)
       if default_subspec
-        specs = [subspec_by_name("#{name}/#{default_subspec}")]
+        specs = [subspec_by_name("#{base_name}/#{default_subspec}")]
       else
         specs = subspecs.compact
       end


### PR DESCRIPTION
Fixes CocoaPods/CocoaPods#1021 which has been around for a long time now.
