### PR TITLE
Fixes exception when git tag is a Version

### DIFF
--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -312,10 +312,9 @@ module Pod
           if commit && commit.downcase =~ /head/
             error 'The commit of a Git source cannot be `HEAD`.'
           end
-          if tag && !tag.include?(version)
+          if tag && !tag.to_s.include?(version)
             warning 'The version should be included in the Git tag.'
           end
-
           if version == '0.0.1'
             if commit.nil? && tag.nil?
               error 'Git sources should specify either a commit or a tag.'

--- a/spec/specification/linter_spec.rb
+++ b/spec/specification/linter_spec.rb
@@ -254,9 +254,15 @@ module Pod
         message_should_include('source', 'HEAD')
       end
 
-      it "checks that the version is included in the git tag" do
+      it "checks that the version is included in the git tag when the version is a string" do
         @spec.stubs(:version).returns(Version.new '1.0.1')
         @spec.stubs(:source).returns({ :git => 'http://repo.git', :tag => '1.0' })
+        message_should_include('git', 'version', 'tag')
+      end
+      
+      it "checks that the version is included in the git tag  when the version is a Version" do
+        @spec.stubs(:version).returns(Version.new '1.0.1')
+        @spec.stubs(:source).returns({ :git => 'http://repo.git', :tag => (Version.new '1.0') })
         message_should_include('git', 'version', 'tag')
       end
 


### PR DESCRIPTION
This fixes Cocoapods/cocoapods#1721

Now if someone writes

```
     s.source = { :git => "https://github.com/DDBen/pods.git", :tag => s.version }
```

in their pod spec its going to succeed instead of fail with a stack trace.
# cocoapodsbugbash
