### PR TITLE
Use libraries’ existing Xcode projects.

### DIFF
--- a/lib/cocoapods-core/specification/consumer.rb
+++ b/lib/cocoapods-core/specification/consumer.rb
@@ -88,6 +88,11 @@ module Pod
       #
       spec_attr_accessor :xcconfig
 
+      # @return [Array<Hash>] A list of Hashes describing the subprojects to
+      #         build for this spec.
+      #
+      spec_attr_accessor :xcodeprojs
+
       # @return [String] The contents of the prefix header.
       #
       spec_attr_accessor :prefix_header_contents

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -716,6 +716,40 @@ module Pod
 
       #------------------#
 
+      # @!method xcodeprojs=
+      #
+      #    The Xcode projects to build for this pod. The passed Hashes must
+      #    specify the relative path of an .xcodeproj project for the key
+      #    project and a build target in this project for the library_target
+      #    key. It may optionally specify a target, which builds a .bundle
+      #    containing required resources.
+      #
+      #    The project will be added as a subproject to the Pods project,
+      #    the library will be added to the link frameworks phase of all
+      #    relevant targets and the resource.bundle will by added to a copy
+      #    files phase of all relevant targets.
+      #
+      #   @example
+      #
+      #     spec.ios.xcodeproj = {
+      #       :project => 'A.xcodeproj',
+      #       :library_targets => ['LibraryTarget', 'AnotherLibraryTarget'],
+      #       :resource_targets => ['ResourceTarget']
+      #     }
+      #
+      #   @param [Array<Hash>] A list of Hashes describing the Project to build
+      #          for this spec.
+      #
+      attribute :xcodeprojs, {
+        :types => [Array, Hash],
+        :default_value => [],
+        :keys => [:project, :library_targets, :resource_targets],
+        :inherited => true,
+        :singularize => true,
+      }
+
+      #------------------#
+
       # @!method prefix_header_contents=(content)
       #
       #   Any content to inject in the prefix header of the pod project.

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -740,13 +740,12 @@ module Pod
       #   @param [Array<Hash>] A list of Hashes describing the Project to build
       #          for this spec.
       #
-      attribute :xcodeprojs, {
-        :types => [Array, Hash],
-        :default_value => [],
-        :keys => [:project, :library_targets, :resource_targets],
-        :inherited => true,
-        :singularize => true,
-      }
+      attribute :xcodeprojs,
+                :types => [Array, Hash],
+                :default_value => [],
+                :keys => [:project, :library_targets, :resource_targets],
+                :inherited => true,
+                :singularize => true
 
       #------------------#
 

--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -347,6 +347,29 @@ module Pod
         end
       end
 
+      # Check empty subspec attributes
+      #
+      def check_if_spec_is_empty
+        methods = %w[ source_files resources preserve_paths dependencies xcodeprojs ]
+        empty_patterns = methods.all? { |m| consumer.send(m).empty? }
+        empty = empty_patterns && consumer.spec.subspecs.empty?
+        if empty
+          error "The #{consumer.spec} spec is empty (no source files, resources, preserve paths, dependencies, Xcode subprojects or subspecs)."
+        end
+      end
+
+      # Check the hooks
+      #
+      def check_install_hooks
+        warning "The pre install hook of the specification DSL has been " \
+          "deprecated, use the `resource_bundles` or the `prepare_command` " \
+          "attributes." unless consumer.spec.pre_install_callback.nil?
+
+        warning "The post install hook of the specification DSL has been " \
+          "deprecated, use the `resource_bundles` or the `prepare_command` " \
+          "attributes." unless consumer.spec.post_install_callback.nil?
+      end
+
       #-----------------------------------------------------------------------#
 
       # @!group All specs validation helpers

--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -350,7 +350,7 @@ module Pod
       # Check empty subspec attributes
       #
       def check_if_spec_is_empty
-        methods = %w[ source_files resources preserve_paths dependencies xcodeprojs ]
+        methods = %w(source_files resources preserve_paths dependencies xcodeprojs)
         empty_patterns = methods.all? { |m| consumer.send(m).empty? }
         empty = empty_patterns && consumer.spec.subspecs.empty?
         if empty
@@ -361,13 +361,13 @@ module Pod
       # Check the hooks
       #
       def check_install_hooks
-        warning "The pre install hook of the specification DSL has been " \
-          "deprecated, use the `resource_bundles` or the `prepare_command` " \
-          "attributes." unless consumer.spec.pre_install_callback.nil?
+        warning 'The pre install hook of the specification DSL has been ' \
+          'deprecated, use the `resource_bundles` or the `prepare_command` ' \
+          'attributes.' unless consumer.spec.pre_install_callback.nil?
 
-        warning "The post install hook of the specification DSL has been " \
-          "deprecated, use the `resource_bundles` or the `prepare_command` " \
-          "attributes." unless consumer.spec.post_install_callback.nil?
+        warning 'The post install hook of the specification DSL has been ' \
+          'deprecated, use the `resource_bundles` or the `prepare_command` ' \
+          'attributes.' unless consumer.spec.post_install_callback.nil?
       end
 
       #-----------------------------------------------------------------------#

--- a/spec/specification/consumer_spec.rb
+++ b/spec/specification/consumer_spec.rb
@@ -171,6 +171,22 @@ module Pod
         osx_consumer.xcconfig.should == { 'OTHER_LDFLAGS' => '-lObjC' }
       end
 
+      #----------------#
+
+      it "allows to specify Xcode subprojects" do
+        @spec.xcodeprojs = [{ :project => 'Project.xcproj' }]
+        @consumer.xcodeprojs.should == [{ :project => 'Project.xcproj' }]
+      end
+
+      it "allows to specify a single Xcode subproject" do
+        @spec.xcodeproj = { :project => 'Project.xcproj', :library_targets => ['LibraryTarget'] }
+        @consumer.xcodeprojs.should == { 'project' => 'Project.xcproj', 'library_targets' => ['LibraryTarget'] }
+      end
+
+      it "returns empty hash if no Xcode subproject has been specified" do
+        @consumer.xcodeprojs.should == []
+      end
+
       #------------------#
 
       it 'allows to specify the contents of the prefix header' do

--- a/spec/specification/consumer_spec.rb
+++ b/spec/specification/consumer_spec.rb
@@ -173,17 +173,17 @@ module Pod
 
       #----------------#
 
-      it "allows to specify Xcode subprojects" do
+      it 'allows to specify Xcode subprojects' do
         @spec.xcodeprojs = [{ :project => 'Project.xcproj' }]
         @consumer.xcodeprojs.should == [{ :project => 'Project.xcproj' }]
       end
 
-      it "allows to specify a single Xcode subproject" do
+      it 'allows to specify a single Xcode subproject' do
         @spec.xcodeproj = { :project => 'Project.xcproj', :library_targets => ['LibraryTarget'] }
         @consumer.xcodeprojs.should == { 'project' => 'Project.xcproj', 'library_targets' => ['LibraryTarget'] }
       end
 
-      it "returns empty hash if no Xcode subproject has been specified" do
+      it 'returns empty hash if no Xcode subproject has been specified' do
         @consumer.xcodeprojs.should == []
       end
 

--- a/spec/specification/dsl_spec.rb
+++ b/spec/specification/dsl_spec.rb
@@ -379,7 +379,7 @@ module Pod
         singularized.map { |attr| attr.name.to_s }.sort.should == %w(
           authors compiler_flags default_subspecs frameworks libraries
           preserve_paths resource_bundles resources screenshots
-          vendored_frameworks vendored_libraries weak_frameworks
+          vendored_frameworks vendored_libraries weak_frameworks xcodeprojs
         )
       end
     end


### PR DESCRIPTION
This patch as it is looks good and I consider it acceptable to be merged.

Before doing that I'm looking for an option of the @CocoaPods/core team regarding:

- Enforce one project per spec/subspec.
- Enforce in the linter the presence of either build settings and file patterns (traditional way) or a project and target (project way).
- Also I'm not sure about the syntax:
  - `xcodeprojs` could be `project`
  - it would be cleaner to have just `project` and `target` as attributes instead of a hash. If one of the two is specified also the other must be (`project way`). This can be enforced in the linter.

--

Note, for the sake of the discussion this pull is pointing to the `lookback-pods-by-config` branch (which is expected to be merged in master soon)