### PR TITLE
Move depracted? method from Presenter to a DSL helper in specification

### DIFF
--- a/lib/cocoapods-core/specification/root_attribute_accessors.rb
+++ b/lib/cocoapods-core/specification/root_attribute_accessors.rb
@@ -158,6 +158,13 @@ module Pod
           attributes_hash['deprecated_in_favor_of']
         end
 
+        # @return [Bool] Wether the pod is deprecated either in favor of some other
+        #         pod or simply deprecated.
+        #
+        def deprecated?
+         deprecated || !deprecated_in_favor_of.nil?
+        end
+
         #---------------------------------------------------------------------#
 
         private

--- a/lib/cocoapods-core/specification/set/presenter.rb
+++ b/lib/cocoapods-core/specification/set/presenter.rb
@@ -123,13 +123,6 @@ module Pod
           spec.description || spec.summary
         end
 
-        # @return [Bool] Wether the pod is deprecated either in favor of some other
-        #         pod or simply deprecated.
-        #
-        def deprecated?
-         spec.deprecated || !spec.deprecated_in_favor_of.nil?
-       end
-
        # @return [String] A string that describes the deprecation of the pod.
        #         If the pod is deprecated in favor of another pod it will contain
        #         information about that. If the pod is not deprecated returns nil.
@@ -140,7 +133,7 @@ module Pod
        #          "[DEPRECATED in favor of NewAwesomePod]"
        #
        def deprecation_description
-         if deprecated?
+         if spec.deprecated?
            description = "[DEPRECATED"
            if spec.deprecated_in_favor_of.nil?
              description += "]"

--- a/spec/specification/root_attribute_accessors_spec.rb
+++ b/spec/specification/root_attribute_accessors_spec.rb
@@ -145,5 +145,16 @@ module Pod
       @spec.deprecated_in_favor_of.should == 'NewMoreAwesomePod'
     end
 
+    it 'it returns wether it is deprecated either by deprecated or deprecated_in_favor_of' do
+      @spec.deprecated = true
+      @spec.deprecated?.should == true
+      @spec.deprecated = false
+
+      @spec.deprecated_in_favor_of = 'NewMoreAwesomePod'
+      @spec.deprecated?.should == true
+      @spec.deprecated_in_favor_of = nil
+
+      @spec.deprecated?.should == false
+    end
   end
 end

--- a/spec/specification/set/presenter_spec.rb
+++ b/spec/specification/set/presenter_spec.rb
@@ -39,18 +39,6 @@ module Pod
         @presenter.sources.should == %w(master test_repo)
       end
 
-      it 'returns the correct deprecation status when the spec is deprecated' do
-        @presenter.deprecated?.should == false
-        @presenter.spec.deprecated = true
-        @presenter.deprecated?.should == true
-      end
-
-      it 'returns the correct deprecation status when the spec is deprecated in favor of another pod' do
-        @presenter.deprecated?.should == false
-        @presenter.spec.deprecated_in_favor_of = 'NewMoreAwesomePod'
-        @presenter.deprecated?.should == true
-      end
-
       it 'returns the correct deprecation description' do
         @presenter.deprecation_description.should.nil?
         @presenter.spec.deprecated = true


### PR DESCRIPTION
I realised that it doesn't make much sense to have this logic in the presenter when I was looking at the implementation of https://github.com/CocoaPods/search.cocoapods.org. If you agree with this move I'll update the change I made to https://github.com/CocoaPods/CocoaPods
