### PR TITLE
Feature Request #3275: Add private_spec root attribute to Specification.

### DIFF
--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -427,6 +427,26 @@ module Pod
       #
       root_attribute :deprecated_in_favor_of
 
+      #------------------#
+
+      # @!method private_spec=(flag)
+      #
+      #   `private_spec` allows you to specify that a pod is private
+      #   consumption only and is not allowed to be published to trunk.
+      #
+      #   The default value of this attribute is `false`.
+      #
+      #   @example
+      #
+      #     spec.private_spec = true
+      #
+      #   @param [Bool] flag
+      #          Whether the specification is private.
+      #
+      root_attribute :private_spec,
+                     :types => [TrueClass, FalseClass],
+                     :default_value => false
+
       #-----------------------------------------------------------------------#
 
       # @!group Platform

--- a/lib/cocoapods-core/specification/root_attribute_accessors.rb
+++ b/lib/cocoapods-core/specification/root_attribute_accessors.rb
@@ -166,6 +166,18 @@ module Pod
           deprecated || !deprecated_in_favor_of.nil?
         end
 
+        # @return [Bool] Whether the pod is private and cannot be pushed to trunk.
+        #
+        def private_spec
+          attributes_hash['private_spec']
+        end
+
+        # @return [Bool] Whether the pod is private and cannot be pushed to trunk.
+        #
+        def private_spec?
+          private_spec
+        end
+
         #---------------------------------------------------------------------#
 
         private

--- a/spec/specification/dsl_spec.rb
+++ b/spec/specification/dsl_spec.rb
@@ -85,6 +85,20 @@ module Pod
         @spec.deprecated_in_favor_of = 'NewMoreAwesomePod'
         @spec.attributes_hash['deprecated_in_favor_of'].should == 'NewMoreAwesomePod'
       end
+
+      it 'allows to specify the Pod as private' do
+        @spec.private_spec = true
+        @spec.attributes_hash['private_spec'].should == true
+      end
+    end
+
+    #-----------------------------------------------------------------------------#
+
+    describe 'Root specification attributes default values' do
+      it 'does not specify the Pod as private by default' do
+        attr = Specification::DSL.attributes[:private_spec]
+        attr.default.should == false
+      end
     end
 
     #-----------------------------------------------------------------------------#

--- a/spec/specification/root_attribute_accessors_spec.rb
+++ b/spec/specification/root_attribute_accessors_spec.rb
@@ -163,5 +163,10 @@ module Pod
 
       @spec.deprecated?.should == false
     end
+
+    it 'returns whether the Pod is private' do
+      @spec.private_spec = true
+      @spec.private_spec?.should == true
+    end
   end
 end


### PR DESCRIPTION
This is the first of two parts for [#3275](https://github.com/CocoaPods/CocoaPods/issues/3275), which updates the Specification DSL. The second part in cocoapods-trunk will actually use the new attribute. :rainbow: 

cc: @orta 