### PR TITLE
Add the lost space preceding the attribute name in validation messages

### DIFF
--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -91,10 +91,10 @@ module Pod
           next unless attr.required?
           unless value && (!value.respond_to?(:empty?) || !value.empty?)
             if attr.name == :license
-              results.add_warning('attributes', 'Missing required attribute' \
+              results.add_warning('attributes', 'Missing required attribute ' \
               "`#{attr.name}`.")
             else
-              results.add_error('attributes', 'Missing required attribute' \
+              results.add_error('attributes', 'Missing required attribute ' \
                "`#{attr.name}`.")
             end
           end


### PR DESCRIPTION
This has caused an error after updating the gem on trunk.
```diff
- "Missing required attribute `license`."
+ "Missing required attribute`license`."
```
This minor change fixes that and causes that the generated messages will be generated equal to the prior state, seen as above in red.