### PR TITLE
Add methods to the presenter which expose information about the deprecation of the set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Master
 
+* Added methods `deprecated?` and `deprecation_description` to Presenter.
+  [Hugo Tunius][k0nserv]
+
 * The specification `requires_arc` attribute now defaults to true.  
   [Fabio Pelosin][irrationalfab]
   [CocoaPods#267](https://github.com/CocoaPods/CocoaPods/issues/267)
@@ -150,3 +153,4 @@ Introduction of the Changelog.
 
 [irrationalfab]: https://github.com/irrationalfab
 [Kapin]: https://github.com/Kapin
+[k0nserv]: https://github.com/k0nserv

--- a/lib/cocoapods-core/specification/set/presenter.rb
+++ b/lib/cocoapods-core/specification/set/presenter.rb
@@ -123,6 +123,35 @@ module Pod
           spec.description || spec.summary
         end
 
+        # @return [Bool] Wether the pod is deprecated either in favor of some other
+        #         pod or simply deprecated.
+        #
+        def deprecated?
+         spec.deprecated || !spec.deprecated_in_favor_of.nil?
+       end
+
+       # @return [String] A string that describes the deprecation of the pod.
+       #         If the pod is deprecated in favor of another pod it will contain
+       #         information about that. If the pod is not deprecated returns nil.
+       #
+       # @example Output example
+       #
+       #          "[DEPRECATED]"
+       #          "[DEPRECATED in favor of NewAwesomePod]"
+       #
+       def deprecation_description
+         if deprecated?
+           description = "[DEPRECATED"
+           if spec.deprecated_in_favor_of.nil?
+             description += "]"
+           else
+             description += " in favor of #{spec.deprecated_in_favor_of}]"
+           end
+
+           description
+         end
+       end
+
         # @return [String] the URL of the source of the Pod.
         #
         def source_url

--- a/spec/specification/set/presenter_spec.rb
+++ b/spec/specification/set/presenter_spec.rb
@@ -38,6 +38,26 @@ module Pod
       it 'returns the sources' do
         @presenter.sources.should == %w(master test_repo)
       end
+
+      it 'returns the correct deprecation status when the spec is deprecated' do
+        @presenter.deprecated?.should == false
+        @presenter.spec.deprecated = true
+        @presenter.deprecated?.should == true
+      end
+
+      it 'returns the correct deprecation status when the spec is deprecated in favor of another pod' do
+        @presenter.deprecated?.should == false
+        @presenter.spec.deprecated_in_favor_of = 'NewMoreAwesomePod'
+        @presenter.deprecated?.should == true
+      end
+
+      it 'returns the correct deprecation description' do
+        @presenter.deprecation_description.should.nil?
+        @presenter.spec.deprecated = true
+        @presenter.deprecation_description.should == '[DEPRECATED]'
+        @presenter.spec.deprecated_in_favor_of = 'NewMoreAwesomePod'
+        @presenter.deprecation_description.should == '[DEPRECATED in favor of NewMoreAwesomePod]'
+      end
     end
 
     describe 'Specification Information' do


### PR DESCRIPTION
I was a bit unsure about adding the two new fixtures specs `DeprecatedSpec` and `DeprecatedInFavorOfSpec`, but I wanted to have test cases covering those code paths. Maybe there is a better way to do it?

These changes are preparations for a PR that implements CocoaPods/CocoaPods#2180
