### PR TITLE
[Specification::DSL] Fixes around Linter and Analyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@
   [Samuel Giddins](https://github.com/segiddins)
   [#221](https://github.com/CocoaPods/Core/issues/221)
 
-
 ##### Bug Fixes
+
+* The linter fails now if root attributes occur on subspec level.  
+  [Marius Rackwitz](https://github.com/mrackwitz)
+  [#233](https://github.com/CocoaPods/Core/pull/233)
 
 * Inhibit warnings for pods that only have the `inhibit_warnings` option enabled
   on a subspec.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@
 
 ##### Bug Fixes
 
+* The linter will now ensure that subspecs' names do not contain whitespace.  
+  [Marius Rackwitz](https://github.com/mrackwitz)
+  [Joshua Kalpin](https://github.com/Kapin)
+  [Samuel Giddins](https://github.com/segiddins)
+  [#177](https://github.com/CocoaPods/Core/issues/177)
+  [#178](https://github.com/CocoaPods/Core/pull/178)
+  [#202](https://github.com/CocoaPods/Core/pull/202)
+  [#233](https://github.com/CocoaPods/Core/pull/233)
+
 * The linter fails now if root attributes occur on subspec level.  
   [Marius Rackwitz](https://github.com/mrackwitz)
   [#233](https://github.com/CocoaPods/Core/pull/233)

--- a/lib/cocoapods-core/specification/consumer.rb
+++ b/lib/cocoapods-core/specification/consumer.rb
@@ -57,6 +57,10 @@ module Pod
 
       # @!group Regular attributes
 
+      # @return [String] The name of the specification.
+      #
+      spec_attr_accessor :name
+
       # @return [Bool] Whether the source files of the specification require to
       #         be compiled with ARC.
       #

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -794,8 +794,7 @@ module Pod
       #   @param  [String] name
       #           the module name.
       #
-      root_attribute :module_name,
-                     :inherited => true
+      root_attribute :module_name
 
       #------------------#
 

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -76,8 +76,10 @@ module Pod
       #   @param  [String] name
       #           the name of the pod.
       #
-      root_attribute :name,
-                     :required => true
+      attribute :name,
+                :required => true,
+                :inherited => false,
+                :multi_platform => false
 
       #------------------#
 

--- a/lib/cocoapods-core/specification/dsl/attribute.rb
+++ b/lib/cocoapods-core/specification/dsl/attribute.rb
@@ -185,65 +185,7 @@ module Pod
         def writer_singular_form
           "#{name.to_s.singularize}=" if singularize?
         end
-
-        #---------------------------------------------------------------------#
-
-        # @!group Values validation
-
-        # Validates the value for an attribute. This validation should be
-        # performed before the value is prepared or wrapped.
-        #
-        # @note   The this is called before preparing the value.
-        #
-        # @raise  If the type is not in the allowed list.
-        #
-        # @return [void]
-        #
-        def validate_type(value)
-          return if value.nil?
-          unless supported_types.any? { |klass| value.class == klass }
-            raise StandardError, "Non acceptable type `#{value.class}` for "\
-              "#{self}. Allowed values: `#{types.inspect}`"
-          end
-        end
-
-        # Validates a value before storing.
-        #
-        # @raise If a root only attribute is set in a subspec.
-        #
-        # @raise If a unknown key is added to a hash.
-        #
-        # @return [void]
-        #
-        def validate_for_writing(spec, value)
-          if root_only? && !spec.root?
-            raise StandardError, "Can't set `#{name}` attribute for " \
-              "subspecs (in `#{spec.name}`)."
-          end
-
-          if keys
-            value.keys.each do |key|
-              unless allowed_keys.include?(key)
-                raise StandardError, "Unknown key `#{key}` for "\
-                  "#{self}. Allowed keys: `#{allowed_keys.inspect}`"
-              end
-            end
-          end
-
-          # @return [Array] the flattened list of the allowed keys for the
-          # hash of a given specification.
-          #
-          def allowed_keys
-            if keys.is_a?(Hash)
-              keys.keys.concat(keys.values.flatten.compact)
-            else
-              keys
-            end
-          end
-        end
       end
-
-      #-----------------------------------------------------------------------#
     end
   end
 end

--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -46,7 +46,7 @@ module Pod
       def lint
         @results = Results.new
         if spec
-          check_required_root_attributes
+          check_required_attributes
           validate_name
           run_root_validation_hooks
           perform_all_specs_analysis
@@ -81,15 +81,14 @@ module Pod
 
       # !@group Lint steps
 
-      # Checks that every root only attribute which is required has a value.
+      # Checks that every required attribute has a value.
       #
       # @return [void]
       #
-      def check_required_root_attributes
-        attributes = DSL.attributes.values.select(&:root_only?)
+      def check_required_attributes
+        attributes = DSL.attributes.values.select(&:required?)
         attributes.each do |attr|
           value = spec.send(attr.name)
-          next unless attr.required?
           unless value && (!value.respond_to?(:empty?) || !value.empty?)
             if attr.name == :license
               results.add_warning('attributes', 'Missing required attribute ' \
@@ -147,7 +146,7 @@ module Pod
       #
       # @note   Hooks are called only if there is a value for the attribute as
       #         required attributes are already checked by the
-      #         {#check_required_root_attributes} step.
+      #         {#check_required_attributes} step.
       #
       # @return [void]
       #

--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -48,7 +48,6 @@ module Pod
         if spec
           validate_root_name
           check_required_attributes
-          validate_name
           run_root_validation_hooks
           perform_all_specs_analysis
         else
@@ -185,22 +184,20 @@ module Pod
 
       # Performs validations related to the `name` attribute.
       #
-      def validate_name
-        if spec.name && file
-          if spec.name =~ /\//
-            results.add_error('name', 'The name of a spec should not contain ' \
-                           'a slash.')
-          end
+      def _validate_name(name)
+        if name =~ /\//
+          results.add_error('name', 'The name of a spec should not contain ' \
+                         'a slash.')
+        end
 
-          if spec.root.name =~ /\s/
-            results.add_error('name', 'The name of a spec should not contain ' \
-                           'whitespace.')
-          end
+        if name =~ /\s/
+          results.add_error('name', 'The name of a spec should not contain ' \
+                         'whitespace.')
+        end
 
-          if spec.root.name[0, 1] == '.'
-            results.add_error('name', 'The name of a spec should not begin' \
-            ' with a period.')
-          end
+        if name[0, 1] == '.'
+          results.add_error('name', 'The name of a spec should not begin' \
+          ' with a period.')
         end
       end
 

--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -46,6 +46,7 @@ module Pod
       def lint
         @results = Results.new
         if spec
+          validate_root_name
           check_required_attributes
           validate_name
           run_root_validation_hooks
@@ -80,6 +81,24 @@ module Pod
       private
 
       # !@group Lint steps
+
+      # Checks that the spec's root name matches the filename.
+      #
+      # @return [void]
+      #
+      def validate_root_name
+        if spec.root.name && file
+          acceptable_names = [
+            spec.root.name + '.podspec',
+            spec.root.name + '.podspec.json',
+          ]
+          names_match = acceptable_names.include?(file.basename.to_s)
+          unless names_match
+            results.add_error('name', 'The name of the spec should match the ' \
+                              'name of the file.')
+          end
+        end
+      end
 
       # Checks that every required attribute has a value.
       #
@@ -168,16 +187,6 @@ module Pod
       #
       def validate_name
         if spec.name && file
-          acceptable_names = [
-            spec.root.name + '.podspec',
-            spec.root.name + '.podspec.json',
-          ]
-          names_match = acceptable_names.include?(file.basename.to_s)
-          unless names_match
-            results.add_error('name', 'The name of the spec should match the ' \
-                           'name of the file.')
-          end
-
           if spec.name =~ /\//
             results.add_error('name', 'The name of a spec should not contain ' \
                            'a slash.')

--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -178,6 +178,11 @@ module Pod
                            'name of the file.')
           end
 
+          if spec.name =~ /\//
+            results.add_error('name', 'The name of a spec should not contain ' \
+                           'a slash.')
+          end
+
           if spec.root.name =~ /\s/
             results.add_error('name', 'The name of a spec should not contain ' \
                            'whitespace.')

--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -47,6 +47,7 @@ module Pod
         @results = Results.new
         if spec
           check_required_root_attributes
+          validate_name
           run_root_validation_hooks
           perform_all_specs_analysis
         else
@@ -164,11 +165,9 @@ module Pod
 
       private
 
-      # @!group Root spec validation helpers
-
       # Performs validations related to the `name` attribute.
       #
-      def _validate_name(_n)
+      def validate_name
         if spec.name && file
           acceptable_names = [
             spec.root.name + '.podspec',
@@ -191,6 +190,8 @@ module Pod
           end
         end
       end
+
+      # @!group Root spec validation helpers
 
       def _validate_authors(a)
         if a.is_a? Hash

--- a/lib/cocoapods-core/specification/linter/analyzer.rb
+++ b/lib/cocoapods-core/specification/linter/analyzer.rb
@@ -132,7 +132,7 @@ module Pod
         # @param  [Spec::DSL::Attribute] attribute
         #         The attribute.
 
-        # @param  [mixed] value
+        # @param  [Object] value
         #         The value of the attribute.
         #
         def validate_attribute_occurrence(attribute, value)
@@ -147,7 +147,7 @@ module Pod
         # @param  [Spec::DSL::Attribute] attribute
         #         The attribute.
         #
-        # @param  [mixed] value
+        # @param  [Object] value
         #         The value of the attribute.
         #
         def validate_attribute_value(attribute, value)

--- a/lib/cocoapods-core/specification/linter/analyzer.rb
+++ b/lib/cocoapods-core/specification/linter/analyzer.rb
@@ -127,7 +127,7 @@ module Pod
           nil
         end
 
-        # Validates the occurrence of the given attribute.
+        # Validates that root attributes don't occur in subspecs.
         #
         # @param  [Spec::DSL::Attribute] attribute
         #         The attribute.

--- a/lib/cocoapods-core/specification/linter/analyzer.rb
+++ b/lib/cocoapods-core/specification/linter/analyzer.rb
@@ -122,7 +122,7 @@ module Pod
         # @param  [Spec::DSL::Attribute] attribute
         #         The attribute.
         #
-        # @param  [Spec::DSL::Attribute] value
+        # @param  [mixed] value
         #         The value of the attribute.
         #
         def validate_attribute_value(attribute, value)

--- a/spec/specification/dsl/attribute_spec.rb
+++ b/spec/specification/dsl/attribute_spec.rb
@@ -113,45 +113,5 @@ module Pod
         attr.writer_singular_form.should == 'framework='
       end
     end
-
-    #-------------------------------------------------------------------------#
-
-    describe 'Writer method support' do
-      it 'validates a value to check whether it is compatible with the accepted types' do
-        attr = Attribute.new(:frameworks,  :types => [String], :container => Array)
-        lambda { attr.validate_type('a string') }.should.not.raise
-        lambda { attr.validate_type(['with container']) }.should.not.raise
-        lambda { attr.validate_type(:non_accepted) }.should.raise StandardError
-      end
-
-      it 'validates root only values before writing' do
-        attr = Attribute.new(:summary, :root_only => true)
-        spec = Spec.new do |s|
-          s.subspec 'sub' do |_sp|
-          end
-        end
-        subspec = spec.subspecs.first
-
-        lambda { attr.validate_for_writing(spec, 'a string') }.should.not.raise
-        lambda { attr.validate_for_writing(subspec, 'a string') }.should.raise StandardError
-      end
-
-      it 'validates the allowed keys for hashes before writing' do
-        attr = Attribute.new(:source, :keys => [:git])
-        spec = Spec.new
-        lambda { attr.validate_for_writing(spec,  :git => 'repo') }.should.not.raise
-        lambda { attr.validate_for_writing(spec,  :snail_mail => 'repo') }.should.raise StandardError
-      end
-
-      it 'returns the allowed keys' do
-        attr = Attribute.new(:source, :keys => [:git, :svn])
-        attr.allowed_keys.should == [:git, :svn]
-      end
-
-      it 'returns the allowed keys flattening keys specified in a hash' do
-        attr = Attribute.new(:source, :keys => { :git => [:tag, :commit], :http => nil })
-        attr.allowed_keys.map(&:to_s).sort.should == %w(commit git http tag)
-      end
-    end
   end
 end

--- a/spec/specification/linter/analyzer_spec.rb
+++ b/spec/specification/linter/analyzer_spec.rb
@@ -28,6 +28,23 @@ module Pod
 
       #----------------------------------------#
 
+      describe 'Root attributes' do
+        it 'fails a subspec with a root attribute' do
+          subspec = @spec.subspec 'subspec' do |sp|
+            sp.homepage = 'http://example.org'
+          end
+          results = Specification::Linter::Results.new
+          @analyzer = Specification::Linter::Analyzer.new(subspec.consumer(:ios), results)
+          results = @analyzer.analyze
+          results.count.should.be.equal(1)
+          expected = 'Can\'t set `homepage` attribute for subspecs (in `BananaLib/subspec`).'
+          results.first.message.should.include?(expected)
+          results.first.attribute_name.should.include?('attribute')
+        end
+      end
+
+      #----------------------------------------#
+
       describe 'Unknown keys check' do
         it 'validates a spec with valid keys' do
           results = @analyzer.analyze

--- a/spec/specification/linter_spec.rb
+++ b/spec/specification/linter_spec.rb
@@ -113,14 +113,19 @@ module Pod
 
       #------------------#
 
-      xit 'checks for unrecognized keys' do
+      it 'checks for unrecognized keys' do
+        @spec.attributes_hash[:foo] = 'bar'
+        result_should_include('foo', 'unrecognized')
       end
 
-      xit 'checks the type of the values of the attributes' do
+      it 'checks the type of the values of the attributes' do
+        @spec.homepage = %w(Pod)
+        result_should_include('homepage', 'unacceptable type')
       end
 
-      xit 'checks for unknown keys in the license' do
-        lambda { @spec.license = { :name => 'MIT' } }.should.raise StandardError
+      it 'checks for unknown keys in the license' do
+        @spec.license = { :name => 'MIT' }
+        result_should_include('license', 'unrecognized `name` key')
       end
 
       xit 'checks the source for unknown keys' do

--- a/spec/specification/linter_spec.rb
+++ b/spec/specification/linter_spec.rb
@@ -88,12 +88,9 @@ module Pod
       end
     end
 
-    #--------------------------------------#
-
-    describe 'Root spec' do
+    shared 'Linter' do
       before do
-        fixture_path = 'spec-repos/test_repo/Specs/BananaLib/1.0/BananaLib.podspec'
-        @podspec_path = fixture(fixture_path)
+        @podspec_path = fixture(@fixture_path)
         @linter = Specification::Linter.new(@podspec_path)
         @spec = @linter.spec
       end
@@ -110,6 +107,16 @@ module Pod
 
         matched.size.should == 1
       end
+    end
+
+    #--------------------------------------#
+
+    describe 'Root spec' do
+      before do
+        @fixture_path = 'spec-repos/test_repo/Specs/BananaLib/1.0/BananaLib.podspec'
+      end
+
+      behaves_like 'Linter'
 
       #------------------#
 
@@ -146,12 +153,12 @@ module Pod
       end
 
       it 'fails a specification whose name contains whitespace' do
-        @spec.stubs(:name).returns('bad name')
+        @spec.name = 'bad name'
         result_should_include('name', 'whitespace')
       end
 
       it 'fails a specification whose name contains a slash' do
-        @spec.stubs(:name).returns('BananaKit/BananaFruit')
+        @spec.name = 'BananaKit/BananaFruit'
         result_should_include('name', 'slash')
       end
 
@@ -451,6 +458,31 @@ module Pod
       it 'checks if the compiler flags disable warnings' do
         @spec.compiler_flags = '-some_flag', '-another -Wno_flags'
         result_should_include('warnings', 'disabled', 'compiler_flags')
+      end
+    end
+
+    #--------------------------------------#
+
+    describe 'Subspec' do
+      before do
+        @fixture_path = 'spec-repos/master/RestKit/0.20.1/RestKit.podspec'
+      end
+
+      behaves_like 'Linter'
+
+      it 'fails a subspec whose name contains whitespace' do
+        @spec.subspecs.each { |ss| ss.name = 'bad name' }
+        result_should_include('name', 'whitespace')
+      end
+
+      it 'fails a subspec whose name begins with a `.`' do
+        @spec.subspecs.each { |ss| ss.name = '.badname' }
+        result_should_include('name', 'period')
+      end
+
+      it 'fails a specification whose name contains a slash' do
+        @spec.name = 'BananaKit/BananaFruit'
+        result_should_include('name', 'slash')
       end
     end
   end

--- a/spec/specification/linter_spec.rb
+++ b/spec/specification/linter_spec.rb
@@ -150,6 +150,11 @@ module Pod
         result_should_include('name', 'whitespace')
       end
 
+      it 'fails a specification whose name contains a slash' do
+        @spec.stubs(:name).returns('BananaKit/BananaFruit')
+        result_should_include('name', 'slash')
+      end
+
       #------------------#
 
       it 'fails a specification whose authors are the default' do


### PR DESCRIPTION
Includes a fix that `:root_only => true` attributes could been overwritten in subspecs.
Especially the change in a6d508f should been reviewed carefully.
/c @kylef @segiddins @alloy