### PR TITLE
Change required activesupport version to >=4.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CocoaPods Core Changelog
 
+## Master
+
+##### Bug Fixes
+
+* Fixes crash when using plugins where activesupport 4 was not installed.  
+  [Delisa Mason](https://github.com/kattrali)
+  [#266](https://github.com/CocoaPods/Core/pull/266)
+
 ## 0.39.0.beta.4 (2015-09-02)
 
 This version only introduces changes in the CocoaPods gem.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     cocoapods-core (0.39.0.beta.4)
-      activesupport (>= 3.2.15)
+      activesupport (>= 4.0.2)
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)
 
@@ -40,7 +40,7 @@ GEM
       rb-kqueue (>= 0.2)
     metaclass (0.0.4)
     method_source (0.8.2)
-    minitest (5.8.0)
+    minitest (5.8.1)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     mocha-on-bacon (0.2.2)

--- a/cocoapods-core.gemspec
+++ b/cocoapods-core.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files         =  Dir["lib/**/*.rb"] + %w{ README.md LICENSE }
   s.require_paths =  %w{ lib }
 
-  s.add_runtime_dependency 'activesupport', '>= 3.2.15'
+  s.add_runtime_dependency 'activesupport', '>= 4.0.2'
   s.add_runtime_dependency 'nap', '~> 1.0'
   s.add_runtime_dependency 'fuzzy_match', "~> 2.0.4"
 


### PR DESCRIPTION
When a user only has activesupport 3.2.15 installed, invoking `plugin` in a Podfile calls [`Hash.deep_stringify_keys`](http://apidock.com/rails/v4.0.2/Hash/deep_stringify_keys) causing a [crash](https://github.com/CocoaPods/CocoaPods/issues/3076).  `deep_stringify_keys` was first added to activesupport in version 4.0.2, but the base version required by core is 3.2.15. As noted in the comments on Cocoapods/Cocoapods#2307, the base activesupport version was held back to continue support for versions of Ruby before 2.0.0.

As of 76845c8, Cocoapods no longer supports Ruby versions less than 2.0, invalidating the reasoning for holding back the base version number.