### PR TITLE
Add `watchos` as a new platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
 * Attempt to detect (and warn) when a podfile has smart quotes.  
   [Samuel Giddins](https://github.com/segiddins)
 
+* Add `watchos` as a new platform.  
+  [Boris Bügling](https://github.com/neonichu)
+  [Core#249](https://github.com/CocoaPods/Core/pull/249)
+
 
 ## 0.37.2
 

--- a/lib/cocoapods-core/platform.rb
+++ b/lib/cocoapods-core/platform.rb
@@ -67,6 +67,10 @@ module Pod
       new :osx
     end
 
+    def self.watchos
+      new :watchos
+    end
+
     # Checks if a platform is equivalent to another one or to a symbol
     # representation.
     #
@@ -188,6 +192,7 @@ module Pod
       case symbolic_name
       when :ios then 'iOS'
       when :osx then 'OS X'
+      when :watchos then 'watchOS'
       else symbolic_name.to_s end
     end
   end

--- a/lib/cocoapods-core/podfile/dsl.rb
+++ b/lib/cocoapods-core/podfile/dsl.rb
@@ -314,14 +314,14 @@ module Pod
       # Specifies the platform for which a static library should be built.
       #
       # CocoaPods provides a default deployment target if one is not specified.
-      # The current default values are `4.3` for iOS and `10.6` for OS X.
+      # The current default values are `4.3` for iOS, `10.6` for OS X and `2.0` for watchOS.
       #
       # If the deployment target requires it (iOS < `4.3`), `armv6`
       # architecture will be added to `ARCHS`.
       #
       # @param    [Symbol] name
-      #           the name of platform, can be either `:osx` for OS X or `:ios`
-      #           for iOS.
+      #           the name of platform, can be either `:osx` for OS X, `:ios`
+      #           for iOS or `:watchos` for watchOS.
       #
       # @param    [String, Version] target
       #           The optional deployment.  If not provided a default value

--- a/lib/cocoapods-core/podfile/target_definition.rb
+++ b/lib/cocoapods-core/podfile/target_definition.rb
@@ -407,6 +407,7 @@ module Pod
       #         provided.
       #
       def platform
+        platform_defaults = { :ios => '4.3', :osx => '10.6', :watchos => '2.0' }
         name_or_hash = get_hash_value('platform')
         if name_or_hash
           if name_or_hash.is_a?(Hash)
@@ -415,7 +416,7 @@ module Pod
           else
             name = name_or_hash.to_sym
           end
-          target ||= (name == :ios ? '4.3' : (name == :watchos ? '2.0' : '10.6'))
+          target ||= platform_defaults[name]
           Platform.new(name, target)
         else
           parent.platform unless root?

--- a/lib/cocoapods-core/podfile/target_definition.rb
+++ b/lib/cocoapods-core/podfile/target_definition.rb
@@ -401,13 +401,14 @@ module Pod
 
       #--------------------------------------#
 
+      PLATFORM_DEFAULTS = { :ios => '4.3', :osx => '10.6', :watchos => '2.0' }.freeze
+
       # @return [Platform] the platform of the target definition.
       #
       # @note   If no deployment target has been specified a default value is
       #         provided.
       #
       def platform
-        platform_defaults = { :ios => '4.3', :osx => '10.6', :watchos => '2.0' }
         name_or_hash = get_hash_value('platform')
         if name_or_hash
           if name_or_hash.is_a?(Hash)
@@ -416,7 +417,7 @@ module Pod
           else
             name = name_or_hash.to_sym
           end
-          target ||= platform_defaults[name]
+          target ||= PLATFORM_DEFAULTS[name]
           Platform.new(name, target)
         else
           parent.platform unless root?
@@ -438,7 +439,7 @@ module Pod
       def set_platform(name, target = nil)
         unless [:ios, :osx, :watchos].include?(name)
           raise StandardError, "Unsupported platform `#{name}`. Platform " \
-            'must be `:ios`, `:osx`, `:watchos`.'
+            'must be `:ios`, `:osx`, or `:watchos`.'
         end
 
         if target

--- a/lib/cocoapods-core/podfile/target_definition.rb
+++ b/lib/cocoapods-core/podfile/target_definition.rb
@@ -415,7 +415,7 @@ module Pod
           else
             name = name_or_hash.to_sym
           end
-          target ||= (name == :ios ? '4.3' : '10.6')
+          target ||= (name == :ios ? '4.3' : (name == :watchos ? '2.0' : '10.6'))
           Platform.new(name, target)
         else
           parent.platform unless root?
@@ -435,9 +435,9 @@ module Pod
       # @return [void]
       #
       def set_platform(name, target = nil)
-        unless [:ios, :osx].include?(name)
+        unless [:ios, :osx, :watchos].include?(name)
           raise StandardError, "Unsupported platform `#{name}`. Platform " \
-            'must be `:ios` or `:osx`.'
+            'must be `:ios`, `:osx`, `:watchos`.'
         end
 
         if target

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -461,7 +461,7 @@ module Pod
 
       # The names of the platforms supported by the specification class.
       #
-      PLATFORMS = [:osx, :ios].freeze
+      PLATFORMS = [:osx, :ios, :watchos].freeze
 
       # @todo This currently is not used in the Ruby DSL.
       #
@@ -1368,6 +1368,10 @@ module Pod
       #
       def osx
         PlatformProxy.new(self, :osx)
+      end
+
+      def watchos
+        PlatformProxy.new(self, :watchos)
       end
     end
   end

--- a/spec/platform_spec.rb
+++ b/spec/platform_spec.rb
@@ -6,6 +6,7 @@ module Pod
       it 'returns a new Platform instance' do
         Platform.ios.should == Platform.new(:ios)
         Platform.osx.should == Platform.new(:osx)
+        Platform.watchos.should == Platform.new(:watchos)
       end
 
       it 'can be initialized from another platform' do
@@ -43,8 +44,10 @@ module Pod
       it 'presents an accurate string representation' do
         @platform.to_s.should == 'iOS'
         Platform.new(:osx).to_s.should == 'OS X'
+        Platform.new(:watchos).to_s.should == 'watchOS'
         Platform.new(:ios, '5.0.0').to_s.should == 'iOS 5.0.0'
         Platform.new(:osx, '10.7').to_s.should  == 'OS X 10.7'
+        Platform.new(:watchos, '2.0').to_s.should == 'watchOS 2.0'
       end
 
       it "uses it's name as it's symbold version" do
@@ -80,6 +83,7 @@ module Pod
       it 'returns whether it requires legacy iOS architectures' do
         Platform.new(:ios, '4.0').requires_legacy_ios_archs?.should.be.true
         Platform.new(:ios, '5.0').requires_legacy_ios_archs?.should.be.false
+        Platform.new(:watchos, '2.0').requires_legacy_ios_archs?.should.be.false
       end
 
       it 'is usable as hash keys' do
@@ -106,6 +110,11 @@ module Pod
           Platform.new(:ios, '7.0').should.not.supports_dynamic_frameworks
           Platform.new(:ios, '8.0').should.supports_dynamic_frameworks
           Platform.new(:ios, '8.1').should.supports_dynamic_frameworks
+        end
+
+        it 'supports dynamic frameworks on watchOS' do
+          Platform.watchos.should.supports_dynamic_frameworks
+          Platform.new(:watchos, '2.0').should.supports_dynamic_frameworks
         end
       end
     end

--- a/spec/specification/dsl_spec.rb
+++ b/spec/specification/dsl_spec.rb
@@ -120,6 +120,16 @@ module Pod
         e = lambda { @spec.deployment_target = '6.0' }.should.raise Informative
         e.message.should.match /declared only per platform/
       end
+
+      it 'allows to specify watchOS as supported platform' do
+        @spec.platform = :watchos
+        @spec.attributes_hash['platforms'].should == { 'watchos' => nil }
+      end
+
+      it 'allows to specify a deployment target for the watchOS platform' do
+        @spec.watchos.deployment_target = '2.0'
+        @spec.attributes_hash['platforms']['watchos'].should == '2.0'
+      end
     end
 
     #-----------------------------------------------------------------------------#

--- a/spec/specification/linter_spec.rb
+++ b/spec/specification/linter_spec.rb
@@ -65,7 +65,7 @@ module Pod
         @linter.lint
         @linter.results.count.should == 1
         @linter.results.first.platforms.map(&:to_s).sort.should ==
-          %w(ios osx)
+          %w(ios osx watchos)
       end
 
       before do

--- a/spec/specification/set/presenter_spec.rb
+++ b/spec/specification/set/presenter_spec.rb
@@ -84,7 +84,7 @@ module Pod
       end
 
       it 'returns the platform' do
-        @presenter.platform.should == 'iOS - OS X'
+        @presenter.platform.should == 'iOS - OS X - watchOS'
       end
 
       it 'returns the license' do


### PR DESCRIPTION
This adds `watchos` as a platform to Core, meaning mostly that the DSL helpers are available. This lays the groundwork for supporting watchOS as a new platform in CocoaPods.

Things yet to be addressed:

- [x] Specs
- [x] Changelog

See also CocoaPods/CocoaPods#3681 and CocoaPods/Xcodeproj#272