### PR TITLE
Don't Wrap Long Lines

### DIFF
--- a/lib/cocoapods-core/yaml_helper.rb
+++ b/lib/cocoapods-core/yaml_helper.rb
@@ -96,7 +96,7 @@ module Pod
         case value
         when Array      then process_array(value)
         when Hash       then process_hash(value, hash_keys_hint)
-        else                 YAML.dump(value).sub(/\A---/, '').sub(/[.]{3}\s*\Z/, '').strip
+        else                 YAML.dump(value, :line_width => -1).sub(/\A---/, '').sub(/[.]{3}\s*\Z/, '').strip
         end.strip
       end
 


### PR DESCRIPTION
I have internal packages with unfortunately long names.
This, though, causes CocoaPods to generate lock files it can't read, since it
wraps in such a way as to not be valid YAML anymore.