### PR TITLE
supports git ssh url without preceding `user@` as podspec source url

### DIFF
--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -365,6 +365,7 @@ module Pod
         if git = s[:git]
           return unless git =~ /^#{URI.regexp}$/
           git_uri = URI.parse(git)
+          return unless git_uri.host
           perform_github_uri_checks(git, git_uri) if git_uri.host.end_with?('github.com')
         end
       end
@@ -387,8 +388,15 @@ module Pod
       # Performs validations related to SSH sources
       #
       def check_git_ssh_source(s)
+        require 'uri'
+
         if git = s[:git]
-          if git =~ /\w+\@(\w|\.)+\:(\/\w+)*/
+          if git =~ /^#{URI.regexp}$/
+            git_uri = URI.parse(git)
+            return if %w[http https git].include?(git_uri.scheme) && git_uri.host
+          end
+          
+          if git =~ /(\w+\@)?(\w|\.)+\:(\/\w+)*/
             results.add_warning('source', 'Git SSH URLs will NOT work for ' \
               'people behind firewalls configured to only allow HTTP, ' \
               'therefore HTTPS is preferred.')

--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -365,8 +365,7 @@ module Pod
         if git = s[:git]
           return unless git =~ /^#{URI.regexp}$/
           git_uri = URI.parse(git)
-          return unless git_uri.host
-          perform_github_uri_checks(git, git_uri) if git_uri.host.end_with?('github.com')
+          perform_github_uri_checks(git, git_uri) if git_uri.host && git_uri.host.end_with?('github.com')
         end
       end
 

--- a/spec/specification/linter_spec.rb
+++ b/spec/specification/linter_spec.rb
@@ -327,6 +327,12 @@ module Pod
         result_should_include('Git', 'SSH')
       end
 
+      it 'warns for SSH repositories (without user@)' do
+        @spec.stubs(:source).returns(:git => 'gitbucket:/group/repo.git', :tag => '1.0')
+        @linter.lint
+        result_should_include('Git', 'SSH')
+      end
+
       it 'warns for SSH repositories on Github' do
         @spec.stubs(:source).returns(:git => 'git@github.com:kylef/test.git', :tag => '1.0')
         result_should_include('Git', 'SSH')


### PR DESCRIPTION
`pod _0.36.0.rc.1_ lib lint` fails with an error when podspec source url have some form of `hostname:/path/to.git`, without preceding `user@` (such as `git@hostname:/path/to.git`).
some github clone (such as GitBucket) do not use `git@` as username. they use account names for ssh login. so we should avoid using specific username from podspec source urls.

### Error

```
NoMethodError - undefined method `end_with?' for nil:NilClass
/Library/Ruby/Gems/2.0.0/gems/cocoapods-core-0.36.0.rc.1/lib/cocoapods-core/specification/linter.rb:368:in `perform_github_source_checks'
/Library/Ruby/Gems/2.0.0/gems/cocoapods-core-0.36.0.rc.1/lib/cocoapods-core/specification/linter.rb:347:in `_validate_source'
/Library/Ruby/Gems/2.0.0/gems/cocoapods-core-0.36.0.rc.1/lib/cocoapods-core/specification/linter.rb:159:in `block in run_validation_hooks'
/Library/Ruby/Gems/2.0.0/gems/cocoapods-core-0.36.0.rc.1/lib/cocoapods-core/specification/linter.rb:154:in `each'
/Library/Ruby/Gems/2.0.0/gems/cocoapods-core-0.36.0.rc.1/lib/cocoapods-core/specification/linter.rb:154:in `run_validation_hooks'
/Library/Ruby/Gems/2.0.0/gems/cocoapods-core-0.36.0.rc.1/lib/cocoapods-core/specification/linter.rb:110:in `run_root_validation_hooks'
/Library/Ruby/Gems/2.0.0/gems/cocoapods-core-0.36.0.rc.1/lib/cocoapods-core/specification/linter.rb:50:in `lint'
/Library/Ruby/Gems/2.0.0/gems/cocoapods-0.36.0.rc.1/lib/cocoapods/validator.rb:198:in `perform_linting'
/Library/Ruby/Gems/2.0.0/gems/cocoapods-0.36.0.rc.1/lib/cocoapods/validator.rb:72:in `validate'
/Library/Ruby/Gems/2.0.0/gems/cocoapods-0.36.0.rc.1/lib/cocoapods/command/lib.rb:149:in `block in run'
/Library/Ruby/Gems/2.0.0/gems/cocoapods-0.36.0.rc.1/lib/cocoapods/command/lib.rb:140:in `each'
/Library/Ruby/Gems/2.0.0/gems/cocoapods-0.36.0.rc.1/lib/cocoapods/command/lib.rb:140:in `run'
/Library/Ruby/Gems/2.0.0/gems/claide-0.8.1/lib/claide/command.rb:312:in `run'
/Library/Ruby/Gems/2.0.0/gems/cocoapods-0.36.0.rc.1/lib/cocoapods/command.rb:46:in `run'
/Library/Ruby/Gems/2.0.0/gems/cocoapods-0.36.0.rc.1/bin/pod:44:in `<top (required)>'
/usr/bin/pod:23:in `load'
/usr/bin/pod:23:in `<main>'
```
