### PR TITLE
[LinterSpec] Add spec for subspec names with whitespace

### DIFF
--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -178,7 +178,7 @@ module Pod
                     file.'
           end
 
-          if spec.root.name =~ /\s/
+          if spec.name =~ /\s/
             error '[name] The name of a spec should not contain whitespace.'
           end
 

--- a/spec/specification/linter_spec.rb
+++ b/spec/specification/linter_spec.rb
@@ -387,5 +387,32 @@ module Pod
         message_should_include('warnings', 'disabled', 'compiler_flags')
       end
     end
+
+    describe 'Subspec' do
+      before do
+        fixture_path = 'spec-repos/master/RestKit/0.20.1/RestKit.podspec'
+        @podspec_path = fixture(fixture_path)
+        @linter = Specification::Linter.new(@podspec_path)
+        @spec = @linter.spec
+      end
+
+      def message_should_include(*values)
+        @linter.lint
+        results = @linter.results
+
+        matched = results.select do |result|
+          values.all? do |value|
+            result.message.downcase.include?(value.downcase)
+          end
+        end
+
+        matched.size.should == 1
+      end
+
+      it 'fails a subspec whose name contains whitespace' do
+        @spec.subspecs.each { |ss| ss.stubs(:name).returns('bad name') }
+        message_should_include('name', 'whitespace')
+      end
+    end
   end
 end


### PR DESCRIPTION
Needed for https://github.com/CocoaPods/Core/issues/177

@kylef here's the spec, I just can't figure out a way to get the linter to lint the `name` attribute of subspecs without changing too much

:warning: WORK IN PROGRESS - DO NOT MERGE :warning: 