### PR TITLE
Proxy #module_name from Specification::Consumer

### DIFF
--- a/lib/cocoapods-core/specification/consumer.rb
+++ b/lib/cocoapods-core/specification/consumer.rb
@@ -96,6 +96,10 @@ module Pod
       #
       spec_attr_accessor :prefix_header_file
 
+      # @return [String] the module name.
+      #
+      spec_attr_accessor :module_name
+
       # @return [String] the headers directory.
       #
       spec_attr_accessor :header_dir

--- a/spec/specification/consumer_spec.rb
+++ b/spec/specification/consumer_spec.rb
@@ -211,6 +211,13 @@ module Pod
 
       #------------------#
 
+      it 'allows to specify a module name' do
+        @spec.module_name = 'Three20Core'
+        @consumer.module_name.should == 'Three20Core'
+      end
+
+      #------------------#
+
       it 'allows to specify a directory to use for the headers' do
         @spec.header_dir = 'Three20Core'
         @consumer.header_dir.should == 'Three20Core'


### PR DESCRIPTION
Needed in addition to #209 to fulfill #205.
