### PR TITLE
Support repositories with dots in the name when making GitHub requests

### DIFF
--- a/lib/cocoapods-core/github.rb
+++ b/lib/cocoapods-core/github.rb
@@ -103,7 +103,7 @@ module Pod
     # @return [Nil] if the given url is not a valid github repo url.
     #
     def self.repo_id_from_url(url)
-      url[%r{github.com/([^/\.]*/[^/\.]*)\.*}, 1]
+      url[%r{github.com/([^/]*/[^/]*)\.*}, 1]
     end
 
     # Performs a get request with the given URL.

--- a/spec/fixtures/vcr_cassettes/GitHub.yml
+++ b/spec/fixtures/vcr_cassettes/GitHub.yml
@@ -358,4 +358,75 @@ http_interactions:
       string: '{"message":"Not Found","documentation_url":"http://developer.github.com/v3"}'
     http_version: 
   recorded_at: Mon, 02 Dec 2013 03:19:46 GMT
-recorded_with: VCR 2.5.0
+- request:
+    method: get
+    uri: https://api.github.com/repos/contentful/contentful.objc
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CocoaPods
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Tue, 08 Apr 2014 14:25:21 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '60'
+      X-Ratelimit-Remaining:
+      - '45'
+      X-Ratelimit-Reset:
+      - '1396968436'
+      Cache-Control:
+      - public, max-age=60, s-maxage=60
+      Last-Modified:
+      - Tue, 08 Apr 2014 11:04:26 GMT
+      Etag:
+      - '"67d75da27c6c75797e7f4d3a94e47275"'
+      Vary:
+      - Accept
+      - Accept-Encoding
+      X-Github-Media-Type:
+      - github.beta
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - deny
+      Content-Security-Policy:
+      - default-src 'none'
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Expose-Headers:
+      - ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - '*'
+      X-Github-Request-Id:
+      - 4E359872:6646:DD2F:534406D0
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Served-By:
+      - a1d8c69b807c8e21f06cad9da377d1b0
+    body:
+      encoding: UTF-8
+      string: '{"id":17830008,"name":"contentful.objc","full_name":"contentful/contentful.objc","owner":{"login":"contentful","id":472182,"avatar_url":"https://avatars.githubusercontent.com/u/472182?","gravatar_id":"e56de7e4f179bef19f5faa9771f5e085","url":"https://api.github.com/users/contentful","html_url":"https://github.com/contentful","followers_url":"https://api.github.com/users/contentful/followers","following_url":"https://api.github.com/users/contentful/following{/other_user}","gists_url":"https://api.github.com/users/contentful/gists{/gist_id}","starred_url":"https://api.github.com/users/contentful/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/contentful/subscriptions","organizations_url":"https://api.github.com/users/contentful/orgs","repos_url":"https://api.github.com/users/contentful/repos","events_url":"https://api.github.com/users/contentful/events{/privacy}","received_events_url":"https://api.github.com/users/contentful/received_events","type":"Organization","site_admin":false},"private":false,"html_url":"https://github.com/contentful/contentful.objc","description":"","fork":false,"url":"https://api.github.com/repos/contentful/contentful.objc","forks_url":"https://api.github.com/repos/contentful/contentful.objc/forks","keys_url":"https://api.github.com/repos/contentful/contentful.objc/keys{/key_id}","collaborators_url":"https://api.github.com/repos/contentful/contentful.objc/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/contentful/contentful.objc/teams","hooks_url":"https://api.github.com/repos/contentful/contentful.objc/hooks","issue_events_url":"https://api.github.com/repos/contentful/contentful.objc/issues/events{/number}","events_url":"https://api.github.com/repos/contentful/contentful.objc/events","assignees_url":"https://api.github.com/repos/contentful/contentful.objc/assignees{/user}","branches_url":"https://api.github.com/repos/contentful/contentful.objc/branches{/branch}","tags_url":"https://api.github.com/repos/contentful/contentful.objc/tags","blobs_url":"https://api.github.com/repos/contentful/contentful.objc/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/contentful/contentful.objc/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/contentful/contentful.objc/git/refs{/sha}","trees_url":"https://api.github.com/repos/contentful/contentful.objc/git/trees{/sha}","statuses_url":"https://api.github.com/repos/contentful/contentful.objc/statuses/{sha}","languages_url":"https://api.github.com/repos/contentful/contentful.objc/languages","stargazers_url":"https://api.github.com/repos/contentful/contentful.objc/stargazers","contributors_url":"https://api.github.com/repos/contentful/contentful.objc/contributors","subscribers_url":"https://api.github.com/repos/contentful/contentful.objc/subscribers","subscription_url":"https://api.github.com/repos/contentful/contentful.objc/subscription","commits_url":"https://api.github.com/repos/contentful/contentful.objc/commits{/sha}","git_commits_url":"https://api.github.com/repos/contentful/contentful.objc/git/commits{/sha}","comments_url":"https://api.github.com/repos/contentful/contentful.objc/comments{/number}","issue_comment_url":"https://api.github.com/repos/contentful/contentful.objc/issues/comments/{number}","contents_url":"https://api.github.com/repos/contentful/contentful.objc/contents/{+path}","compare_url":"https://api.github.com/repos/contentful/contentful.objc/compare/{base}...{head}","merges_url":"https://api.github.com/repos/contentful/contentful.objc/merges","archive_url":"https://api.github.com/repos/contentful/contentful.objc/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/contentful/contentful.objc/downloads","issues_url":"https://api.github.com/repos/contentful/contentful.objc/issues{/number}","pulls_url":"https://api.github.com/repos/contentful/contentful.objc/pulls{/number}","milestones_url":"https://api.github.com/repos/contentful/contentful.objc/milestones{/number}","notifications_url":"https://api.github.com/repos/contentful/contentful.objc/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/contentful/contentful.objc/labels{/name}","releases_url":"https://api.github.com/repos/contentful/contentful.objc/releases{/id}","created_at":"2014-03-17T14:05:15Z","updated_at":"2014-04-08T11:04:26Z","pushed_at":"2014-04-08T11:04:25Z","git_url":"git://github.com/contentful/contentful.objc.git","ssh_url":"git@github.com:contentful/contentful.objc.git","clone_url":"https://github.com/contentful/contentful.objc.git","svn_url":"https://github.com/contentful/contentful.objc","homepage":null,"size":12976,"stargazers_count":3,"watchers_count":3,"language":"Objective-C","has_issues":true,"has_downloads":true,"has_wiki":true,"forks_count":0,"mirror_url":null,"open_issues_count":0,"forks":0,"open_issues":0,"watchers":3,"default_branch":"master","master_branch":"master","organization":{"login":"contentful","id":472182,"avatar_url":"https://avatars.githubusercontent.com/u/472182?","gravatar_id":"e56de7e4f179bef19f5faa9771f5e085","url":"https://api.github.com/users/contentful","html_url":"https://github.com/contentful","followers_url":"https://api.github.com/users/contentful/followers","following_url":"https://api.github.com/users/contentful/following{/other_user}","gists_url":"https://api.github.com/users/contentful/gists{/gist_id}","starred_url":"https://api.github.com/users/contentful/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/contentful/subscriptions","organizations_url":"https://api.github.com/users/contentful/orgs","repos_url":"https://api.github.com/users/contentful/repos","events_url":"https://api.github.com/users/contentful/events{/privacy}","received_events_url":"https://api.github.com/users/contentful/received_events","type":"Organization","site_admin":false},"network_count":0,"subscribers_count":6}'
+    http_version: 
+  recorded_at: Tue, 08 Apr 2014 14:25:15 GMT
+recorded_with: VCR 2.9.0

--- a/spec/github_spec.rb
+++ b/spec/github_spec.rb
@@ -18,6 +18,13 @@ module Pod
         end
       end
 
+      it 'returns the information of a repo with dots in the name' do
+        VCR.use_cassette('GitHub', :record => :new_episodes) do
+          repo = GitHub.repo('https://github.com/contentful/contentful.objc')
+          repo['name'].should == 'contentful.objc'
+        end
+      end
+
       it 'returns the tags of a repo' do
         VCR.use_cassette('GitHub', :record => :new_episodes) do
           tags = GitHub.tags('https://github.com/CocoaPods/CocoaPods')


### PR DESCRIPTION
Repositories can have a dot in their name, e.g. https://github.com/contentful/contentful.objc - they're currently broken, as the name will be cut off in front of the dot. 

This is a fix for that, but I am unsure about that regular expression, @irrationalfab was there a reason why it split at dots?
