### PR TITLE
Better linting for Github URIs.

### DIFF
--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -333,18 +333,15 @@ module Pod
       # Performs validations related to github sources.
       #
       def perform_github_source_checks(s)
-        supported_domains = [
-          'https://github.com',
-          'https://gist.github.com',
-        ]
+        require 'uri'
 
         if git = s[:git]
-          is_github = git.include?('github.com')
-          if is_github
+          git_uri = URI.parse(git)
+          if git_uri.host == 'github.com'
             unless git.end_with?('.git')
               warning "Github repositories should end in `.git`."
             end
-            unless supported_domains.find { |domain| git.start_with?(domain) }
+            unless git_uri.scheme == 'https'
               warning "Github repositories should use `https` link."
             end
           end

--- a/spec/specification/linter_spec.rb
+++ b/spec/specification/linter_spec.rb
@@ -286,6 +286,12 @@ module Pod
         message_should_include('Github', '.git')
       end
 
+      it "does not warn for Github repositories with OAuth authentication" do
+        @spec.stubs(:source).returns({ :git => 'https://TOKEN:x-oauth-basic@github.com/COMPANY/REPO.git', :tag => '1.0' })
+        @linter.lint
+        @linter.results.should.be.empty
+      end
+
       it "checks the source of 0.0.1 specifications for commit or a tag" do
         @spec.stubs(:version).returns(Version.new '0.0.1')
         @spec.stubs(:source).returns({ :git => 'www.banana-empire.git' })


### PR DESCRIPTION
Actually check URI.host and URI.scheme instead of checking against hardcoded URLs.

Does not longer warn for Github repositories with OAuth authentication, which was reported in CocoaPods/CocoaPods#1928
