### PR TITLE
Account for missing numeric segments while comparing Pod Versions

### DIFF
--- a/lib/cocoapods-core/requirement.rb
+++ b/lib/cocoapods-core/requirement.rb
@@ -15,6 +15,8 @@ module Pod
     #
     PATTERN = /\A\s*(#{quoted_operators})?\s*(#{Version::VERSION_PATTERN})\s*\z/
 
+    DefaultRequirement = [">=", Version.new(0)]
+
     #-------------------------------------------------------------------------#
 
     # Factory method to create a new requirement.
@@ -64,6 +66,27 @@ module Pod
       operator = Regexp.last_match[1] || '='
       version = Version.new(Regexp.last_match[2])
       [operator, version]
+    end
+
+    # Constructs a requirement from `requirements`.
+    #
+    # @param [String, Version, Array<String>, Array<Version>] requirements
+    #        The set of requirements
+    #
+    # @note Duplicate requirements are ignored.
+    #
+    # @note An empty set of `requirements` is the same as `">= 0"`
+    #
+    def initialize *requirements
+      requirements = requirements.flatten
+      requirements.compact!
+      requirements.uniq!
+
+      if requirements.empty?
+        @requirements = [DefaultRequirement]
+      else
+        @requirements = requirements.map! { |r| self.class.parse r }
+      end
     end
 
     #-------------------------------------------------------------------------#

--- a/lib/cocoapods-core/requirement.rb
+++ b/lib/cocoapods-core/requirement.rb
@@ -77,7 +77,7 @@ module Pod
     #
     # @note An empty set of `requirements` is the same as `">= 0"`
     #
-    def initialize *requirements
+    def initialize(*requirements)
       requirements = requirements.flatten
       requirements.compact!
       requirements.uniq!

--- a/lib/cocoapods-core/requirement.rb
+++ b/lib/cocoapods-core/requirement.rb
@@ -90,7 +90,7 @@ module Pod
     end
 
     #
-    # @return [Bool] true if this gem has no requirements.
+    # @return [Bool] true if this pod has no requirements.
     #
     def none?
       if @requirements.size == 1

--- a/lib/cocoapods-core/requirement.rb
+++ b/lib/cocoapods-core/requirement.rb
@@ -15,7 +15,7 @@ module Pod
     #
     PATTERN = /\A\s*(#{quoted_operators})?\s*(#{Version::VERSION_PATTERN})\s*\z/
 
-    DefaultRequirement = [">=", Version.new(0)]
+    DefaultRequirement = ['>=', Version.new(0)] # rubocop:disable Style/ConstantName
 
     #-------------------------------------------------------------------------#
 

--- a/lib/cocoapods-core/requirement.rb
+++ b/lib/cocoapods-core/requirement.rb
@@ -89,6 +89,16 @@ module Pod
       end
     end
 
+    #
+    # @return [Bool] true if this gem has no requirements.
+    #
+    def none?
+      if @requirements.size == 1
+        @requirements[0] == DefaultRequirement
+      else
+        false
+      end
+    end
     #-------------------------------------------------------------------------#
   end
 end

--- a/lib/cocoapods-core/version.rb
+++ b/lib/cocoapods-core/version.rb
@@ -150,8 +150,8 @@ module Pod
     #
     # @note   Attempts to compare something that's not a {Version} return nil
     #
-    def <=> other
-      return unless Pod::Version === other
+    def <=>(other)
+      return unless other.is_a?(Pod::Version)
       return 0 if @version == other.version
 
       if major != other.major
@@ -180,13 +180,13 @@ module Pod
         i += 1
 
         next      if lhs == rhs
-        return -1 if String  === lhs && Numeric === rhs
-        return  1 if Numeric === lhs && String  === rhs
+        return -1 if lhs.is_a?(String) && rhs.is_a?(Numeric)
+        return  1 if lhs.is_a?(Numeric) && rhs.is_a?(String)
 
         return lhs <=> rhs
       end
 
-        return version <=> other.version
+      version <=> other.version
     end
 
     private

--- a/lib/cocoapods-core/version.rb
+++ b/lib/cocoapods-core/version.rb
@@ -138,6 +138,51 @@ module Pod
     #
     def patch
       numeric_segments[2].to_i
+  end
+
+  ##
+  # Compares this version with +other+ returning -1, 0, or 1 if the
+  # other version is larger, the same, or smaller than this
+  # one. Attempts to compare to something that's not a
+  # <tt>Pod::Version</tt> return +nil+.
+
+  def <=> other
+    return unless Pod::Version === other
+    return 0 if @version == other.version
+
+    if major != other.major
+      return major <=> other.major
+    end
+
+    if minor != other.minor
+      return minor <=> other.minor
+    end
+
+    if patch != other.patch
+      return patch <=> other.patch
+    end
+
+    lhsegments = segments.drop_while { |s| s.is_a?(Numeric) }
+    rhsegments = other.segments.drop_while { |s| s.is_a?(Numeric) }
+
+    lhsize = lhsegments.size
+    rhsize = rhsegments.size
+    limit  = (lhsize > rhsize ? lhsize : rhsize) - 1
+
+    i = 0
+
+    while i <= limit
+      lhs, rhs = lhsegments[i] || 0, rhsegments[i] || 0
+      i += 1
+
+      next      if lhs == rhs
+      return -1 if String  === lhs && Numeric === rhs
+      return  1 if Numeric === lhs && String  === rhs
+
+      return lhs <=> rhs
+    end
+
+      return version <=> other.version
     end
 
     private

--- a/lib/cocoapods-core/version.rb
+++ b/lib/cocoapods-core/version.rb
@@ -140,6 +140,8 @@ module Pod
       numeric_segments[2].to_i
     end
 
+    # rubocop:disable Metrics/PerceivedComplexity
+
     # Compares the versions for sorting.
     #
     # @param  [Version] other
@@ -188,6 +190,7 @@ module Pod
 
       version <=> other.version
     end
+    # rubocop:enable Metrics/PerceivedComplexity
 
     private
 

--- a/lib/cocoapods-core/version.rb
+++ b/lib/cocoapods-core/version.rb
@@ -138,51 +138,55 @@ module Pod
     #
     def patch
       numeric_segments[2].to_i
-  end
-
-  ##
-  # Compares this version with +other+ returning -1, 0, or 1 if the
-  # other version is larger, the same, or smaller than this
-  # one. Attempts to compare to something that's not a
-  # <tt>Pod::Version</tt> return +nil+.
-
-  def <=> other
-    return unless Pod::Version === other
-    return 0 if @version == other.version
-
-    if major != other.major
-      return major <=> other.major
     end
 
-    if minor != other.minor
-      return minor <=> other.minor
-    end
+    # Compares the versions for sorting.
+    #
+    # @param  [Version] other
+    #         The other version to compare.
+    #
+    # @return [Fixnum] -1, 0, or +1 depending on whether the receiver is less
+    #         than, equal to, or greater than other.
+    #
+    # @note   Attempts to compare something that's not a {Version} return nil
+    #
+    def <=> other
+      return unless Pod::Version === other
+      return 0 if @version == other.version
 
-    if patch != other.patch
-      return patch <=> other.patch
-    end
+      if major != other.major
+        return major <=> other.major
+      end
 
-    lhsegments = segments.drop_while { |s| s.is_a?(Numeric) }
-    rhsegments = other.segments.drop_while { |s| s.is_a?(Numeric) }
+      if minor != other.minor
+        return minor <=> other.minor
+      end
 
-    lhsize = lhsegments.size
-    rhsize = rhsegments.size
-    limit  = (lhsize > rhsize ? lhsize : rhsize) - 1
+      if patch != other.patch
+        return patch <=> other.patch
+      end
 
-    i = 0
+      lhsegments = segments.drop_while { |s| s.is_a?(Numeric) }
+      rhsegments = other.segments.drop_while { |s| s.is_a?(Numeric) }
 
-    while i <= limit
-      lhs, rhs = lhsegments[i] || 0, rhsegments[i] || 0
-      i += 1
+      lhsize = lhsegments.size
+      rhsize = rhsegments.size
+      limit  = (lhsize > rhsize ? lhsize : rhsize) - 1
 
-      next      if lhs == rhs
-      return -1 if String  === lhs && Numeric === rhs
-      return  1 if Numeric === lhs && String  === rhs
+      i = 0
 
-      return lhs <=> rhs
-    end
+      while i <= limit
+        lhs, rhs = lhsegments[i] || 0, rhsegments[i] || 0
+        i += 1
 
-      return version <=> other.version
+        next      if lhs == rhs
+        return -1 if String  === lhs && Numeric === rhs
+        return  1 if Numeric === lhs && String  === rhs
+
+        return lhs <=> rhs
+      end
+
+        return version <=> other.version
     end
 
     private

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -118,6 +118,17 @@ module Pod
         Version.new('1.alpha').patch.should == 0
         Version.new('1.alpha.2').patch.should == 0
       end
+
+      it 'ignores missing numeric identifiers while comparing' do
+        (Version.new('1.9.0-alpha') < Version.new('1.9-beta')).should == true
+        (Version.new('2.0.0-beta') < Version.new('2.0-rc')).should == true
+      end
+
+      it 'tie-breaks between semantically equal versions' do
+        (Version.new('1') < Version.new('1.0')).should == true
+        (Version.new('1.0') < Version.new('1.0.0')).should == true
+        (Version.new('1.0-alpha') < Version.new('1.0.0-alpha')).should == true
+      end
     end
 
     #-------------------------------------------------------------------------#


### PR DESCRIPTION
As discussed in https://github.com/CocoaPods/cocoapods.org/issues/185#issuecomment-123417647

Long story short, now

```
3.0.0-alpha.1 < 3.0-beta.9
```

I haven't been too creative: I simply handled major, minor and patch explicitly then just used the same comparison algorithm as `Gem::Version` for the remaining segments.

@floere I tried to write some tests for the "funky" versions you pointed me at (http://search.cocoapods.org/api/v1/pods.facets.json?include=version&only=version&counts=false) but apparently `Version.new("20aa2b2b15b6f8db350ec07b6041e4951bb255d0")` is not a valid `Pod::Version` (the initializer fails)

Same goes for other version strings such as `"beta.9"`, `"2-beta"` and similar.