### PR TITLE
Fix undefined method error in inhibit_warnings_for_pod

### DIFF
--- a/lib/cocoapods-core/podfile/target_definition.rb
+++ b/lib/cocoapods-core/podfile/target_definition.rb
@@ -314,8 +314,11 @@ module Pod
       # @return [void]
       #
       def inhibit_warnings_for_pod(pod_name)
-        inhibit_warnings_hash['for_pods'] ||= []
-        inhibit_warnings_hash['for_pods'] << pod_name
+        if inhibit_warnings_hash['for_pods']
+          inhibit_warnings_hash['for_pods'] << pod_name
+        else
+          inhibit_warnings_hash['for_pods'] = [pod_name]
+        end
       end
 
       #--------------------------------------#


### PR DESCRIPTION
The following error occurs without this fix on OS X El Capitan with Ruby 2.3.0
and cocoapods-core 1.0.0.beta.1 when I use `inhibit_warnings: true` in my Podfile.

Output of pod update --verbose:
```
[!] Invalid `Podfile` file: undefined method `<<' for nil:NilClass. Updating
CocoaPods might fix the issue.

 #  from /Users/clemens/ProjectFoo/Podfile:9
 #  -------------------------------------------
 #    # Database: SQLite
 >    pod 'sqlite3', inhibit_warnings: true
 #
 #  -------------------------------------------

/Users/clemens/.rvm/gems/ruby-2.3.0/gems/cocoapods-core-1.0.0.beta.1/lib/cocoapods-core/podfile/target_definition.rb:323:in `inhibit_warnings_for_pod'
/Users/clemens/.rvm/gems/ruby-2.3.0/gems/cocoapods-core-1.0.0.beta.1/lib/cocoapods-core/podfile/target_definition.rb:746:in `parse_inhibit_warnings'
/Users/clemens/.rvm/gems/ruby-2.3.0/gems/cocoapods-core-1.0.0.beta.1/lib/cocoapods-core/podfile/target_definition.rb:484:in `store_pod'
/Users/clemens/.rvm/gems/ruby-2.3.0/gems/cocoapods-core-1.0.0.beta.1/lib/cocoapods-core/podfile/dsl.rb:194:in `pod'
/Users/clemens/ProjectFoo/Podfile:9:in `block (2 levels) in from_ruby'
/Users/clemens/.rvm/gems/ruby-2.3.0/gems/cocoapods-core-1.0.0.beta.1/lib/cocoapods-core/podfile/dsl.rb:294:in `target'
/Users/clemens/ProjectFoo/Podfile:7:in `block in from_ruby'
/Users/clemens/.rvm/gems/ruby-2.3.0/gems/cocoapods-core-1.0.0.beta.1/lib/cocoapods-core/podfile.rb:291:in `eval'
/Users/clemens/.rvm/gems/ruby-2.3.0/gems/cocoapods-core-1.0.0.beta.1/lib/cocoapods-core/podfile.rb:291:in `block in from_ruby'
/Users/clemens/.rvm/gems/ruby-2.3.0/gems/cocoapods-core-1.0.0.beta.1/lib/cocoapods-core/podfile.rb:51:in `instance_eval'
/Users/clemens/.rvm/gems/ruby-2.3.0/gems/cocoapods-core-1.0.0.beta.1/lib/cocoapods-core/podfile.rb:51:in `initialize'
/Users/clemens/.rvm/gems/ruby-2.3.0/gems/cocoapods-core-1.0.0.beta.1/lib/cocoapods-core/podfile.rb:287:in `new'
/Users/clemens/.rvm/gems/ruby-2.3.0/gems/cocoapods-core-1.0.0.beta.1/lib/cocoapods-core/podfile.rb:287:in `from_ruby'
/Users/clemens/.rvm/gems/ruby-2.3.0/gems/cocoapods-core-1.0.0.beta.1/lib/cocoapods-core/podfile.rb:253:in `from_file'
/Users/clemens/.rvm/gems/ruby-2.3.0/gems/cocoapods-1.0.0.beta.1/lib/cocoapods/config.rb:189:in `podfile'
/Users/clemens/.rvm/gems/ruby-2.3.0/gems/cocoapods-1.0.0.beta.1/lib/cocoapods/command.rb:112:in `verify_podfile_exists!'
/Users/clemens/.rvm/gems/ruby-2.3.0/gems/cocoapods-1.0.0.beta.1/lib/cocoapods/command/project.rb:127:in `run'
/Users/clemens/.rvm/gems/ruby-2.3.0/gems/claide-1.0.0.beta.1/lib/claide/command.rb:312:in `run'
/Users/clemens/.rvm/gems/ruby-2.3.0/gems/cocoapods-1.0.0.beta.1/lib/cocoapods/command.rb:48:in `run'
/Users/clemens/.rvm/gems/ruby-2.3.0/gems/cocoapods-1.0.0.beta.1/bin/pod:44:in `<top (required)>'
/Users/clemens/.rvm/gems/ruby-2.3.0/bin/pod:23:in `load'
/Users/clemens/.rvm/gems/ruby-2.3.0/bin/pod:23:in `<main>'
/Users/clemens/.rvm/gems/ruby-2.3.0/bin/ruby_executable_hooks:15:in `eval'
/Users/clemens/.rvm/gems/ruby-2.3.0/bin/ruby_executable_hooks:15:in `<main>'
```

I am programming in Ruby for quite a long time now, but I do not understand why my change is fixing this bug. As far as I know, the previous version with the `||=` statement should be equivalent to the code I replaced it with, but in practice, the original code fails with the above described error and my more verbose variant with if and else works. Would be nice if someone could explain what's going on here.
Could this be a Ruby bug?

Signed-off-by: Clemens Gruber <clemensgru@gmail.com>