### PR TITLE
Better podspec source examples

### DIFF
--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -246,10 +246,10 @@ module Pod
       #     spec.source = { :git => 'https://github.com/AFNetworking/AFNetworking.git',
       #                     :tag => spec.version.to_s }
       #
-      #   @example Using the version of the Pod to identify the Git commit and using submodules.
+      #   @example Using a tag prefixed with 'v' and submodules.
       #
-      #     spec.source = { :git => 'https://github.com/AFNetworking/AFNetworking.git',
-      #                     :commit => "v#{spec.version}", :submodules => true }
+      #     spec.source = { :git => 'https://github.com/typhoon-framework/Typhoon.git',
+      #                     :tag => "v#{spec.version}", :submodules => true }
       #
       #   @example Using Subversion with a tag.
       #


### PR DESCRIPTION
After discussion in CocoaPods/CocoaPods#2334

Before merging, I’d like to hear your opinion about [Using the **version of the Pod** to identify the Git commit](https://github.com/CocoaPods/Core/blob/3b72760a736bd9733a42912882009d9e85838a6d/lib/cocoapods-core/specification/dsl.rb#L249-L252):

> :commit => "v#{spec.version}"

Does this actually work? This seems very weird to me.
