### PR TITLE
[Linter] Show an error for an empty description

### DIFF
--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -244,8 +244,8 @@ module Pod
       # Performs validations related to the `description` attribute.
       #
       def _validate_description(d)
-        if d =~ /An optional longer description of/
-          results.add_warning('description', 'The description is not meaningful.')
+        if d.strip.length == 0
+          results.add_error('description', 'The description is empty.')
         end
         if d == spec.summary
           results.add_warning('description', 'The description is equal to' \

--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -244,14 +244,15 @@ module Pod
       # Performs validations related to the `description` attribute.
       #
       def _validate_description(d)
-        if d.strip.length == 0
-          results.add_error('description', 'The description is empty.')
-        end
         if d == spec.summary
           results.add_warning('description', 'The description is equal to' \
            ' the summary.')
         end
-        if d.length < spec.summary.length
+
+        if d.strip.length == 0
+          results.add_error('description', 'The description is empty.')
+
+        elsif d.length < spec.summary.length
           results.add_warning('description', 'The description is shorter ' \
           'than the summary.')
         end

--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -249,9 +249,8 @@ module Pod
            ' the summary.')
         end
 
-        if d.strip.length == 0
+        if d.strip.empty?
           results.add_error('description', 'The description is empty.')
-
         elsif d.length < spec.summary.length
           results.add_warning('description', 'The description is shorter ' \
           'than the summary.')

--- a/spec/specification/linter_spec.rb
+++ b/spec/specification/linter_spec.rb
@@ -253,9 +253,9 @@ module Pod
 
       #------------------#
 
-      it 'checks the description for the example value' do
-        @spec.stubs(:description).returns('An optional longer description of.')
-        result_should_include('description', 'meaningful')
+      it 'checks if the description is not an empty string' do
+        @spec.stubs(:description).returns("")
+        result_should_include('description', 'empty')
       end
 
       it 'checks if the description is equal to the summary' do

--- a/spec/specification/linter_spec.rb
+++ b/spec/specification/linter_spec.rb
@@ -254,7 +254,7 @@ module Pod
       #------------------#
 
       it 'checks if the description is not an empty string' do
-        @spec.stubs(:description).returns("")
+        @spec.stubs(:description).returns('')
         result_should_include('description', 'empty')
       end
 


### PR DESCRIPTION
With the new defaults from https://github.com/CocoaPods/pod-template/pull/129#issuecomment-131301753 and https://github.com/CocoaPods/CocoaPods/pull/3984 we provide an empty description instead of some meaningful starter text.

I've opted to make this an outright error if you don't include it, but a warning if it's shorter than the summary. Open to discussion around it, but it's pretty core metadata.