### PR TITLE
Fix CocoaDocs Podspec `cocoapods_version` example not showing

### DIFF
--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -106,13 +106,13 @@ module Pod
       #
       #   The version of CocoaPods that the sepcification supports.
       #
-      # @example
-      #
-      #   spec.cocoapods_version = '>= 0.36'
-      #
-      # @param  [String] cocoapods_version
-      #         the CocoaPods version that the specification supports.
-      #         CocoaPods follows [semantic versioning](http://semver.org).
+      #   @example
+      #   
+      #     spec.cocoapods_version = '>= 0.36'
+      #  
+      #   @param  [String] cocoapods_version
+      #           the CocoaPods version that the specification supports.
+      #           CocoaPods follows [semantic versioning](http://semver.org).
       #
       root_attribute :cocoapods_version
 

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -107,9 +107,9 @@ module Pod
       #   The version of CocoaPods that the sepcification supports.
       #
       #   @example
-      #   
+      #
       #     spec.cocoapods_version = '>= 0.36'
-      #  
+      #
       #   @param  [String] cocoapods_version
       #           the CocoaPods version that the specification supports.
       #           CocoaPods follows [semantic versioning](http://semver.org).


### PR DESCRIPTION
Indentation made the docs parser ignore it