### PR TITLE
[WIP] Split xcconfig to pod_target_xcconfig and user_target_xcconfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Master
 
+##### Breaking
+
+* Deprecate the `xcconfig` attribute in the Podspec DSL, which is replaced by
+  the new attributes `pod_target_xcconfig` and `user_target_xcconfig`.  
+  [Marius Rackwitz](https://github.com/mrackwitz)
+  [CocoaPods#3465](https://github.com/CocoaPods/CocoaPods/issues/3465)
+
 ##### Enhancements
 
 * A more useful DSLError will be shown when there are syntax errors in a Ruby

--- a/lib/cocoapods-core/specification/consumer.rb
+++ b/lib/cocoapods-core/specification/consumer.rb
@@ -88,9 +88,9 @@ module Pod
       spec_attr_accessor :compiler_flags
 
       # @return [Hash{String => String}] the xcconfig flags for the current
-      #         specification.
+      #         specification for the pod target.
       #
-      spec_attr_accessor :xcconfig
+      spec_attr_accessor :pod_target_xcconfig
 
       # @return [String] The contents of the prefix header.
       #

--- a/lib/cocoapods-core/specification/consumer.rb
+++ b/lib/cocoapods-core/specification/consumer.rb
@@ -92,6 +92,11 @@ module Pod
       #
       spec_attr_accessor :pod_target_xcconfig
 
+      # @return [Hash{String => String}] the xcconfig flags for the current
+      #         specification for the user target.
+      #
+      spec_attr_accessor :user_target_xcconfig
+
       # @return [String] The contents of the prefix header.
       #
       spec_attr_accessor :prefix_header_contents

--- a/lib/cocoapods-core/specification/consumer.rb
+++ b/lib/cocoapods-core/specification/consumer.rb
@@ -90,12 +90,18 @@ module Pod
       # @return [Hash{String => String}] the xcconfig flags for the current
       #         specification for the pod target.
       #
-      spec_attr_accessor :pod_target_xcconfig
+      def pod_target_xcconfig
+        attr = Specification::DSL.attributes[:pod_target_xcconfig]
+        merge_values(attr, value_for_attribute(:xcconfig), value_for_attribute(:pod_target_xcconfig))
+      end
 
       # @return [Hash{String => String}] the xcconfig flags for the current
       #         specification for the user target.
       #
-      spec_attr_accessor :user_target_xcconfig
+      def user_target_xcconfig
+        attr = Specification::DSL.attributes[:user_target_xcconfig]
+        merge_values(attr, value_for_attribute(:xcconfig), value_for_attribute(:user_target_xcconfig))
+      end
 
       # @return [String] The contents of the prefix header.
       #

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -717,18 +717,18 @@ module Pod
 
       #------------------#
 
-      # @!method xcconfig=(value)
+      # @!method pod_target_xcconfig=(value)
       #
-      #   Any flag to add to the final xcconfig file.
+      #   Any flag to add to the final __private__ pod target xcconfig file.
       #
       #   @example
       #
-      #     spec.xcconfig = { 'OTHER_LDFLAGS' => '-lObjC' }
+      #     spec.pod_target_xcconfig = { 'OTHER_LDFLAGS' => '-lObjC' }
       #
       #   @param  [Hash{String => String}] value
-      #           A representing an xcconfig.
+      #           Key-value pairs representing build settings.
       #
-      attribute :xcconfig,
+      attribute :pod_target_xcconfig,
                 :container => Hash,
                 :inherited => true
 

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -732,6 +732,41 @@ module Pod
                 :container => Hash,
                 :inherited => true
 
+      # @!method user_target_xcconfig=(value)
+      #
+      #   Any flag to add to the final aggregate target xcconfig file, which
+      #   propagates to non-overridden build settings to the integrated user
+      #   targets.
+      #
+      #   ---
+      #
+      #   This attribute is __not recommended__ as Pods should not pollute the
+      #   build settings of the user project and this can cause conflicts.
+      #
+      #   Multiple definitions for build settings, which take multiple values,
+      #   will be merged. The user is warned on conflicting definitions for
+      #   custom build settings and build settings, which take only one value.
+      #
+      #   Typically clang compiler flags or precompiler macro definitions go
+      #   in here, if they are required when importing the pod in the user
+      #   target. Note that, this influences only the compiler view of the
+      #   public interface of your pod, but also all other integrated pods
+      #   alongside to yours. You should always prefer [`pod_target_xcconfig`](
+      #   http://guides.cocoapods.org/syntax/podspec.html#pod_target_xcconfig),
+      #   which can contain the same settings, but only influence the
+      #   toolchain, when compiling your pod target.
+      #
+      #   @example
+      #
+      #     spec.user_target_xcconfig = { 'MY_SUBSPEC' => 'YES' }
+      #
+      #   @param  [Hash{String => String}] value
+      #           Key-value pairs representing build settings.
+      #
+      attribute :user_target_xcconfig,
+                :container => Hash,
+                :inherited => true
+
       #------------------#
 
       # @!method prefix_header_contents=(content)

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -734,27 +734,27 @@ module Pod
 
       # @!method user_target_xcconfig=(value)
       #
-      #   Any flag to add to the final aggregate target xcconfig file, which
-      #   propagates to non-overridden build settings to the integrated user
-      #   targets.
+      #   Specifies flags to add to the final aggregate target xcconfig file,
+      #   which propagates to non-overridden and inheriting build settings to
+      #   the integrated user targets.
       #
       #   ---
       #
       #   This attribute is __not recommended__ as Pods should not pollute the
       #   build settings of the user project and this can cause conflicts.
       #
-      #   Multiple definitions for build settings, which take multiple values,
+      #   Multiple definitions for build settings that take multiple values
       #   will be merged. The user is warned on conflicting definitions for
-      #   custom build settings and build settings, which take only one value.
+      #   custom build settings and build settings that take only one value.
       #
       #   Typically clang compiler flags or precompiler macro definitions go
-      #   in here, if they are required when importing the pod in the user
-      #   target. Note that, this influences only the compiler view of the
+      #   in here if they are required when importing the pod in the user
+      #   target. Note that, this influences not only the compiler view of the
       #   public interface of your pod, but also all other integrated pods
       #   alongside to yours. You should always prefer [`pod_target_xcconfig`](
       #   http://guides.cocoapods.org/syntax/podspec.html#pod_target_xcconfig),
       #   which can contain the same settings, but only influence the
-      #   toolchain, when compiling your pod target.
+      #   toolchain when compiling your pod target.
       #
       #   @example
       #

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -1,7 +1,6 @@
 require 'cocoapods-core/specification/dsl/attribute_support'
 require 'cocoapods-core/specification/dsl/attribute'
 require 'cocoapods-core/specification/dsl/platform_proxy'
-require 'cocoapods-core/specification/dsl/deprecations'
 
 module Pod
   class Specification
@@ -42,6 +41,9 @@ module Pod
     #
     module DSL
       extend Pod::Specification::DSL::AttributeSupport
+
+      # Deprecations must be required after include AttributeSupport
+      require 'cocoapods-core/specification/dsl/deprecations'
 
       #-----------------------------------------------------------------------#
 

--- a/lib/cocoapods-core/specification/dsl/deprecations.rb
+++ b/lib/cocoapods-core/specification/dsl/deprecations.rb
@@ -10,6 +10,10 @@ module Pod
             'to `default_subspecs`.'
         end
 
+        DSL.attribute :xcconfig,
+                      :container => Hash,
+                      :inherited => true
+
         def xcconfig=(value)
           self.pod_target_xcconfig = value
           self.user_target_xcconfig = value

--- a/lib/cocoapods-core/specification/dsl/deprecations.rb
+++ b/lib/cocoapods-core/specification/dsl/deprecations.rb
@@ -9,6 +9,13 @@ module Pod
           CoreUI.warn "[#{self}] `preferred_dependency` has been renamed "\
             'to `default_subspecs`.'
         end
+
+        def xcconfig=(value)
+          self.pod_target_xcconfig = value
+          CoreUI.warn "[#{self}] `xcconfig` has been renamed to "\
+            '`pod_target_xcconfig`. See also the new introduced '\
+            '`user_target_xcconfig`.'
+        end
       end
     end
   end

--- a/lib/cocoapods-core/specification/dsl/deprecations.rb
+++ b/lib/cocoapods-core/specification/dsl/deprecations.rb
@@ -12,9 +12,9 @@ module Pod
 
         def xcconfig=(value)
           self.pod_target_xcconfig = value
-          CoreUI.warn "[#{self}] `xcconfig` has been renamed to "\
-            '`pod_target_xcconfig`. See also the new introduced '\
-            '`user_target_xcconfig`.'
+          self.user_target_xcconfig = value
+          CoreUI.warn "[#{self}] `xcconfig` has been split to "\
+            '`pod_target_xcconfig` and `user_target_xcconfig`.'
         end
       end
     end

--- a/lib/cocoapods-core/specification/dsl/deprecations.rb
+++ b/lib/cocoapods-core/specification/dsl/deprecations.rb
@@ -17,7 +17,7 @@ module Pod
         def xcconfig=(value)
           self.pod_target_xcconfig = value
           self.user_target_xcconfig = value
-          CoreUI.warn "[#{self}] `xcconfig` has been split to "\
+          CoreUI.warn "[#{self}] `xcconfig` has been split into "\
             '`pod_target_xcconfig` and `user_target_xcconfig`.'
         end
       end

--- a/spec/fixtures/BananaLib.podspec
+++ b/spec/fixtures/BananaLib.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.resources        = "Resources/*.png"
 
   # Build settings
-  s.xcconfig           = { 'OTHER_LDFLAGS' => '-framework SystemConfiguration' }
+  s.pod_target_xcconfig = { 'OTHER_LDFLAGS' => '-framework SystemConfiguration' }
   s.prefix_header_file = 'Classes/BananaLib.pch'
   s.requires_arc       = true
 

--- a/spec/specification/consumer_spec.rb
+++ b/spec/specification/consumer_spec.rb
@@ -169,6 +169,15 @@ module Pod
         osx_consumer.pod_target_xcconfig.should == { 'OTHER_LDFLAGS' => '-lObjC' }
       end
 
+      it 'merges the legacy xcconfig attribute' do
+        @spec.attributes_hash['xcconfig'] = { 'OTHER_LDFLAGS' => '-Wl' }
+        @spec.pod_target_xcconfig = { 'OTHER_LDFLAGS' => '-lObjC' }
+        @spec.user_target_xcconfig = { 'OTHER_LDFLAGS' => '-lObjC' }
+
+        @consumer.pod_target_xcconfig.should == { 'OTHER_LDFLAGS' => '-Wl -lObjC' }
+        @consumer.user_target_xcconfig.should == { 'OTHER_LDFLAGS' => '-Wl -lObjC' }
+      end
+
       #------------------#
 
       it 'allows to specify the contents of the prefix header' do

--- a/spec/specification/consumer_spec.rb
+++ b/spec/specification/consumer_spec.rb
@@ -151,22 +151,22 @@ module Pod
       #------------------#
 
       it 'allows to specify xcconfig settings' do
-        @spec.xcconfig = { 'OTHER_LDFLAGS' => '-lObjC' }
-        @consumer.xcconfig.should == { 'OTHER_LDFLAGS' => '-lObjC' }
+        @spec.pod_target_xcconfig = { 'OTHER_LDFLAGS' => '-lObjC' }
+        @consumer.pod_target_xcconfig.should == { 'OTHER_LDFLAGS' => '-lObjC' }
       end
 
       it 'inherits the xcconfig values from the parent' do
-        @spec.xcconfig = { 'OTHER_LDFLAGS' => '-lObjC' }
-        @subspec.xcconfig = { 'OTHER_LDFLAGS' => '-Wl -no_compact_unwind' }
-        @subspec_consumer.xcconfig.should == { 'OTHER_LDFLAGS' => '-lObjC -Wl -no_compact_unwind' }
+        @spec.pod_target_xcconfig = { 'OTHER_LDFLAGS' => '-lObjC' }
+        @subspec.pod_target_xcconfig = { 'OTHER_LDFLAGS' => '-Wl -no_compact_unwind' }
+        @subspec_consumer.pod_target_xcconfig.should == { 'OTHER_LDFLAGS' => '-lObjC -Wl -no_compact_unwind' }
       end
 
       it 'merges the xcconfig values so values for platforms can be specified' do
-        @spec.xcconfig = { 'OTHER_LDFLAGS' => '-lObjC' }
-        @spec.ios.xcconfig = { 'OTHER_LDFLAGS' => '-Wl -no_compact_unwind' }
-        @consumer.xcconfig.should == { 'OTHER_LDFLAGS' => '-lObjC -Wl -no_compact_unwind' }
+        @spec.pod_target_xcconfig = { 'OTHER_LDFLAGS' => '-lObjC' }
+        @spec.ios.pod_target_xcconfig = { 'OTHER_LDFLAGS' => '-Wl -no_compact_unwind' }
+        @consumer.pod_target_xcconfig.should == { 'OTHER_LDFLAGS' => '-lObjC -Wl -no_compact_unwind' }
         osx_consumer = Specification::Consumer.new(@spec, :osx)
-        osx_consumer.xcconfig.should == { 'OTHER_LDFLAGS' => '-lObjC' }
+        osx_consumer.pod_target_xcconfig.should == { 'OTHER_LDFLAGS' => '-lObjC' }
       end
 
       #------------------#

--- a/spec/specification/dsl_spec.rb
+++ b/spec/specification/dsl_spec.rb
@@ -229,6 +229,11 @@ module Pod
         @spec.attributes_hash['pod_target_xcconfig'].should == { 'OTHER_LDFLAGS' => '-lObjC' }
       end
 
+      it 'allows to specify user target xcconfig settings' do
+        @spec.user_target_xcconfig = { 'OTHER_CPLUSPLUSFLAGS' => '-std=c++1y' }
+        @spec.attributes_hash['user_target_xcconfig'].should == { 'OTHER_CPLUSPLUSFLAGS' => '-std=c++1y' }
+      end
+
       it 'allows to specify the contents of the prefix header' do
         @spec.prefix_header_contents = '#import <UIKit/UIKit.h>'
         @spec.attributes_hash['prefix_header_contents'].should == '#import <UIKit/UIKit.h>'

--- a/spec/specification/dsl_spec.rb
+++ b/spec/specification/dsl_spec.rb
@@ -224,9 +224,9 @@ module Pod
         @spec.attributes_hash['compiler_flags'].should == %w(-Wdeprecated-implementations -Wunused-value)
       end
 
-      it 'allows to specify xcconfig settings' do
-        @spec.xcconfig = { 'OTHER_LDFLAGS' => '-lObjC' }
-        @spec.attributes_hash['xcconfig'].should == { 'OTHER_LDFLAGS' => '-lObjC' }
+      it 'allows to specify pod target xcconfig settings' do
+        @spec.pod_target_xcconfig = { 'OTHER_LDFLAGS' => '-lObjC' }
+        @spec.attributes_hash['pod_target_xcconfig'].should == { 'OTHER_LDFLAGS' => '-lObjC' }
       end
 
       it 'allows to specify the contents of the prefix header' do

--- a/spec/specification_spec.rb
+++ b/spec/specification_spec.rb
@@ -501,7 +501,7 @@ module Pod
       end
 
       it 'returns the checksum of the file in which it is defined' do
-        @spec.checksum.should == '1b6fff3413356e7975ad0852ab380d59e3929ffa'
+        @spec.checksum.should == '2060b3e89229b8b30e6bf1a7730ddefdd7669730'
       end
 
       it 'returns a nil checksum if the specification is not defined in a file' do


### PR DESCRIPTION
* [x] Implement the deprecation logic.

Belongs to CocoaPods/CocoaPods#3573.