### PR TITLE
[DSLError] Present fancy error messages even for things like SyntaxErrors that dont have cooperative backtraces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Master
 
+##### Enhancements
+
+* DSL errors now show more context when errors such as `SyntaxError` are
+  encountered.  
+  [Samuel Giddins](https://github.com/segiddins)
+
 ##### Bug Fixes
 
 * Allow a `Dependency` to be initialized with no non-nil external source

--- a/lib/cocoapods-core/podfile.rb
+++ b/lib/cocoapods-core/podfile.rb
@@ -255,7 +255,7 @@ module Pod
           # rubocop:enable Eval
         rescue => e
           message = "Invalid `#{path.basename}` file: #{e.message}"
-          raise DSLError.new(message, path, e.backtrace)
+          raise DSLError.new(message, path, e.backtrace, string)
         end
       end
       podfile

--- a/lib/cocoapods-core/specification.rb
+++ b/lib/cocoapods-core/specification.rb
@@ -608,6 +608,6 @@ module Pod
     # rubocop:enable Eval
   rescue => e
     message = "Invalid `#{path.basename}` file: #{e.message}"
-    raise DSLError.new(message, path, e.backtrace)
+    raise DSLError.new(message, path, e.backtrace, string)
   end
 end

--- a/spec/standard_error_spec.rb
+++ b/spec/standard_error_spec.rb
@@ -9,11 +9,23 @@ module Pod
         "#{@dsl_path}:127:in `block (2 levels) in _eval_podspec'",
         "lib/cocoapods-core/specification.rb:41:in `initialize'",
       ]
-      description = 'Invalid podspec.'
+      description = 'Invalid podspec'
       @err = DSLError.new(description, @dsl_path, backtrace)
 
       lines = ['first line', 'error line', 'last line']
       File.stubs(:readlines).returns(lines)
+    end
+
+    it 'returns a properly formed message' do
+      @err.message.should == <<-MSG.strip_heredoc
+
+        [!] Invalid podspec. Updating CocoaPods might fix the issue.
+
+         #  from /Users/segiddins/Development/OpenSource/Rainforest/Core/spec/fixtures/spec-repos/master/Three20/1.0.11/Three20.podspec:2
+         #  -------------------------------------------
+         #  first line >  error line #  last line
+         #  -------------------------------------------
+      MSG
     end
 
     it 'includes the given description in the message' do


### PR DESCRIPTION
The new functionality is demonstrated at https://github.com/CocoaPods/Core/pull/226/files#diff-7dd13ddd3ab90c5487ed0e20928c423eR33

\c @kylef @orta 