### PR TITLE
[Dependency] Compact and ensure #external_source is not empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CocoaPods Core Changelog
 
+## Master
+
+##### Bug Fixes
+
+* Allow a `Dependency` to be initialized with no non-nil external source
+  key-value pairs and not be considered external.  
+  [Samuel Giddins](https://github.com/segiddins)
+  [CocoaPods#3320](https://github.com/CocoaPods/CocoaPods/issues/3320)
+
+
 ## 0.36.1
 
 ##### Bug Fixes

--- a/lib/cocoapods-core/dependency.rb
+++ b/lib/cocoapods-core/dependency.rb
@@ -69,7 +69,8 @@ module Pod
     #
     def initialize(name = nil, *requirements)
       if requirements.last.is_a?(Hash)
-        @external_source = requirements.pop
+        external_source = requirements.pop.select { |_, v| !v.nil? }
+        @external_source = external_source unless external_source.empty?
         unless requirements.empty?
           raise Informative, 'A dependency with an external source may not ' \
             "specify version requirements (#{name})."

--- a/spec/dependency_spec.rb
+++ b/spec/dependency_spec.rb
@@ -23,6 +23,12 @@ module Pod
         dep.should.be.external
       end
 
+      it 'can be initialized with an empty external source and not be ' \
+         'considered external' do
+        dep = Dependency.new('cocoapods', :git => nil)
+        dep.should.not.be.external
+      end
+
       it "knows if it's local" do
         dep = Dependency.new('cocoapods', :path => '/tmp/cocoapods')
         dep.should.be.local


### PR DESCRIPTION
Closes https://github.com/CocoaPods/CocoaPods/issues/3320.

\c @kylef 