### PR TITLE
Improve documentation for DSL attribute hash keys [RFC] [Guides]

### DIFF
--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -221,10 +221,17 @@ module Pod
       #                      LICENSE
       #                    }
       #
-      #   @param  [String, Hash{Symbol=>String}] license
-      #           The type of the license and the text of the grant that
-      #           allows to use the library (or the relative path to the file
-      #           that contains it).
+      #   @param  [String] license
+      #           The type of the license
+      #
+      #   @overload source=(git)
+      #     @param  [String, Hash{Symbol=>String}] license
+      #             The type of the license and the text of the grant that
+      #             allows to use the library (or the relative path to the file
+      #             that contains it).
+      #     @option license [String] :type license type
+      #     @option license [String] :file file containing full license text. Supports `txt`, `md`, and `markdown`
+      #     @option license [String] :text full license text
       #
       root_attribute :license,
                      :container => Hash,

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -224,13 +224,10 @@ module Pod
       #   @param  [String] license
       #           The type of the license
       #
-      #   @overload source=(git)
+      #   @overload license=(license)
       #     @param  [String, Hash{Symbol=>String}] license
-      #             The type of the license and the text of the grant that
-      #             allows to use the library (or the relative path to the file
-      #             that contains it).
       #     @option license [String] :type license type
-      #     @option license [String] :file file containing full license text. Supports `txt`, `md`, and `markdown`
+      #     @option license [String] :file file containing full license text. Supports txt, md, and markdown
       #     @option license [String] :text full license text
       #
       root_attribute :license,
@@ -302,7 +299,7 @@ module Pod
       #     @param  [Hash] git
       #     @option git [String] :git git source URI
       #     @option git [String] :tag version tag
-      #     @option git [Boolean] :submodules Whether to checkout submodules
+      #     @option git [Bool] :submodules Whether to checkout submodules
       #     @option git [String] :branch branch name
       #     @option git [String] :commit commit hash
       #

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -290,10 +290,6 @@ module Pod
       #     spec.source = { :http => 'http://dev.wechatapp.com/download/sdk/WeChat_SDK_iOS_en.zip',
       #                     :sha1 => '7e21857fe11a511f472cfd7cfa2d979bd7ab7d96' }
       #
-      #   @param  [Hash{Symbol=>String}] source
-      #           The location from where the library should be retrieved.
-      #   @option source [String] :tag The git tag
-      #   @option source [String] :branch The git branch
       #
       #   @overload source=(git)
       #     @param  [Hash{Symbol=>String}] git

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -295,7 +295,7 @@ module Pod
       #     @param  [Hash{Symbol=>String}] git
       #     @option git [String] :git URI where library git repo can be cloned.
       #     @option git [String] :tag git tag
-      #     @option git [true or false] :submodules checkout submodules
+      #     @option git [Boolean] :submodules checkout submodules
       #     @option git [String] :branch git branch
       #     @option git [String] :commit git commit
       #

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -292,6 +292,38 @@ module Pod
       #
       #   @param  [Hash{Symbol=>String}] source
       #           The location from where the library should be retrieved.
+      #   @option source [String] :tag The git tag
+      #   @option source [String] :branch The git branch
+      #
+      #   @overload source=(git)
+      #     @param  [Hash{Symbol=>String}] git
+      #     @option git [String] :git URI where library git repo can be cloned.
+      #     @option git [String] :tag git tag
+      #     @option git [true or false] :submodules checkout submodules
+      #     @option git [String] :branch git branch
+      #     @option git [String] :commit git commit
+      #
+      #   @overload source=(svn)
+      #     @param  [Hash{Symbol=>String}] svn
+      #     @option svn [String] :svn URI where library svn repo can be checked out.
+      #     @option svn [String] :tag tag
+      #     @option svn [String] :folder folder
+      #     @option svn [String] :revision revision
+      #
+      #   @overload source=(hg)
+      #     @param  [Hash{Symbol=>String}] hg
+      #     @option hg [String] :hg URI where library hg repo can be cloned.
+      #     @option hg [String] :revision revision
+      #
+      #   @overload source=(http)
+      #     @param  [Hash{Symbol=>String}] http
+      #     @option http [String] :http URL where library should be retrieved.
+      #     @option http [String] :type File type
+      #     @option http [String] :sha1 SHA1 hash
+      #
+      #   @overload source=(path)
+      #     @param  [Hash{Symbol=>String}] path
+      #     @option path [String] :path local file path to library
       #
       root_attribute :source,
                      :container => Hash,

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -292,34 +292,34 @@ module Pod
       #
       #
       #   @overload source=(git)
-      #     @param  [Hash{Symbol=>String}] git
-      #     @option git [String] :git URI where library git repo can be cloned.
-      #     @option git [String] :tag git tag
-      #     @option git [Boolean] :submodules checkout submodules
-      #     @option git [String] :branch git branch
-      #     @option git [String] :commit git commit
+      #     @param  [Hash] git
+      #     @option git [String] :git git source URI
+      #     @option git [String] :tag version tag
+      #     @option git [Boolean] :submodules Whether to checkout submodules
+      #     @option git [String] :branch branch name
+      #     @option git [String] :commit commit hash
       #
       #   @overload source=(svn)
-      #     @param  [Hash{Symbol=>String}] svn
-      #     @option svn [String] :svn URI where library svn repo can be checked out.
-      #     @option svn [String] :tag tag
+      #     @param  [Hash] svn
+      #     @option svn [String] :svn svn source URI
+      #     @option svn [String] :tag version tag
       #     @option svn [String] :folder folder
       #     @option svn [String] :revision revision
       #
       #   @overload source=(hg)
-      #     @param  [Hash{Symbol=>String}] hg
-      #     @option hg [String] :hg URI where library hg repo can be cloned.
+      #     @param  [Hash] hg
+      #     @option hg [String] :hg mercurial source URI
       #     @option hg [String] :revision revision
       #
       #   @overload source=(http)
-      #     @param  [Hash{Symbol=>String}] http
-      #     @option http [String] :http URL where library should be retrieved.
-      #     @option http [String] :type File type
-      #     @option http [String] :sha1 SHA1 hash
+      #     @param  [Hash] http
+      #     @option http [String] :http compressed source URL
+      #     @option http [String] :type file type. Supports zip, tgz, bz2, txz and tar
+      #     @option http [String] :sha1 SHA hash. Supports SHA1 and SHA256
       #
       #   @overload source=(path)
-      #     @param  [Hash{Symbol=>String}] path
-      #     @option path [String] :path local file path to library
+      #     @param  [Hash] path
+      #     @option path [String] :path local source path
       #
       root_attribute :source,
                      :container => Hash,


### PR DESCRIPTION
I want to improve the Guides for the DSLs. Currently they don't list the acceptable hash keys, there are only examples from which you can gleam this important information.
https://guides.cocoapods.org/syntax/podspec.html#source

I'm trying to find a good pattern to get this information into the documentation system, then we will also have to update **guides.cocoapods.org** to format and include it. Right now I'm just using `yard` to see how it picks up the comments.

Idealy, we shouldn't have to repeat ourselves. Where we define the options should be where the documentation is. I'm finding it hard to do this, and I'm not happy with the `@overload` usage here.

:bird: @orta
