### PR TITLE
[Podfile]add support to specify a pod's source when there are multi sources

### DIFF
--- a/lib/cocoapods-core/dependency.rb
+++ b/lib/cocoapods-core/dependency.rb
@@ -19,6 +19,11 @@ module Pod
     #
     attr_accessor :external_source
 
+    # @return [String] a string describing the source where the pod should
+    #         be fetched.
+    #
+    attr_accessor :source
+
     # @return [Bool] whether the dependency should use the podspec with the
     #         highest know version but force the downloader to checkout the
     #         `head` of the source repository.
@@ -40,6 +45,7 @@ module Pod
     #             Dependency.new('AFNetworking')
     #             Dependency.new('AFNetworking', '~> 1.0')
     #             Dependency.new('AFNetworking', '>= 0.5', '< 0.7')
+    #             Dependency.new('AFNetworking', '>= 0.5', '< 0.7', {:source => 'example_repo'})
     #
     # @overload   initialize(name, external_source)
     #
@@ -69,13 +75,16 @@ module Pod
     #
     def initialize(name = nil, *requirements)
       if requirements.last.is_a?(Hash)
-        external_source = requirements.pop.select { |_, v| !v.nil? }
-        @external_source = external_source unless external_source.empty?
-        unless requirements.empty?
-          raise Informative, 'A dependency with an external source may not ' \
-            "specify version requirements (#{name})."
+        if requirements.last.keys.include?(:source)
+          @source = requirements.pop[:source]
+        else
+          external_source = requirements.pop.select { |_, v| !v.nil? }
+          @external_source = external_source unless external_source.empty?
+          unless requirements.empty?
+            raise Informative, 'A dependency with an external source may not ' \
+              "specify version requirements (#{name})."
+          end
         end
-
       elsif requirements.last == :head
         @head = true
         requirements.pop

--- a/lib/cocoapods-core/source/aggregate.rb
+++ b/lib/cocoapods-core/source/aggregate.rb
@@ -85,7 +85,15 @@ module Pod
       # @see    Source#search
       #
       def search(dependency)
-        found_sources = sources.select { |s| s.search(dependency) }
+        ss = sources
+        unless dependency.source.nil?
+          ss = ss.select { |s| s.name == dependency.source }
+          if ss.blank?
+            raise Informative, 'Unable to find a source with name ' \
+            "`#{dependency.source}' for the `#{dependency.name}'"
+          end
+        end
+        found_sources = ss.select { |s| s.search(dependency) }
         unless found_sources.empty?
           Specification::Set.new(dependency.root_name, found_sources)
         end

--- a/spec/dependency_spec.rb
+++ b/spec/dependency_spec.rb
@@ -29,6 +29,18 @@ module Pod
         dep.should.not.be.external
       end
 
+      it 'can be initialized with a spec source' do
+        dep = Dependency.new('cocoapods', :source => 'master1')
+        dep.should.not.be.external
+      end
+
+      it 'can be initialized with a spec source and multiple requirements' do
+        dependency = Dependency.new('bananas', '> 1.0', '< 2.0', :source => 'master1')
+        dependency.requirement.to_s.should == '< 2.0, > 1.0'
+        dependency.should.not.be.external
+        dependency.source.should == 'master1'
+      end
+
       it "knows if it's local" do
         dep = Dependency.new('cocoapods', :path => '/tmp/cocoapods')
         dep.should.be.local

--- a/spec/source/aggregate_spec.rb
+++ b/spec/source/aggregate_spec.rb
@@ -41,6 +41,13 @@ module Pod
         set.sources.map(&:name).should == %w(test_repo master)
       end
 
+      it 'searches the sets by dependency with spec source' do
+        dep = Dependency.new('JSONKit', :source => 'test_repo')
+        set = @aggregate.search(dep)
+        set.name.should == 'JSONKit'
+        set.sources.map(&:name).should == %w(test_repo)
+      end
+
       it 'searches the sets specifying a dependency on a subspec' do
         dep = Dependency.new('RestKit/Network')
         set = @aggregate.search(dep)


### PR DESCRIPTION
I have three spec repos in my company, and they are same code, but different type. A source code repo, a framework repo with debug mode and a framework repo with release mode!!!

```
source "git@mycompany.com/framework-release.git"
source "git@mycompany.com/framework-debug.git"
source "git@mycompany.com/source.git"
pod "AFNetwork"
pod "SDWebImage"
```

So, I will get the AFNetwork in the `framework-release` and the SDWebImage in the `framework-release`.

But, now, I need that SDWebImage `source code`, I must write `pod "SDWebImage", :git=>"xxxx"`.

I think it is not good idea.

So, I hope this:
```
pod "SDWebImage", :source=>"mycompany-source"
```

The `:source` said that I will use the SDWebImage in the `git@mycompany.com/source.git`

What about this idea?