### PR TITLE
Add support for cocoapods_version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 ##### Enhancements
 
 * Add support for specifying the CocoaPods version in the podspec.
-	[Daniel Tomlinson](https://github.com/DanielTomlinson)
-	[CocoaPods#something](https://github.com/CocoaPods/Core/issues/something)
+  [Daniel Tomlinson](https://github.com/DanielTomlinson)
+  [Core#240](https://github.com/CocoaPods/Core/issues/240)
 
 ## 0.37.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CocoaPods Core Changelog
 
+## Master
+
+##### Enhancements
+
+* Add support for specifying the CocoaPods version in the podspec.
+	[Daniel Tomlinson](https://github.com/DanielTomlinson)
+	[CocoaPods#something](https://github.com/CocoaPods/Core/issues/something)
+
 ## 0.37.2
 
 ##### Enhancements

--- a/lib/cocoapods-core/specification.rb
+++ b/lib/cocoapods-core/specification.rb
@@ -583,6 +583,18 @@ module Pod
       end
       @defined_in_file = file
     end
+
+    # @!group Validation
+
+    # Validates the cocoapods_version in the specification against the current version of Core.
+    # It will raise an Informative error if the version is not satisfied.
+    #
+    def validate_cocoapods_version
+      unless cocoapods_version.satisfied_by?(Version.create(CORE_VERSION))
+        raise Informative, "`#{name}` requires CocoaPods version `#{cocoapods_version}`, " \
+                           "which is not satisified by your current version, `#{CORE_VERSION}`."
+      end
+    end
   end
 
   #---------------------------------------------------------------------------#

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -81,10 +81,6 @@ module Pod
                 :inherited => false,
                 :multi_platform => false
 
-      #-----------------------------------------------------------------------#
-
-      root_attribute :cocoapods_version
-
       #------------------#
 
       # @!method version=(version)
@@ -101,6 +97,22 @@ module Pod
       #
       root_attribute :version,
                      :required => true
+
+      #-----------------------------------------------------------------------#
+
+      # @!method cocoapods_version=(cocoapods_version)
+      #
+      #   The version of CocoaPods that the sepcification supports.
+      #
+      # @example
+      #
+      #   spec.cocoapods_version = '>= 0.36'
+      #
+      # @param  [String] cocoapods_version
+      #         the CocoaPods version that the specification supports.
+      #         CocoaPods follows [semantic versioning](http://semver.org).
+      #
+      root_attribute :cocoapods_version
 
       #------------------#
 

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -81,6 +81,10 @@ module Pod
                 :inherited => false,
                 :multi_platform => false
 
+      #-----------------------------------------------------------------------#
+
+      root_attribute :cocoapods_version
+
       #------------------#
 
       # @!method version=(version)

--- a/lib/cocoapods-core/specification/root_attribute_accessors.rb
+++ b/lib/cocoapods-core/specification/root_attribute_accessors.rb
@@ -34,6 +34,10 @@ module Pod
           end
         end
 
+        def cocoapods_version
+          @cocoapods_version ||= Requirement.create(attributes_hash['cocoapods_version'])
+        end
+
         # @return [Hash] a hash containing the authors as the keys and their
         #         email address as the values.
         #

--- a/lib/cocoapods-core/specification/root_attribute_accessors.rb
+++ b/lib/cocoapods-core/specification/root_attribute_accessors.rb
@@ -34,6 +34,8 @@ module Pod
           end
         end
 
+        # @return [Requirement] The CocoaPods version required to use the specification.
+        #
         def cocoapods_version
           @cocoapods_version ||= Requirement.create(attributes_hash['cocoapods_version'])
         end

--- a/spec/specification/dsl_spec.rb
+++ b/spec/specification/dsl_spec.rb
@@ -19,6 +19,11 @@ module Pod
         @spec.attributes_hash['version'].should == '1.0'
       end
 
+      it 'allows specifying the cocoapods version' do
+        @spec.cocoapods_version = '>= 0.36'
+        @spec.attributes_hash['cocoapods_version'].should == '>= 0.36'
+      end
+
       it 'allows to specify the authors' do
         hash = { 'Darth Vader' => 'darthvader@darkside.com',
                  'Wookiee' => 'wookiee@aggrrttaaggrrt.com' }

--- a/spec/specification/root_attribute_accessors_spec.rb
+++ b/spec/specification/root_attribute_accessors_spec.rb
@@ -25,6 +25,11 @@ module Pod
       @spec.version.should == Version.new('1.0')
     end
 
+    it 'returns the cocoapods version requirement of the specification' do
+      @spec.cocoapods_version = '>= 0.36'
+      @spec.cocoapods_version.should == Requirement.new('>= 0.36')
+    end
+
     it 'memoizes the version to allow to set it to head' do
       @spec.version.should.equal? @spec.version
     end

--- a/spec/specification_spec.rb
+++ b/spec/specification_spec.rb
@@ -107,7 +107,7 @@ module Pod
         it 'fails when the requirement is not satisfied' do
           spec_1 = Specification.new { |s| s.cocoapods_version = '= 999999.0.0' }
           should.raise(Informative) { spec_1.validate_cocoapods_version }.message.
-            should.match //
+            should.match /CocoaPods version/
         end
       end
 

--- a/spec/specification_spec.rb
+++ b/spec/specification_spec.rb
@@ -93,6 +93,24 @@ module Pod
         spec_1.to_s.should == 'No-name'
       end
 
+      describe '#validate_cocoapods_version' do
+        it 'passes when none is specified' do
+          spec_1 = Specification.new
+          should.not.raise { spec_1.validate_cocoapods_version }
+        end
+
+        it 'passes when the requirement is satisfied' do
+          spec_1 = Specification.new { |s| s.cocoapods_version = '>= 0.1.0' }
+          should.not.raise { spec_1.validate_cocoapods_version }
+        end
+
+        it 'fails when the requirement is not satisfied' do
+          spec_1 = Specification.new { |s| s.cocoapods_version = '= 999999.0.0' }
+          should.raise(Informative) { spec_1.validate_cocoapods_version }.message.
+            should.match //
+        end
+      end
+
       describe '::name_and_version_from_string' do
         it 'returns the name and the version of a Specification from its #to_s output' do
           name, version = Specification.name_and_version_from_string('libPusher (1.0)')


### PR DESCRIPTION
This pull request adds support for specifying a CocoaPods version inside the podspec (https://github.com/cocoapods/core/issues/240)