### PR TITLE
Add ability to specify an explicit source for a given dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ##### Enhancements
 
+* Add support for specifying :source with a pod dependency.  
+  [Eric Firestone](https://github.com/efirestone)
+  [#278](https://github.com/CocoaPods/Core/pull/278)
+
 * Add ability to get all platforms.  
   [Muhammed Yavuz Nuzumlalı](https://github.com/manuyavuz)
   [cocoapods-search#11](https://github.com/CocoaPods/cocoapods-search/issues/11)

--- a/lib/cocoapods-core/podfile/target_definition.rb
+++ b/lib/cocoapods-core/podfile/target_definition.rb
@@ -497,7 +497,7 @@ module Pod
       # @note   The storage of this information is optimized for YAML
       #         readability.
       #
-      # @todo   This needs urgently a rename.
+      # @todo   This urgently needs a rename.
       #
       # @return [void]
       #
@@ -657,8 +657,8 @@ module Pod
 
       # @return [Array<Dependency>] The dependencies inherited by the podspecs.
       #
-      # @note   The podspec directive is intended include the dependencies of a
-      #         spec in the project where it is developed. For this reason the
+      # @note   The podspec directive is intended to include the dependencies of
+      #         a spec in the project where it is developed. For this reason the
       #         spec, or any of it subspecs, cannot be included in the
       #         dependencies. Otherwise it would generate a chicken-and-egg
       #         problem.
@@ -753,7 +753,7 @@ module Pod
         requirements.pop if options.empty?
       end
 
-      # Removes :subspecs form the requirements list, and stores the pods
+      # Removes :subspecs from the requirements list, and stores the pods
       # with the given subspecs as dependencies.
       #
       # @param  [String] name

--- a/lib/cocoapods-core/source.rb
+++ b/lib/cocoapods-core/source.rb
@@ -348,7 +348,7 @@ module Pod
     #
     # @note   In previous versions of CocoaPods they used to be stored in
     #         the root of the repo. This lead to issues, especially with
-    #         the GitHub interface and now the are stored in a dedicated
+    #         the GitHub interface and now they are stored in a dedicated
     #         folder.
     #
     def specs_dir

--- a/lib/cocoapods-core/specification.rb
+++ b/lib/cocoapods-core/specification.rb
@@ -326,7 +326,7 @@ module Pod
 
     # @!group DSL helpers
 
-    # @return [Bool] whether the specification should use a directory as it
+    # @return [Bool] whether the specification should use a directory as its
     #         source.
     #
     def local?

--- a/spec/dependency_spec.rb
+++ b/spec/dependency_spec.rb
@@ -18,6 +18,18 @@ module Pod
         dependency.requirement.to_s.should == '> 1.0-pre'
       end
 
+      it 'can be initialized with multiple requirements and a podspec source' do
+        dependency = Dependency.new('bananas', '> 1.0', '< 2.0', :source => 'https://github.com/CocoaPods/CocoaPods.git')
+        dependency.requirement.to_s.should == '< 2.0, > 1.0'
+        dependency.podspec_repo.should == 'https://github.com/CocoaPods/CocoaPods.git'
+      end
+
+      it 'can be initialized with a requirement on a pre-release version and a podspec source' do
+        dependency = Dependency.new('bananas', '> 1.0-pre', :source => 'https://github.com/CocoaPods/CocoaPods.git')
+        dependency.requirement.to_s.should == '> 1.0-pre'
+        dependency.podspec_repo.should == 'https://github.com/CocoaPods/CocoaPods.git'
+      end
+
       it 'can be initialized with an external source' do
         dep = Dependency.new('cocoapods', :git => 'git://github.com/cocoapods/cocoapods')
         dep.should.be.external


### PR DESCRIPTION
This adds the ability to add a `:source` flag to pod dependencies in a Podfile. This behavior mirrors in [Gemfiles](http://bundler.io/gemfile.html), allowing a dependency to be specified as such:

`pod 'JSONKit', '1.4', :source => 'http://github.com/MyOrg/Specs.git'`

This is a prerequisite for https://github.com/CocoaPods/CocoaPods/pull/4486