### PR TITLE
Fail if a spec is deprecated_in_favor_of itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ##### Enhancements
 
+* The Linter will now ensure against marking a spec as
+  `deprecated_in_favor_of` itself.  
+  [Keith Smiley](https://github.com/Keithbsmiley)
+  [#212](https://github.com/CocoaPods/Core/pull/212)
+
 * Added `module_name` attribute for use with frameworks.  
   [Boris Bügling](https://github.com/neonichu)
   [#205](https://github.com/CocoaPods/Core/issues/205)

--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -335,6 +335,15 @@ module Pod
         check_git_ssh_source(s)
       end
 
+      # Performs validations related to the `deprecated_in_favor_of` attribute.
+      #
+      def _validate_deprecated_in_favor_of(d)
+        if d == Specification.root_name(d)
+          results.add_error('deprecated_in_favor_of', 'a spec cannot be ' \
+            'deprecated in favor of itself')
+        end
+      end
+
       # Performs validations related to github sources.
       #
       def perform_github_source_checks(s)

--- a/spec/specification/linter_spec.rb
+++ b/spec/specification/linter_spec.rb
@@ -410,6 +410,11 @@ module Pod
                               'libraries')
       end
 
+      it 'checks that a spec is not deprecated in favor of itself' do
+        @spec.deprecated_in_favor_of = @spec.name
+        result_should_include('a spec cannot be', 'deprecated_in_favor_of')
+      end
+
       #------------------#
 
       it 'checks if the compiler flags disable warnings' do


### PR DESCRIPTION
This may seem funny. If so, see https://github.com/CocoaPods/Specs/pull/12876
