### PR TITLE
Changes search index format to fasten `pod search --full` command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Master
 
+##### Enhancements
+
+* Improve `pod search` performance while using _`--full`_ flag  
+  [Muhammed Yavuz Nuzumlalı](https://github.com/manuyavuz)
+  [cocoapods-search#8](https://github.com/CocoaPods/cocoapods-search/issues/8)
+
 ##### Bug Fixes
 
 * Allow non-exact version matches to be equal while maintaining a sort order.  

--- a/lib/cocoapods-core/source.rb
+++ b/lib/cocoapods-core/source.rb
@@ -288,8 +288,8 @@ module Pod
     def update(show_output = false)
       changed_spec_paths = []
       Dir.chdir(repo) do
-        prev_commit_hash = (`git rev-parse HEAD`).strip
-        output = `git pull --ff-only 2>&1`
+        prev_commit_hash = git_commit_hash
+        output = update_git_repo
         CoreUI.puts output if show_output
         unless $?.success?
           CoreUI.warn 'CocoaPods was not able to update the ' \
@@ -297,7 +297,7 @@ module Pod
                   'and persists you can inspect it running ' \
                   '`pod repo update --verbose`'
         end
-        changed_spec_paths = (`git diff --name-only #{prev_commit_hash}..HEAD`).strip.split("\n")
+        changed_spec_paths = diff_until_commit_hash(prev_commit_hash)
       end
       changed_spec_paths
     end
@@ -367,6 +367,18 @@ module Pod
           repo
         end
       end
+    end
+
+    def git_commit_hash
+      (`git rev-parse HEAD` || '').strip
+    end
+
+    def update_git_repo
+      `git pull --ff-only 2>&1`
+    end
+
+    def diff_until_commit_hash(commit_hash)
+      (`git diff --name-only #{commit_hash}..HEAD` || '').strip.split("\n")
     end
 
     #-------------------------------------------------------------------------#

--- a/lib/cocoapods-core/source.rb
+++ b/lib/cocoapods-core/source.rb
@@ -93,6 +93,22 @@ module Pod
       end.sort
     end
 
+    # Returns pod names for given array of specification paths.
+    #
+    # @param  [Array<String>] spec_paths
+    #         Array of file path names for specifications. Path strings should be relative to the source path.
+    #
+    # @return [Array<String>] the list of the name of Pods corresponding to specification paths.
+    #
+    def pods_for_specification_paths(spec_paths)
+      spec_paths.map do |path|
+        absolute_path = repo + path
+        relative_path = absolute_path.relative_path_from(specs_dir)
+        # The first file name returned by 'each_filename' is the pod name
+        relative_path.each_filename.first
+      end
+    end
+
     # @return [Array<Version>] all the available versions for the Pod, sorted
     #         from highest to lowest.
     #

--- a/lib/cocoapods-core/source.rb
+++ b/lib/cocoapods-core/source.rb
@@ -279,19 +279,27 @@ module Pod
     #-------------------------------------------------------------------------#
 
     # Updates the local clone of the source repo.
-    # @return  [Array] output and changed_spec_paths
-    #         First value of the array is `git pull` output. Second value is an array of changed spec paths.
     #
-    def update
-      output = nil
-      changed_spec_paths = nil
+    # @param  [Bool] show_output
+    #
+    # @return  [Array<String>] changed_spec_paths
+    #          Returns the list of changed spec paths.
+    #
+    def update(show_output = false)
+      changed_spec_paths = []
       Dir.chdir(repo) do
         prev_commit_hash = (`git rev-parse HEAD`).strip
         output = `git pull --ff-only 2>&1`
-        raise Informative, output unless $?.success?
+        CoreUI.puts output if show_output
+        unless $?.success?
+          CoreUI.warn 'CocoaPods was not able to update the ' \
+                  "`#{name}` repo. If this is an unexpected issue " \
+                  'and persists you can inspect it running ' \
+                  '`pod repo update --verbose`'
+        end
         changed_spec_paths = (`git diff --name-only #{prev_commit_hash}..HEAD`).strip.split("\n")
       end
-      [output, changed_spec_paths]
+      changed_spec_paths
     end
 
     public

--- a/lib/cocoapods-core/source.rb
+++ b/lib/cocoapods-core/source.rb
@@ -275,6 +275,24 @@ module Pod
       end
     end
 
+    # @!group Updating the source
+    #-------------------------------------------------------------------------#
+
+    # Updates the local clone of the source repo.
+    # @return  [Array] output and changed_spec_paths
+    #         First value of the array is `git pull` output. Second value is an array of changed spec paths.
+    #
+    def update
+      output = nil
+      changed_spec_paths = nil
+      Dir.chdir(repo) do
+        prev_commit_hash = (`git rev-parse HEAD`).strip
+        output = `git pull --ff-only`
+        changed_spec_paths = (`git diff --name-only #{prev_commit_hash}..HEAD`).strip.split("\n")
+      end
+      [output, changed_spec_paths]
+    end
+
     public
 
     # @!group Representations

--- a/lib/cocoapods-core/source.rb
+++ b/lib/cocoapods-core/source.rb
@@ -285,18 +285,11 @@ module Pod
     # @return  [Array<String>] changed_spec_paths
     #          Returns the list of changed spec paths.
     #
-    def update(show_output = false)
+    def update(show_output)
       changed_spec_paths = []
       Dir.chdir(repo) do
         prev_commit_hash = git_commit_hash
-        output = update_git_repo
-        CoreUI.puts output if show_output
-        unless $?.success?
-          CoreUI.warn 'CocoaPods was not able to update the ' \
-                  "`#{name}` repo. If this is an unexpected issue " \
-                  'and persists you can inspect it running ' \
-                  '`pod repo update --verbose`'
-        end
+        update_git_repo(show_output)
         changed_spec_paths = diff_until_commit_hash(prev_commit_hash)
       end
       changed_spec_paths
@@ -373,8 +366,9 @@ module Pod
       (`git rev-parse HEAD` || '').strip
     end
 
-    def update_git_repo
-      `git pull --ff-only 2>&1`
+    def update_git_repo(show_output = false)
+      output = `git pull --ff-only 2>&1`
+      CoreUI.puts output if show_output
     end
 
     def diff_until_commit_hash(commit_hash)

--- a/lib/cocoapods-core/source.rb
+++ b/lib/cocoapods-core/source.rb
@@ -287,7 +287,8 @@ module Pod
       changed_spec_paths = nil
       Dir.chdir(repo) do
         prev_commit_hash = (`git rev-parse HEAD`).strip
-        output = `git pull --ff-only`
+        output = `git pull --ff-only 2>&1`
+        raise Informative, output unless $?.success?
         changed_spec_paths = (`git diff --name-only #{prev_commit_hash}..HEAD`).strip.split("\n")
       end
       [output, changed_spec_paths]

--- a/lib/cocoapods-core/source/aggregate.rb
+++ b/lib/cocoapods-core/source/aggregate.rb
@@ -53,7 +53,7 @@ module Pod
       #         The name of the Pod.
       #
       # @return [Set] The most representative set for the Pod with the given
-      #         name.
+      #         name. Returns nil if no representative source found containing a pod with given name.
       #
       def representative_set(name)
         representative_source = nil
@@ -68,7 +68,7 @@ module Pod
             end
           end
         end
-        Specification::Set.new(name, representative_source)
+        representative_source ? Specification::Set.new(name, representative_source) : nil
       end
 
       public

--- a/lib/cocoapods-core/source/aggregate.rb
+++ b/lib/cocoapods-core/source/aggregate.rb
@@ -170,7 +170,7 @@ module Pod
         result = {}
         sets.each do |set|
           word_list_from_set(set).each do |w|
-            (result[w] ||= []).push(set.name)
+            (result[w] ||= []).push(set.name.to_sym)
           end
         end
         result

--- a/lib/cocoapods-core/source/aggregate.rb
+++ b/lib/cocoapods-core/source/aggregate.rb
@@ -197,20 +197,20 @@ module Pod
       #
       def word_list_from_set(set)
         spec = set.specification
-        string = set.name.dup
+        word_list = [set.name.dup]
         if spec.summary
-          string << ' ' << spec.summary
+          word_list += spec.summary.split
         end
         if spec.description
-          string << ' ' << spec.description
+          word_list += spec.description.split
         end
         if spec.authors
           spec.authors.each_pair do |k, v|
-            string << ' ' << k if k
-            string << ' ' << v if v
+            word_list += k.split if k
+            word_list += v.split if v
           end
         end
-        string.gsub(/\s+/m, ' ').strip.split(' ').uniq
+        word_list.uniq
       rescue
         CoreUI.warn "Skipping `#{set.name}` because the podspec contains " \
           'errors.'

--- a/spec/source/aggregate_spec.rb
+++ b/spec/source/aggregate_spec.rb
@@ -105,7 +105,7 @@ module Pod
         index = @aggregate.generate_search_index_for_source(@test_source)
         text = 'BananaLib Chunky bananas! Full of chunky bananas. Banana Corp Monkey Boy monkey@banana-corp.local'
         text.split.each do |word|
-          index[word].should == ['BananaLib']
+          index[word].should == [:BananaLib]
         end
         index['Faulty_spec'].should.be.nil
       end
@@ -113,7 +113,7 @@ module Pod
       it 'generates the search index for changes in source' do
         changed_paths = ['Specs/JSONKit/1.4/JSONKit.podspec']
         index = @aggregate.generate_search_index_for_changes_in_source(@test_source, changed_paths)
-        index['JSONKit'].should == ['JSONKit']
+        index['JSONKit'].should == [:JSONKit]
         index['BananaLib'].should.be.nil
       end
     end

--- a/spec/source/aggregate_spec.rb
+++ b/spec/source/aggregate_spec.rb
@@ -116,6 +116,18 @@ module Pod
         index['JSONKit'].should == [:JSONKit]
         index['BananaLib'].should.be.nil
       end
+
+      it 'generates correct vocabulary form given set' do
+        set = Specification::Set.new('PodName', [])
+        spec = Specification.new
+        spec.stubs(:summary).returns("\n\n    Summary of\t\tpod name\n\n")
+        spec.stubs(:description).returns("\n\n    \t\t       \n\n")
+        spec.stubs(:authors).returns("\nauthor1\n" => nil, "\t\tauthor2" => '***woww---@mymail.com')
+        set.stubs(:specification).returns(spec)
+
+        vocabulary = %w(PodName Summary of pod name author1 author2 ***woww---@mymail.com)
+        @aggregate.send(:word_list_from_set, set).should == vocabulary
+      end
     end
 
     #-------------------------------------------------------------------------#

--- a/spec/source/aggregate_spec.rb
+++ b/spec/source/aggregate_spec.rb
@@ -98,55 +98,25 @@ module Pod
 
     describe 'Search Index' do
       before do
-        test_source = Source.new(fixture('spec-repos/test_repo'))
-        @aggregate.stubs(:sources).returns([test_source])
+        @test_source = Source.new(fixture('spec-repos/test_repo'))
+        @aggregate.stubs(:sources).returns([@test_source])
       end
 
       it 'generates the search index from scratch' do
-        index = @aggregate.generate_search_index
-        index.keys.sort.should == %w(BananaLib Faulty_spec IncorrectPath JSONKit JSONSpec)
-        index['BananaLib']['version'].should == '1.0'
-        index['BananaLib']['summary'].should == 'Chunky bananas!'
-        index['BananaLib']['description'].should == 'Full of chunky bananas.'
-        index['BananaLib']['authors'].should == 'Banana Corp, Monkey Boy'
-      end
-
-      it 'updates a given index' do
-        old_index = { 'Faulty_spec' => {}, 'JSONKit' => {}, 'JSONSpec' => {} }
-        index = @aggregate.update_search_index(old_index)
-        index.keys.sort.should == %w(BananaLib Faulty_spec IncorrectPath JSONKit JSONSpec)
-        index['BananaLib']['version'].should == '1.0'
-      end
-
-      it 'updates a set in the index if a lower version was stored' do
-        old_index = { 'BananaLib' => { 'version' => '0.8' } }
-        index = @aggregate.update_search_index(old_index)
-        index['BananaLib']['version'].should == '1.0'
-      end
-
-      it 'updates a set in the search index if no information was stored' do
-        old_index = { 'BananaLib' => {} }
-        index = @aggregate.update_search_index(old_index)
-        index['BananaLib']['version'].should == '1.0'
-      end
-
-      it "doesn't updates a set in the index if there already information for an equal or higher version" do
-        old_index = { 'BananaLib' => { 'version' => '1.0', 'summary' => 'custom' } }
-        index = @aggregate.update_search_index(old_index)
-        index['BananaLib']['summary'].should == 'custom'
-      end
-
-      it 'loads only the specifications which need to be updated' do
-        Specification.expects(:from_file).at_least_once
-        index = @aggregate.generate_search_index
-        Specification.expects(:from_file).never
-        @aggregate.update_search_index(index)
-      end
-
-      it 'deletes from the index the data of the sets which are not present in the aggregate' do
-        old_index = { 'Deleted-Pod' => { 'version' => '1.0', 'summary' => 'custom' } }
-        index = @aggregate.update_search_index(old_index)
-        index['Deleted-Pod'].should.be.nil
+        index = @aggregate.generate_search_index_for_source(@test_source)
+        index['BananaLib'].should == ['BananaLib']
+        index['JSONKit'].should == ['JSONKit']
+        index['JSONSpec'].should == ['JSONSpec']
+        index['Faulty_spec'].should.be.nil
+        index['Chunky'].should == ['BananaLib']
+        index['bananas!'].should == ['BananaLib']
+        index['Full'].should == ['BananaLib']
+        index['of'].should == ['BananaLib']
+        index['chunky'].should == ['BananaLib']
+        index['bananas.'].should == ['BananaLib']
+        index['Corp'].should == ['BananaLib']
+        index['Monkey'].should == ['BananaLib']
+        index['Boy'].should == ['BananaLib']
       end
     end
 

--- a/spec/source/aggregate_spec.rb
+++ b/spec/source/aggregate_spec.rb
@@ -99,24 +99,22 @@ module Pod
     describe 'Search Index' do
       before do
         @test_source = Source.new(fixture('spec-repos/test_repo'))
-        @aggregate.stubs(:sources).returns([@test_source])
       end
 
-      it 'generates the search index from scratch' do
+      it 'generates the search index for source' do
         index = @aggregate.generate_search_index_for_source(@test_source)
-        index['BananaLib'].should == ['BananaLib']
-        index['JSONKit'].should == ['JSONKit']
-        index['JSONSpec'].should == ['JSONSpec']
+        text = 'BananaLib Chunky bananas! Full of chunky bananas. Banana Corp Monkey Boy monkey@banana-corp.local'
+        text.split.each do |word|
+          index[word].should == ['BananaLib']
+        end
         index['Faulty_spec'].should.be.nil
-        index['Chunky'].should == ['BananaLib']
-        index['bananas!'].should == ['BananaLib']
-        index['Full'].should == ['BananaLib']
-        index['of'].should == ['BananaLib']
-        index['chunky'].should == ['BananaLib']
-        index['bananas.'].should == ['BananaLib']
-        index['Corp'].should == ['BananaLib']
-        index['Monkey'].should == ['BananaLib']
-        index['Boy'].should == ['BananaLib']
+      end
+
+      it 'generates the search index for changes in source' do
+        changed_paths = ['Specs/JSONKit/1.4/JSONKit.podspec']
+        index = @aggregate.generate_search_index_for_changes_in_source(@test_source, changed_paths)
+        index['JSONKit'].should == ['JSONKit']
+        index['BananaLib'].should.be.nil
       end
     end
 

--- a/spec/source_spec.rb
+++ b/spec/source_spec.rb
@@ -40,6 +40,13 @@ module Pod
           @source.pods
         end.message.should.match /Unable to find a source named: `non_existing`/
       end
+
+      it 'returns corresponding pods for given specification paths' do
+        paths = %w(Specs/BananaLib/1.0/BananaLib.podspec)
+        @source.pods_for_specification_paths(paths).should == %w(BananaLib)
+        paths = %w(Specs/monkey/1.0.2/monkey.podspec Specs/JSONKit/1.4/JSONKit.podspec)
+        @source.pods_for_specification_paths(paths).should == %w(monkey JSONKit)
+      end
     end
 
     #-------------------------------------------------------------------------#
@@ -186,6 +193,25 @@ module Pod
     end
 
     #-------------------------------------------------------------------------#
+
+    describe '#update' do
+      it 'uses the only fast forward git option' do
+        @source.expects(:`).with { |cmd| cmd.should.include('--ff-only') }
+        @source.send :update_git_repo
+      end
+
+      it 'uses git diff with name only option' do
+        @source.expects(:`).with { |cmd| cmd.should.include('--name-only') }.returns('')
+        @source.send :diff_until_commit_hash, 'DUMMY_HASH'
+      end
+
+      it 'finds diff of commits before/after repo update' do
+        @source.expects(:`).with { |cmd| cmd.should.include('DUMMY_HASH..HEAD') }.returns('')
+        @source.send :diff_until_commit_hash, 'DUMMY_HASH'
+      end
+    end
+
+    # #-------------------------------------------------------------------------#
 
     describe 'Representations' do
       it 'returns the hash representation' do


### PR DESCRIPTION
Detailed discussion can be found here: CocoaPods/cocoapods-search#8

- Previous implementation was having the drawback of traversing and performing `gsub` on all index strings for each pod specification.
- New implementation stores words as keys and list of pods containing corresponding word inside their specification as the values for corresponding hash keys. By this way, sources manager can perform a faster search operation.