### PR TITLE
[Linter] Split Linter result attribute name from message

### DIFF
--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -50,8 +50,8 @@ module Pod
           run_root_validation_hooks
           perform_all_specs_analysis
         else
-          results.add_error "[spec] The specification defined in `#{file}` "\
-            "could not be loaded.\n\n#{@raise_message}"
+          results.add_error('spec', "The specification defined in `#{file}` "\
+            "could not be loaded.\n\n#{@raise_message}")
         end
         results.empty?
       end
@@ -91,10 +91,10 @@ module Pod
           next unless attr.required?
           unless value && (!value.respond_to?(:empty?) || !value.empty?)
             if attr.name == :license
-              results.add_warning('[attributes] Missing required attribute' \
+              results.add_warning('attributes', 'Missing required attribute' \
               "`#{attr.name}`.")
             else
-              results.add_error('[attributes] Missing required attribute' \
+              results.add_error('attributes', 'Missing required attribute' \
                "`#{attr.name}`.")
             end
           end
@@ -176,28 +176,28 @@ module Pod
           ]
           names_match = acceptable_names.include?(file.basename.to_s)
           unless names_match
-            results.add_error '[name] The name of the spec should match the ' \
-                           'name of the file.'
+            results.add_error('name', 'The name of the spec should match the ' \
+                           'name of the file.')
           end
 
           if spec.root.name =~ /\s/
-            results.add_error '[name] The name of a spec should not contain ' \
-                           'whitespace.'
+            results.add_error('name', 'The name of a spec should not contain ' \
+                           'whitespace.')
           end
 
           if spec.root.name[0, 1] == '.'
-            results.add_error '[name] The name of a spec should not begin' \
-            ' with a period.'
+            results.add_error('name', 'The name of a spec should not begin' \
+            ' with a period.')
           end
         end
       end
 
       def _validate_version(v)
         if v.to_s.empty?
-          results.add_error '[version] A version is required.'
+          results.add_error('version', 'A version is required.')
         elsif v <= Version::ZERO
-          results.add_error '[version] The version of the spec should be' \
-          ' higher than 0.'
+          results.add_error('version', 'The version of the spec should be' \
+          ' higher than 0.')
         end
       end
 
@@ -205,11 +205,11 @@ module Pod
       #
       def _validate_summary(s)
         if s.length > 140
-          results.add_warning '[summary] The summary should be a short ' \
-            'version of `description` (max 140 characters).'
+          results.add_warning('summary', 'The summary should be a short ' \
+            'version of `description` (max 140 characters).')
         end
         if s =~ /A short description of/
-          results.add_warning '[summary] The summary is not meaningful.'
+          results.add_warning('summary', 'The summary is not meaningful.')
         end
       end
 
@@ -217,15 +217,15 @@ module Pod
       #
       def _validate_description(d)
         if d =~ /An optional longer description of/
-          results.add_warning '[description] The description is not meaningful.'
+          results.add_warning('description', 'The description is not meaningful.')
         end
         if d == spec.summary
-          results.add_warning '[description] The description is equal to' \
-           ' the summary.'
+          results.add_warning('description', 'The description is equal to' \
+           ' the summary.')
         end
         if d.length < spec.summary.length
-          results.add_warning '[description] The description is shorter ' \
-          'than the summary.'
+          results.add_warning('description', 'The description is shorter ' \
+          'than the summary.')
         end
       end
 
@@ -233,8 +233,8 @@ module Pod
       #
       def _validate_homepage(h)
         if h =~ %r{http://EXAMPLE}
-          results.add_warning '[homepage] The homepage has not been updated' \
-           ' from default'
+          results.add_warning('homepage', 'The homepage has not been updated' \
+           ' from default')
         end
       end
 
@@ -242,8 +242,8 @@ module Pod
       #
       def _validate_frameworks(frameworks)
         if frameworks_invalid?(frameworks)
-          results.add_error '[frameworks] A framework should only be' \
-          ' specified by its name'
+          results.add_error('frameworks', 'A framework should only be' \
+          ' specified by its name')
         end
       end
 
@@ -251,8 +251,8 @@ module Pod
       #
       def _validate_weak_frameworks(frameworks)
         if frameworks_invalid?(frameworks)
-          results.add_error '[weak_frameworks] A weak framework should only be' \
-          ' specified by its name'
+          results.add_error('weak_frameworks', 'A weak framework should only be' \
+          ' specified by its name')
         end
       end
 
@@ -262,20 +262,20 @@ module Pod
         libs.each do |lib|
           lib = lib.downcase
           if lib.end_with?('.a') || lib.end_with?('.dylib')
-            results.add_error '[libraries] Libraries should not include the' \
+            results.add_error('libraries', 'Libraries should not include the' \
             ' extension ' \
-            "(`#{lib}`)"
+            "(`#{lib}`)")
           end
 
           if lib.start_with?('lib')
-            results.add_error '[libraries] Libraries should omit the `lib`' \
+            results.add_error('libraries', 'Libraries should omit the `lib`' \
             ' prefix ' \
-            " (`#{lib}`)"
+            " (`#{lib}`)")
           end
 
           if lib.include?(',')
-            results.add_error '[libraries] Libraries should not include comas ' \
-            "(`#{lib}`)"
+            results.add_error('libraries', 'Libraries should not include comas ' \
+            "(`#{lib}`)")
           end
         end
       end
@@ -286,16 +286,16 @@ module Pod
         type = l[:type]
         file = l[:file]
         if type.nil?
-          results.add_warning '[license] Missing license type.'
+          results.add_warning('license', 'Missing license type.')
         end
         if type && type.gsub(' ', '').gsub("\n", '').empty?
-          results.add_warning '[license] Invalid license type.'
+          results.add_warning('license', 'Invalid license type.')
         end
         if type && type =~ /\(example\)/
-          results.add_error '[license] Sample license type.'
+          results.add_error('license', 'Sample license type.')
         end
         if file && Pathname.new(file).extname !~ /^(\.(txt|md|markdown|))?$/i
-          results.add_error '[license] Invalid file type'
+          results.add_error('license', 'Invalid file type')
         end
       end
 
@@ -307,19 +307,19 @@ module Pod
           version = spec.version.to_s
 
           if git =~ %r{http://EXAMPLE}
-            results.add_error '[source] The Git source still contains the ' \
-            'example URL.'
+            results.add_error('source', 'The Git source still contains the ' \
+            'example URL.')
           end
           if commit && commit.downcase =~ /head/
-            results.add_error '[source] The commit of a Git source cannot be' \
-            ' `HEAD`.'
+            results.add_error('source', 'The commit of a Git source cannot be' \
+            ' `HEAD`.')
           end
           if tag && !tag.to_s.include?(version)
-            results.add_warning '[source] The version should be included in' \
-             ' the Git tag.'
+            results.add_warning('source', 'The version should be included in' \
+             ' the Git tag.')
           end
           if tag.nil?
-            results.add_warning '[source] Git sources should specify a tag.'
+            results.add_warning('source', 'Git sources should specify a tag.')
           end
         end
 
@@ -336,17 +336,17 @@ module Pod
           return unless git =~ /^#{URI.regexp}$/
           git_uri = URI.parse(git)
           if git_uri.host == 'www.github.com'
-            results.add_warning '[github_sources] Github repositories should ' \
-             'not use `www` in their URL.'
+            results.add_warning('github_sources', 'Github repositories should ' \
+             'not use `www` in their URL.')
           end
           if git_uri.host == 'github.com' || git_uri.host == 'gist.github.com'
             unless git.end_with?('.git')
-              results.add_warning '[github_sources] Github repositories ' \
-              'should end in `.git`.'
+              results.add_warning('github_sources', 'Github repositories ' \
+              'should end in `.git`.')
             end
             unless git_uri.scheme == 'https'
-              results.add_warning '[github_sources] Github repositories ' \
-                'should use an `https` link.'
+              results.add_warning('github_sources', 'Github repositories ' \
+                'should use an `https` link.')
             end
           end
         end
@@ -357,9 +357,9 @@ module Pod
       def check_git_ssh_source(s)
         if git = s[:git]
           if git =~ /\w+\@(\w|\.)+\:(\/\w+)*/
-            results.add_warning '[source] Git SSH URLs will NOT work for ' \
+            results.add_warning('source', 'Git SSH URLs will NOT work for ' \
               'people behind firewalls configured to only allow HTTP, ' \
-              'therefore HTTPS is preferred.'
+              'therefore HTTPS is preferred.')
           end
         end
       end
@@ -368,8 +368,8 @@ module Pod
       #
       def _validate_social_media_url(s)
         if s =~ %r{https://twitter.com/EXAMPLE}
-          results.add_warning '[social_media_url] The social media URL has ' \
-            'not been updated from the default.'
+          results.add_warning('social_media_url', 'The social media URL has ' \
+            'not been updated from the default.')
         end
       end
 
@@ -383,8 +383,8 @@ module Pod
       #
       def _validate_compiler_flags(flags)
         if flags.join(' ').split(' ').any? { |flag| flag.start_with?('-Wno') }
-          results.add_warning '[compiler_flags] Warnings must not be disabled' \
-          '(`-Wno compiler` flags).'
+          results.add_warning('compiler_flags', 'Warnings must not be disabled' \
+          '(`-Wno compiler` flags).')
         end
       end
 

--- a/lib/cocoapods-core/specification/linter/analyzer.rb
+++ b/lib/cocoapods-core/specification/linter/analyzer.rb
@@ -53,7 +53,7 @@ module Pod
           unknown_keys = keys - valid_keys
 
           unknown_keys.each do |key|
-            results.add_warning "Unrecognized `#{key}` key"
+            results.add_warning('attributes', "Unrecognized `#{key}` key")
           end
 
           Pod::Specification::DSL.attributes.each do |_key, attribute|
@@ -84,8 +84,8 @@ module Pod
             if patterns.respond_to?(:each)
               patterns.each do |pattern|
                 if pattern.start_with?('/')
-                  results.add_error '[File Patterns] File patterns must be ' \
-                    "relative and cannot start with a slash (#{attrb.name})."
+                  results.add_error('File Patterns', 'File patterns must be ' \
+                    "relative and cannot start with a slash (#{attrb.name}).")
                 end
               end
             end
@@ -100,10 +100,10 @@ module Pod
           empty_patterns = methods.all? { |m| consumer.send(m).empty? }
           empty = empty_patterns && consumer.spec.subspecs.empty?
           if empty
-            results.add_error "[File Patterns] The #{consumer.spec} spec is " \
+            results.add_error('File Patterns', "The #{consumer.spec} spec is " \
               'empty (no source files, resources, resource_bundles, ' \
               'preserve paths, vendored_libraries, vendored_frameworks, ' \
-              'dependencies, nor subspecs).'
+              'dependencies, nor subspecs).')
           end
         end
 
@@ -129,29 +129,29 @@ module Pod
         def validate_attribute_array_keys(attribute, value)
           unknown_keys = value.keys.map(&:to_s) - attribute.keys.map(&:to_s)
           unknown_keys.each do |unknown_key|
-            results.add_warning "Unrecognized `#{unknown_key}` key for " \
-              "`#{attribute.name}` attribute."
+            results.add_warning('keys', "Unrecognized `#{unknown_key}` key for " \
+              "`#{attribute.name}` attribute.")
           end
         end
 
         def validate_attribute_hash_keys(attribute, value)
           major_keys = value.keys & attribute.keys.keys
           if major_keys.count.zero?
-            results.add_warning "Missing primary key for `#{attribute.name}` " \
+            results.add_warning('keys', "Missing primary key for `#{attribute.name}` " \
               'attribute. The acceptable ones are: ' \
-              "`#{attribute.keys.keys.map(&:to_s).sort.join(', ')}`."
+              "`#{attribute.keys.keys.map(&:to_s).sort.join(', ')}`.")
           elsif major_keys.count == 1
             acceptable = attribute.keys[major_keys.first] || []
             unknown = value.keys - major_keys - acceptable
             unless unknown.empty?
-              results.add_warning "Incompatible `#{unknown.sort.join(', ')}` " \
+              results.add_warning('keys', "Incompatible `#{unknown.sort.join(', ')}` " \
                 "key(s) with `#{major_keys.first}` primary key for " \
-                "`#{attribute.name}` attribute."
+                "`#{attribute.name}` attribute.")
             end
           else
             sorted_keys = major_keys.map(&:to_s).sort
-            results.add_warning "Incompatible `#{sorted_keys.join(', ')}` " \
-              "keys for `#{attribute.name}` attribute."
+            results.add_warning('keys', "Incompatible `#{sorted_keys.join(', ')}` " \
+              "keys for `#{attribute.name}` attribute.")
           end
         end
       end

--- a/lib/cocoapods-core/specification/linter/result.rb
+++ b/lib/cocoapods-core/specification/linter/result.rb
@@ -9,6 +9,10 @@ module Pod
           #
           attr_reader :type
 
+          # @return[String] the name of the attribute associated with result.
+          #
+          attr_reader :attribute_name
+
           # @return [String] the message associated with result.
           #
           attr_reader :message
@@ -16,8 +20,9 @@ module Pod
           # @param [Symbol] type    @see type
           # @param [String] message @see message
           #
-          def initialize(type, message)
+          def initialize(type, attribute_name, message)
             @type    = type
+            @attribute_name = attribute_name
             @message = message
             @platforms = []
           end
@@ -30,7 +35,7 @@ module Pod
           # @return [String] a string representation suitable for UI output.
           #
           def to_s
-            r = "[#{type.to_s.upcase}] #{message}"
+            r = "[#{type.to_s.upcase}] [#{attribute_name}] #{message}"
             if platforms != Specification::PLATFORMS
               platforms_names = platforms.uniq.map do |p|
                 Platform.string_name(p)
@@ -67,8 +72,8 @@ module Pod
         #
         # @return [void]
         #
-        def add_error(message)
-          add_result(:error, message)
+        def add_error(attribute_name, message)
+          add_result(:error, attribute_name, message)
         end
 
         # Adds a warning result with the given message.
@@ -78,8 +83,8 @@ module Pod
         #
         # @return [void]
         #
-        def add_warning(message)
-          add_result(:warning, message)
+        def add_warning(attribute_name, message)
+          add_result(:warning, attribute_name, message)
         end
 
         private
@@ -101,10 +106,12 @@ module Pod
         #
         # @return [void]
         #
-        def add_result(type, message)
-          result = results.find { |r| r.type == type && r.message == message }
+        def add_result(type, attribute_name, message)
+          result = results.find do |r|
+            r.type == type && r.attribute_name == attribute_name && r.message == message
+          end
           unless result
-            result = Result.new(type, message)
+            result = Result.new(type, attribute_name, message)
             results << result
           end
           result.platforms << @consumer.platform_name if @consumer

--- a/spec/specification/linter/analyzer_spec.rb
+++ b/spec/specification/linter/analyzer_spec.rb
@@ -35,6 +35,7 @@ module Pod
           results.count.should.be.equal(1)
           expected = 'Unrecognized `unknown_key` key'
           results.first.message.should.include?(expected)
+          results.first.attribute_name.should.include?('attributes')
         end
 
         it 'fails a spec with unknown multi-platform key' do
@@ -43,6 +44,7 @@ module Pod
           results.count.should.be.equal(1)
           expected = 'Unrecognized `unknown_key` key'
           results.first.message.should.include?(expected)
+          results.first.attribute_name.should.include?('attributes')
         end
 
         it 'validates a spec with valid sub-keys' do
@@ -57,6 +59,7 @@ module Pod
           results.count.should.be.equal(1)
           expected = 'Unrecognized `is_safe_for_work` key'
           results.first.message.should.include?(expected)
+          results.first.attribute_name.should.include?('keys')
         end
 
         it 'validates a spec with valid minor sub-keys' do
@@ -71,6 +74,7 @@ module Pod
           results.count.should.be.equal(1)
           expected = 'Missing primary key for `source` attribute.'
           results.first.message.should.include?(expected)
+          results.first.attribute_name.should.include?('keys')
         end
 
         it 'fails a spec with invalid secondary sub-keys' do
@@ -79,6 +83,7 @@ module Pod
           results.count.should.be.equal(1)
           expected = 'Incompatible `folder` key(s) with `git`'
           results.first.message.should.include?(expected)
+          results.first.attribute_name.should.include?('keys')
         end
 
         it 'fails a spec with multiple primary keys' do
@@ -87,6 +92,7 @@ module Pod
           results.count.should.be.equal(1)
           expected = 'Incompatible `git, http` keys'
           results.first.message.should.include?(expected)
+          results.first.attribute_name.should.include?('keys')
         end
 
         it 'fails a spec invalid secondary sub-keys when no sub-keys are supported' do
@@ -95,6 +101,7 @@ module Pod
           results.count.should.be.equal(1)
           expected = 'Incompatible `unsupported` key(s) with `http`'
           results.first.message.should.include?(expected)
+          results.first.attribute_name.should.include?('keys')
         end
       end
 
@@ -107,7 +114,7 @@ module Pod
           results.count.should.be.equal(1)
           expected = 'patterns must be relative'
           results.first.message.should.include?(expected)
-          results.first.message.should.include?('File Patterns')
+          results.first.attribute_name.should.include?('File Patterns')
         end
 
         it 'checks if a specification is empty' do
@@ -123,7 +130,7 @@ module Pod
           results = @analyzer.analyze
           results.count.should.be.equal(1)
           results.first.message.should.include?('spec is empty')
-          results.first.message.should.include?('File Patterns')
+          results.first.attribute_name.should.include?('File Patterns')
         end
       end
 


### PR DESCRIPTION
Splitting the attribute name from the message allows for more
extendibility and in general better practice for linter errors.
Currently, the attribute names are just added to the front of messages.
This change will enforce specifying an attribute name.

Part of #48
