### PR TITLE
Reinstate checks for gist.github.com

### DIFF
--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -334,7 +334,7 @@ module Pod
 
         if git = s[:git]
           git_uri = URI.parse(git)
-          if git_uri.host == 'github.com'
+          if git_uri.host == 'github.com' || git_uri.host == 'gist.github.com'
             unless git.end_with?('.git')
               warning "Github repositories should end in `.git`."
             end

--- a/spec/specification/linter_spec.rb
+++ b/spec/specification/linter_spec.rb
@@ -286,6 +286,11 @@ module Pod
         @linter.results.should.be.empty
       end
 
+      it "performs checks for Gist Github repositories" do
+        @spec.stubs(:source).returns({ :git => "git://gist.github.com/2823399.git", :tag => "1.0" })
+        message_should_include('Github', 'https')
+      end
+
       it "checks the source of 0.0.1 specifications for commit or a tag" do
         @spec.stubs(:version).returns(Version.new '0.0.1')
         @spec.stubs(:source).returns({ :git => 'www.banana-empire.git' })


### PR DESCRIPTION
As @kylef noticed, #77 disabled the checks for `gist.github.com` URLs. This PR reinstates them. 
