### PR TITLE
Update podfile syntax reference on branches and tags

### DIFF
--- a/lib/cocoapods-core/podfile/dsl.rb
+++ b/lib/cocoapods-core/podfile/dsl.rb
@@ -145,6 +145,16 @@ module Pod
       #     pod 'AFNetworking', :git => 'https://github.com/gowalla/AFNetworking.git'
       #
       #
+      # To use a different branch of the repo:
+      #
+      #     pod 'AFNetworking', :git => 'https://github.com/gowalla/AFNetworking.git', :branch => 'dev'
+      #
+      #
+      # To use a tag of the repo:
+      #
+      #     pod 'AFNetworking', :git => 'https://github.com/gowalla/AFNetworking.git', :tag => '0.7.0'
+      #
+      #
       # Or specify a commit:
       #
       #     pod 'AFNetworking', :git => 'https://github.com/gowalla/AFNetworking.git', :commit => '082f8319af'


### PR DESCRIPTION
Adding information from [the Using guide](https://github.com/CocoaPods/guides.cocoapods.org/blob/master/source/using/the-podfile.html.md) which tells how to use a specific branch or tag

As a side note, generating the same documentation from two files (the comments here and the Markdown in the guides repo) that aren't kept in sync seems like it could be made better. Confusing to have conflicting (or at least non-matching) doc pages, the way that [the syntax page](http://guides.cocoapods.org/syntax/podfile.html#pod) and [the Using page](http://guides.cocoapods.org/using/the-podfile.html) are now.
