### PR TITLE
fixed issue with exception being thrown when local git URL is used as source

### DIFF
--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -372,7 +372,9 @@ module Pod
         if git = s[:git]
           return unless git =~ /^#{URI.regexp}$/
           git_uri = URI.parse(git)
-          perform_github_uri_checks(git, git_uri) if git_uri.host.end_with?('github.com')
+          if git_uri.host
+            perform_github_uri_checks(git, git_uri) if git_uri.host.end_with?('github.com')
+          end
         end
       end
 

--- a/spec/specification/linter_spec.rb
+++ b/spec/specification/linter_spec.rb
@@ -311,6 +311,12 @@ module Pod
 
       #------------------#
 
+      it 'allows a local git URL as source' do
+        @spec.stubs(:source).returns(:git => 'file:///tmp/d20131009-82757-1tztajd', :tag => '1.0')
+        @linter.lint
+        @linter.results.should.be.empty
+      end
+
       it 'checks for the example source' do
         @spec.stubs(:source).returns(:git => 'http://EXAMPLE.git', :tag => '1.0')
         result_should_include('source', 'example')


### PR DESCRIPTION
This fixes an issue with an exception being thrown when a local git URL is used as source. This is only really useful when you are writing tests with Rugged and Cocoapods to test our release process. 

If this is the source JSON:
```json
{:git=>"file:///tmp/d20150610-82513-1tuo9f7", :tag=>"builds/v1.0.0-b20131009151140"}
```

```ruby
perform_github_source_checks(s)
```
would throw an exception.

This is my first pull request against this repo, so please let me know if I forgot to do anything. 