### PR TITLE
Fix Podfile guide by correcting whitespace

### DIFF
--- a/lib/cocoapods-core/podfile/dsl.rb
+++ b/lib/cocoapods-core/podfile/dsl.rb
@@ -145,7 +145,7 @@ module Pod
       # @note       This method allow a nil name and the raises to be more
       #             informative.
       #
-        # @note       Support for inline podspecs has been deprecated.
+      # @note       Support for inline podspecs has been deprecated.
       #
       # @return     [void]
       #


### PR DESCRIPTION
This fixes
https://github.com/CocoaPods/guides.cocoapods.org/issues/1

It seems that the rake task was having trouble parsing the documentation, but it worked when I fixed the whitespace.
