### PR TITLE
[Analyzer] The linter will allow non-file-pattern values for `requires_arc`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CocoaPods Core Changelog
 
+## Master
+
+##### Bug Fixes
+
+* The linter will allow non-file-pattern values for `requires_arc`.  
+  [Samuel Giddins](https://github.com/segiddins)
+  [CocoaPods#2923](https://github.com/CocoaPods/CocoaPods/issues/2923)
+
+
 ## 0.36.0.beta.1
 
 ##### Enhancements

--- a/lib/cocoapods-core/specification/linter/analyzer.rb
+++ b/lib/cocoapods-core/specification/linter/analyzer.rb
@@ -83,7 +83,7 @@ module Pod
 
             if patterns.respond_to?(:each)
               patterns.each do |pattern|
-                if pattern.start_with?('/')
+                if pattern.is_a?(String) && pattern.start_with?('/')
                   results.add_error('File Patterns', 'File patterns must be ' \
                     "relative and cannot start with a slash (#{attrb.name}).")
                 end

--- a/spec/specification/linter/analyzer_spec.rb
+++ b/spec/specification/linter/analyzer_spec.rb
@@ -130,6 +130,12 @@ module Pod
           results.first.message.should.include?('spec is empty')
           results.first.attribute_name.should.include?('File Patterns')
         end
+
+        it 'allows a non-string value for requires_arc' do
+          @spec.requires_arc = true
+          results = @analyzer.analyze
+          results.should.be.empty
+        end
       end
 
       #----------------------------------------#


### PR DESCRIPTION
\c @kylef 