### PR TITLE
Fix Unsupported class for YAML conversion Fixnum when `write_lockfiles`

### DIFF
--- a/lib/cocoapods-core/lockfile.rb
+++ b/lib/cocoapods-core/lockfile.rb
@@ -294,19 +294,6 @@ module Pod
       self.defined_in_file = path
     end
 
-    # @return [Hash{String=>Array,Hash,String}] Convert Fixnum to String
-    #
-    def clean_node(node)
-      case node
-
-      when Fixnum then node = node.to_s
-      when Array then node.map! { |obj| clean_node(obj) }
-      when Hash then node.each_pair { |key, value| node[key] = clean_node(value) }
-      end
-
-      node
-    end
-
     # @return [Hash{String=>Array,Hash,String}] a hash representation of the
     #         Lockfile.
     #
@@ -328,7 +315,7 @@ module Pod
     def to_hash
       hash = {}
       internal_data.each do |key, value|
-        hash[key] = clean_node(value) unless value.empty?
+        hash[key] = value unless value.empty?
       end
       hash
     end

--- a/lib/cocoapods-core/lockfile.rb
+++ b/lib/cocoapods-core/lockfile.rb
@@ -294,6 +294,19 @@ module Pod
       self.defined_in_file = path
     end
 
+    # @return [Hash{String=>Array,Hash,String}] Convert Fixnum to String
+    #
+    def clean_node(node)
+      case node
+
+      when Fixnum then node = node.to_s
+      when Array then node.map! { |obj| clean_node(obj) }
+      when Hash then node.each_pair { |key, value| node[key] = clean_node(value) }
+      end
+
+      node
+    end
+
     # @return [Hash{String=>Array,Hash,String}] a hash representation of the
     #         Lockfile.
     #
@@ -315,7 +328,7 @@ module Pod
     def to_hash
       hash = {}
       internal_data.each do |key, value|
-        hash[key] = value unless value.empty?
+        hash[key] = clean_node(value) unless value.empty?
       end
       hash
     end

--- a/lib/cocoapods-core/yaml_helper.rb
+++ b/lib/cocoapods-core/yaml_helper.rb
@@ -93,6 +93,7 @@ module Pod
       def process_according_to_class(value, hash_keys_hint = nil)
         case value
         when String     then value
+        when Fixnum     then value.to_s
         when Symbol     then ":#{value}"
         when TrueClass  then 'true'
         when FalseClass then 'false'


### PR DESCRIPTION
### Report

* What did you do?

  add pod using svn without `:revision` and run `pod install`, after `Podfile.lock` is updated, run `pod install` again, Pod::StandardError occurred.

* What did you expect to happen?

  Pod::StandardError - Unsupported class for YAML conversion Fixnum


### Stack

```
   CocoaPods : 0.35.0
        Ruby : ruby 2.1.4p247 (2014-09-24 revision 47703) [x86_64-darwin13.0]
    RubyGems : 2.4.2
        Host : Mac OS X 10.9.5 (13F34)
       Xcode : 6.1.1 (6A2008a)
         Git : git version 1.9.3 (Apple Git-50)
Ruby lib dir : /Users/ratazzi/.rvm/rubies/ruby-2.1-head/lib
Repositories : master - git://github.com/CocoaPods/Specs.git @ e8207654b2240ff02947f46dc5f1b2f435bc6da0
               master-1 - https://github.com/CocoaPods/Specs.git @ 1057e5b8711f327ba657f6c7f64b0cefdb04065f
               Yunyue - git@192.168.0.252:ratazzi/specs.git @ dc85221596e40e1b3e50347baa49d7dbc3053b0d
```

### Plugins

```

```

### Podfile

```ruby
# Uncomment this line to define a global platform for your project
platform :ios, "4.3"

source 'git://github.com/CocoaPods/Specs.git'

pod 'UMengAnalytics', '~> 2.2.1'
pod 'OpenUDID', :head
pod 'assets', :path => 'assets'
pod 'HXAppPlatformKit', :git => 'git@192.168.0.252:ratazzi/HXAppPlatformKit.git', :tag => 'v2.1.8'
pod 'AppIcon', :svn => 'file:///Volumes/Untitled/itools' # , :revision => "2" # If :revision is enabled, it is ok
```

### Podfile.lock

```ruby
PODS:
  - AppIcon (1.00000)
  - assets (1.00003)
  - HXAppPlatformKit (2.1.8)
  - OpenUDID (HEAD based on 1.0.0)
  - UMengAnalytics (2.2.1)

DEPENDENCIES:
  - AppIcon (from `file:///Volumes/Untitled/itools`)
  - assets (from `assets`)
  - HXAppPlatformKit (from `git@192.168.0.252:ratazzi/HXAppPlatformKit.git`, tag `v2.1.8`)
  - OpenUDID (HEAD)
  - UMengAnalytics (~> 2.2.1)

EXTERNAL SOURCES:
  AppIcon:
    :svn: file:///Volumes/Untitled/itools
  assets:
    :path: assets
  HXAppPlatformKit:
    :git: git@192.168.0.252:ratazzi/HXAppPlatformKit.git
    :tag: v2.1.8

CHECKOUT OPTIONS:
  AppIcon:
    :revision: 2 # It is a digital after YAMLHelper.load_file
    :svn: file:///Volumes/Untitled/itools
  HXAppPlatformKit:
    :git: git@192.168.0.252:ratazzi/HXAppPlatformKit.git
    :tag: v2.1.8

SPEC CHECKSUMS:
  AppIcon: 134c9e6bbaf7b14af855f5a6c406f9433b7b7fcc
  assets: 2bc963e22b83635ec28825e48f34bc444eb075f0
  HXAppPlatformKit: 84d5477a742653e9691915e4d6949a1186d42d0f
  OpenUDID: 5a23b7477755efc2d7871b57aa79ba3089c40b74
  UMengAnalytics: d4154135487c209b23698841e55f0fbd536d383b

COCOAPODS: 0.35.0

```


### Error

```
Pod::StandardError - Unsupported class for YAML conversion Fixnum
/Users/ratazzi/.rvm/gems/ruby-2.1-head/gems/cocoapods-core-0.35.0/lib/cocoapods-core/yaml_helper.rb:102:in `process_according_to_class'
/Users/ratazzi/.rvm/gems/ruby-2.1-head/gems/cocoapods-core-0.35.0/lib/cocoapods-core/yaml_helper.rb:142:in `block in process_hash'
/Users/ratazzi/.rvm/gems/ruby-2.1-head/gems/cocoapods-core-0.35.0/lib/cocoapods-core/yaml_helper.rb:140:in `each'
/Users/ratazzi/.rvm/gems/ruby-2.1-head/gems/cocoapods-core-0.35.0/lib/cocoapods-core/yaml_helper.rb:140:in `process_hash'
/Users/ratazzi/.rvm/gems/ruby-2.1-head/gems/cocoapods-core-0.35.0/lib/cocoapods-core/yaml_helper.rb:100:in `process_according_to_class'
/Users/ratazzi/.rvm/gems/ruby-2.1-head/gems/cocoapods-core-0.35.0/lib/cocoapods-core/yaml_helper.rb:142:in `block in process_hash'
/Users/ratazzi/.rvm/gems/ruby-2.1-head/gems/cocoapods-core-0.35.0/lib/cocoapods-core/yaml_helper.rb:140:in `each'
/Users/ratazzi/.rvm/gems/ruby-2.1-head/gems/cocoapods-core-0.35.0/lib/cocoapods-core/yaml_helper.rb:140:in `process_hash'
/Users/ratazzi/.rvm/gems/ruby-2.1-head/gems/cocoapods-core-0.35.0/lib/cocoapods-core/yaml_helper.rb:100:in `process_according_to_class'
/Users/ratazzi/.rvm/gems/ruby-2.1-head/gems/cocoapods-core-0.35.0/lib/cocoapods-core/yaml_helper.rb:142:in `block in process_hash'
/Users/ratazzi/.rvm/gems/ruby-2.1-head/gems/cocoapods-core-0.35.0/lib/cocoapods-core/yaml_helper.rb:140:in `each'
/Users/ratazzi/.rvm/gems/ruby-2.1-head/gems/cocoapods-core-0.35.0/lib/cocoapods-core/yaml_helper.rb:140:in `process_hash'
/Users/ratazzi/.rvm/gems/ruby-2.1-head/gems/cocoapods-core-0.35.0/lib/cocoapods-core/yaml_helper.rb:39:in `convert_hash'
/Users/ratazzi/.rvm/gems/ruby-2.1-head/gems/cocoapods-core-0.35.0/lib/cocoapods-core/lockfile.rb:339:in `to_yaml'
/Users/ratazzi/.rvm/gems/ruby-2.1-head/gems/cocoapods-core-0.35.0/lib/cocoapods-core/lockfile.rb:293:in `block in write_to_disk'
/Users/ratazzi/.rvm/gems/ruby-2.1-head/gems/cocoapods-core-0.35.0/lib/cocoapods-core/lockfile.rb:293:in `open'
/Users/ratazzi/.rvm/gems/ruby-2.1-head/gems/cocoapods-core-0.35.0/lib/cocoapods-core/lockfile.rb:293:in `write_to_disk'
/Users/ratazzi/.rvm/gems/ruby-2.1-head/gems/cocoapods-0.35.0/lib/cocoapods/installer.rb:473:in `block in write_lockfiles'
/Users/ratazzi/.rvm/gems/ruby-2.1-head/gems/cocoapods-0.35.0/lib/cocoapods/user_interface.rb:110:in `message'
/Users/ratazzi/.rvm/gems/ruby-2.1-head/gems/cocoapods-0.35.0/lib/cocoapods/installer.rb:472:in `write_lockfiles'
/Users/ratazzi/.rvm/gems/ruby-2.1-head/gems/cocoapods-0.35.0/lib/cocoapods/installer.rb:130:in `block in generate_pods_project'
/Users/ratazzi/.rvm/gems/ruby-2.1-head/gems/cocoapods-0.35.0/lib/cocoapods/user_interface.rb:49:in `section'
/Users/ratazzi/.rvm/gems/ruby-2.1-head/gems/cocoapods-0.35.0/lib/cocoapods/installer.rb:123:in `generate_pods_project'
/Users/ratazzi/.rvm/gems/ruby-2.1-head/gems/cocoapods-0.35.0/lib/cocoapods/installer.rb:92:in `install!'
/Users/ratazzi/.rvm/gems/ruby-2.1-head/gems/cocoapods-0.35.0/lib/cocoapods/command/project.rb:71:in `run_install_with_update'
/Users/ratazzi/.rvm/gems/ruby-2.1-head/gems/cocoapods-0.35.0/lib/cocoapods/command/project.rb:101:in `run'
/Users/ratazzi/.rvm/gems/ruby-2.1-head/gems/claide-0.7.0/lib/claide/command.rb:271:in `run'
/Users/ratazzi/.rvm/gems/ruby-2.1-head/gems/cocoapods-0.35.0/lib/cocoapods/command.rb:45:in `run'
/Users/ratazzi/.rvm/gems/ruby-2.1-head/gems/cocoapods-0.35.0/bin/pod:43:in `<top (required)>'
/Users/ratazzi/.rvm/gems/ruby-2.1-head/bin/pod:23:in `load'
/Users/ratazzi/.rvm/gems/ruby-2.1-head/bin/pod:23:in `<main>'
/Users/ratazzi/.rvm/gems/ruby-2.1-head/bin/ruby_executable_hooks:15:in `eval'
/Users/ratazzi/.rvm/gems/ruby-2.1-head/bin/ruby_executable_hooks:15:in `<main>'
```
