### PR TITLE
Removed incompatibility with active_support 4.x.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group :development do
   gem 'vcr'
   gem 'webmock', "< 1.16"
   if RUBY_VERSION >= '1.9.3'
-    gem 'rubocop'
+    gem 'rubocop', '~> 0.20.1'
   end
 end
 

--- a/cocoapods-core.gemspec
+++ b/cocoapods-core.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files         =  Dir["lib/**/*.rb"] + %w{ README.md LICENSE }
   s.require_paths =  %w{ lib }
 
-  s.add_runtime_dependency 'activesupport', '>= 3.2.15', '< 4'
+  s.add_runtime_dependency 'activesupport', '>= 3.2.15'
   s.add_runtime_dependency 'nap', "~> 0.5"
   s.add_runtime_dependency "json_pure", "~> 1.8"
   s.add_runtime_dependency 'fuzzy_match', "~> 2.0.4"


### PR DESCRIPTION
Tested with active_support 4.x and everything works well.

Rubocop 0.21 is not supported, version fixed to 0.20.1
