### PR TITLE
[DSL] Add support for test specifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 0.36.1
 
+##### Enhancements
+
+* Add support for test specifications in the podspec DSL.  
+  [Kyle Fuller](https://github.com/kylef)
+  [#142](https://github.com/CocoaPods/Core/pull/142)
+
 ##### Bug Fixes
 
 * Ensure that strings that are serialized to YAML are escaped and quoted, if

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -1221,6 +1221,28 @@ module Pod
         subspec
       end
 
+      # Represents a test specification for the library. Here you can place all
+      # your unit tests for your podspec along with the test dependencies.
+      #
+      # ---
+      #
+      # @example
+      #
+      #   Pod::Spec.new do |spec|
+      #     spec.name = 'NSAttributedString+CCLFormat'
+      #
+      #     spec.test_spec do |test_spec|
+      #       test_spec.source_files = 'NSAttributedString+CCLFormatTests.m'
+      #       test_spec.dependency 'Expecta'
+      #     end
+      #   end
+      #
+      def test_spec(&block)
+        subspec = Specification.new(self, 'Tests', true, &block)
+        @subspecs << subspec
+        subspec
+      end
+
       #------------------#
 
       # @!method default_subspecs=(subspec_array)

--- a/spec/specification/dsl_spec.rb
+++ b/spec/specification/dsl_spec.rb
@@ -338,6 +338,26 @@ module Pod
 
     #-----------------------------------------------------------------------------#
 
+    describe 'Test specs' do
+      before do
+        @spec = Spec.new do |spec|
+          spec.name = 'Spec'
+
+          spec.test_spec do
+          end
+        end
+      end
+
+      it 'allows you to specify a test spec' do
+        test_spec = @spec.test_spec
+        test_spec.class.should == Specification
+        test_spec.name.should == 'Spec/Tests'
+        test_spec.test_specification?.should == true
+      end
+    end
+
+    #-----------------------------------------------------------------------------#
+
     describe 'Multi-Platform' do
       before do
         @spec = Spec.new do |s|

--- a/spec/specification_spec.rb
+++ b/spec/specification_spec.rb
@@ -226,6 +226,17 @@ module Pod
         @spec.subspec_by_name('Pod/Subspec/Subsubspec').should == @subsubspec
       end
 
+      it "doesn't return the test subspec given the Tests name" do
+        @spec = Spec.new do |s|
+          s.name = 'Pod'
+          s.version = '1.0'
+          s.dependency 'AFNetworking'
+          s.osx.dependency 'MagicalRecord'
+          s.test_spec {}
+        end
+        @spec.subspec_by_name('Pod/Tests', false).should. nil?
+      end
+
       it 'returns a subspec given the relative name' do
         @subspec.subspec_by_name('Subspec/Subsubspec').should == @subsubspec
       end
@@ -278,6 +289,15 @@ module Pod
           Dependency.new('Pod/Subspec', '1.0'),
           Dependency.new('Pod/SubspeciOS', '1.0'),
         ]
+      end
+
+      it 'excludes the test subspec from the subspec dependencies' do
+        @spec.test_spec {}
+
+        @spec.subspec_dependencies.sort.should == [
+          Dependency.new('Pod/Subspec', '1.0'),
+          Dependency.new('Pod/SubspecOSX', '1.0'),
+          Dependency.new('Pod/SubspeciOS', '1.0')]
       end
 
       it 'returns all the dependencies' do


### PR DESCRIPTION
Closes #129 

/cc @supermarin 

@irrationalfab Is there anywhere I can put the 'Tests' hard coded name? Also open for better suggestions as a name. Perhaps 'CP_Tests' (reserved prefix), or even another property to mark this state?