### PR TITLE
Added missing space to acceptor

### DIFF
--- a/lib/cocoapods-core/source/acceptor.rb
+++ b/lib/cocoapods-core/source/acceptor.rb
@@ -73,7 +73,7 @@ module Pod
           unless source == old_source
             message = "The source of the spec doesn't match with the recorded "
             message << "ones. Source: `#{source}`. Previous: `#{old_source}`.\n "
-            message << 'Please contact the specs repo maintainers if the'
+            message << 'Please contact the specs repo maintainers if the '
             message << 'library changed location.'
             errors << message
           end


### PR DESCRIPTION
Tiniest pull request ever: there's a missing space in the acceptor file, which results in messages like this:

```
Please contact the specs repo maintainers if thelibrary changed location.
```
