### PR TITLE
[Source] Make #search case sensistive even on case-insensitive HFS+

### DIFF
--- a/lib/cocoapods-core/source.rb
+++ b/lib/cocoapods-core/source.rb
@@ -201,8 +201,7 @@ module Pod
       if query.is_a?(Dependency)
         query = query.root_name
       end
-      spec_dir = specs_dir + query
-      if Pathname.glob(spec_dir) == [spec_dir]
+      if specs_dir.children.select(&:directory?).map(&:basename).map(&:to_s).include?(query.to_s)
         set(query)
       end
     end

--- a/lib/cocoapods-core/source.rb
+++ b/lib/cocoapods-core/source.rb
@@ -201,7 +201,8 @@ module Pod
       if query.is_a?(Dependency)
         query = query.root_name
       end
-      if (specs_dir + query).directory?
+      spec_dir = specs_dir + query
+      if Pathname.glob(spec_dir) == [spec_dir]
         set(query)
       end
     end

--- a/spec/source_spec.rb
+++ b/spec/source_spec.rb
@@ -109,6 +109,10 @@ module Pod
         @source.search(dep).name.should == 'BananaLib'
       end
 
+      it 'matches case' do
+        @source.search('bAnAnAlIb').should.be.nil?
+      end
+
       describe '#search_by_name' do
         it 'properly configures the sources of a set in search by name' do
           source = Source.new(fixture('spec-repos/test_repo'))


### PR DESCRIPTION
I'd love to do this in a faster way, and in a manner that doesn't rely on `Pathname.glob`'s results matching the underlying preserved case.

\c @kylef @samdmarshall

Closes https://github.com/CocoaPods/CocoaPods/issues/3024.
Closes https://github.com/CocoaPods/CocoaPods/issues/2910.