### PR TITLE
Add ability to disable inhibiting warnings per pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ##### Enhancements
 
+* Add ability to disable inhibiting warnings per pod.  
+  Now `:inhibit_warnings => false` option can be used in podfile to disable inhibition for specific pods.  
+  [Muhammed Yavuz Nuzumlalı](https://github.com/manuyavuz)
+
 * Dependencies created from a string that use the `HEAD` specifier are properly
   parsed, ignoring the obsolete specifier.  
   [Samuel Giddins](https://github.com/segiddins)

--- a/lib/cocoapods-core/podfile/target_definition.rb
+++ b/lib/cocoapods-core/podfile/target_definition.rb
@@ -286,7 +286,7 @@ module Pod
       def inhibits_warnings_for_pod?(pod_name)
         if Array(inhibit_warnings_hash['not_for_pods']).include?(pod_name)
           false
-        elsif raw_inhibit_warnings_hash['all']
+        elsif inhibit_warnings_hash['all']
           true
         elsif !root? && parent.inhibits_warnings_for_pod?(pod_name)
           true
@@ -650,7 +650,16 @@ module Pod
         if exclusive?
           inhibit_hash
         else
-          parent.send(:inhibit_warnings_hash).merge(inhibit_hash) { |l, r| (l + r).uniq }
+          parent_hash = parent.send(:inhibit_warnings_hash)
+          if parent_hash['not_for_pods']
+            parent_hash['not_for_pods'] -= inhibit_hash['for_pods']
+          end
+          if parent_hash['for_pods']
+            parent_hash['for_pods'] -= inhibit_hash['not_for_pods']
+          end
+          parent_hash.merge(inhibit_hash) { |_, l, r|
+            (l + r).uniq
+          }
         end
       end
 

--- a/lib/cocoapods-core/podfile/target_definition.rb
+++ b/lib/cocoapods-core/podfile/target_definition.rb
@@ -318,12 +318,18 @@ module Pod
       # @return [void]
       #
       def set_inhibit_warnings_for_pod(pod_name, should_inhibit)
-        hash_key = 'for_pods' if should_inhibit == true
-        hash_key = 'not_for_pods' if should_inhibit == false
-        if hash_key
-          raw_inhibit_warnings_hash[hash_key] ||= []
-          raw_inhibit_warnings_hash[hash_key] << pod_name
-        end
+        hash_key = case should_inhibit
+                   when true
+                     'for_pods'
+                   when false
+                     'not_for_pods'
+                   when nil
+                     return
+                   else
+                     raise ArgumentError, "Got `#{should_inhibit.inspect}`, should be a boolean"
+                   end
+        raw_inhibit_warnings_hash[hash_key] ||= []
+        raw_inhibit_warnings_hash[hash_key] << pod_name
       end
 
       #--------------------------------------#

--- a/spec/podfile/dsl_spec.rb
+++ b/spec/podfile/dsl_spec.rb
@@ -77,6 +77,16 @@ module Pod
           target.inhibits_warnings_for_pod?('PonyDebugger').should.be.true
         end
 
+        it 'allows not inhibiting warnings on a single dependency' do
+          podfile = Podfile.new do
+            inhibit_all_warnings!
+            pod 'PonyDebugger', :inhibit_warnings => false
+          end
+
+          target = podfile.target_definitions['Pods']
+          target.inhibits_warnings_for_pod?('PonyDebugger').should.be.false
+        end
+
         it 'allows inhibiting warnings on a single dependency in a target block' do
           podfile = Podfile.new do
             target 'App' do
@@ -86,6 +96,18 @@ module Pod
 
           target = podfile.target_definitions['App']
           target.inhibits_warnings_for_pod?('PonyDebugger').should.be.true
+        end
+
+        it 'allows not inhibiting warnings on a single dependency in a target block' do
+          podfile = Podfile.new do
+            inhibit_all_warnings!
+            target 'App' do
+              pod 'PonyDebugger', :inhibit_warnings => false
+            end
+          end
+
+          target = podfile.target_definitions['App']
+          target.inhibits_warnings_for_pod?('PonyDebugger').should.be.false
         end
 
         it 'allows inhibiting warnings on a single dependency in a target block with inheritance' do
@@ -99,6 +121,40 @@ module Pod
           end
 
           target = podfile.target_definitions['App']
+          target.inhibits_warnings_for_pod?('PonyDebugger').should.be.true
+        end
+
+        it 'allows inhibiting in parent and not inhibiting in child on a single dependency' do
+          podfile = Podfile.new do
+            target 'App' do
+              pod 'PonyDebugger', :inhibit_warnings => true
+              target 'Inherited' do
+                pod 'PonyDebugger', :inhibit_warnings => false
+              end
+            end
+          end
+
+          target = podfile.target_definitions['App']
+          target.inhibits_warnings_for_pod?('PonyDebugger').should.be.true
+
+          target = podfile.target_definitions['Inherited']
+          target.inhibits_warnings_for_pod?('PonyDebugger').should.be.false
+        end
+
+        it 'allows not inhibiting in parent and inhibiting in child on a single dependency' do
+          podfile = Podfile.new do
+            target 'App' do
+              pod 'PonyDebugger', :inhibit_warnings => false
+              target 'Inherited' do
+                pod 'PonyDebugger', :inhibit_warnings => true
+              end
+            end
+          end
+
+          target = podfile.target_definitions['App']
+          target.inhibits_warnings_for_pod?('PonyDebugger').should.be.false
+
+          target = podfile.target_definitions['Inherited']
           target.inhibits_warnings_for_pod?('PonyDebugger').should.be.true
         end
       end

--- a/spec/podfile/dsl_spec.rb
+++ b/spec/podfile/dsl_spec.rb
@@ -68,6 +68,16 @@ module Pod
           target.inhibits_warnings_for_pod?('PonyDebugger').should.be.false
         end
 
+        it 'raises if :inhibit_warnings value is not a boolean' do
+          should.raise ArgumentError do
+            podfile = Podfile.new do
+              pod 'PonyDebugger', :inhibit_warnings => 'true'
+            end
+            target = podfile.target_definitions['Pods']
+            target.inhibits_warnings_for_pod?('PonyDebugger').should.be.true
+          end.message.should.match /should be a boolean/
+        end
+
         it 'allows inhibiting warnings on a single dependency' do
           podfile = Podfile.new do
             pod 'PonyDebugger', :inhibit_warnings => true

--- a/spec/podfile/dsl_spec.rb
+++ b/spec/podfile/dsl_spec.rb
@@ -157,6 +157,44 @@ module Pod
           target = podfile.target_definitions['Inherited']
           target.inhibits_warnings_for_pod?('PonyDebugger').should.be.true
         end
+
+        it 'allows not inhibiting a single dependency in parent and inhibiting all dependencies in child' do
+          podfile = Podfile.new do
+            target 'App' do
+              pod 'PonyDebugger', :inhibit_warnings => false
+              target 'Inherited' do
+                inhibit_all_warnings!
+                pod 'PonyDebugger'
+              end
+            end
+          end
+
+          target = podfile.target_definitions['App']
+          target.inhibits_warnings_for_pod?('PonyDebugger').should.be.false
+
+          target = podfile.target_definitions['Inherited']
+          target.inhibits_warnings_for_pod?('PonyDebugger').should.be.true
+        end
+
+        it 'allows not inhibiting a single dependency in grandparent and inhibiting all dependencies in grandchild' do
+          podfile = Podfile.new do
+            target 'App' do
+              pod 'PonyDebugger', :inhibit_warnings => false
+              target 'Inherited' do
+                target 'InheritedLevelTwo' do
+                  inhibit_all_warnings!
+                  pod 'PonyDebugger'
+                end
+              end
+            end
+          end
+
+          target = podfile.target_definitions['App']
+          target.inhibits_warnings_for_pod?('PonyDebugger').should.be.false
+
+          target = podfile.target_definitions['InheritedLevelTwo']
+          target.inhibits_warnings_for_pod?('PonyDebugger').should.be.true
+        end
       end
 
       it 'allows specifying multiple subspecs' do

--- a/spec/podfile/target_definition_spec.rb
+++ b/spec/podfile/target_definition_spec.rb
@@ -238,6 +238,12 @@ module Pod
         @parent.should.inhibits_warnings_for_pod?('RestKit')
       end
 
+      it 'does not inhibit warnings per pod if the option is false' do
+        @parent.inhibit_all_warnings = true
+        @parent.store_pod('ASIHTTPRequest', :inhibit_warnings => false)
+        @parent.should.not.inhibits_warnings_for_pod?('ASIHTTPRequest')
+      end
+
       it 'must delete the hash if it was empty. otherwise breaks Dependency' do
         reqs = [{ :inhibit_warnings => true }]
         @parent.send(:parse_inhibit_warnings, 'Objective-Record', reqs)
@@ -258,6 +264,12 @@ module Pod
       it 'inherits the option to inhibit warnings per pod' do
         @parent.store_pod('Objective-Record', :inhibit_warnings => true)
         @child.should.inhibits_warnings_for_pod?('Objective-Record')
+      end
+
+      it 'inherits the false option to inhibit warnings per pod' do
+        @parent.inhibit_all_warnings = true
+        @child.store_pod('ASIHTTPRequest', :inhibit_warnings => false)
+        @child.should.not.inhibits_warnings_for_pod?('ASIHTTPRequest')
       end
 
       #--------------------------------------#

--- a/spec/podfile/target_definition_spec.rb
+++ b/spec/podfile/target_definition_spec.rb
@@ -272,6 +272,12 @@ module Pod
         @child.should.not.inhibits_warnings_for_pod?('ASIHTTPRequest')
       end
 
+      it 'overriding inhibition per pod in child should not affect parent' do
+        @parent.store_pod('ASIHTTPRequest', :inhibit_warnings => true)
+        @child.store_pod('ASIHTTPRequest', :inhibit_warnings => false)
+        @child.should.not.inhibits_warnings_for_pod?('ASIHTTPRequest')
+        @parent.should.inhibits_warnings_for_pod?('ASIHTTPRequest')
+      end
       #--------------------------------------#
 
       it 'returns if it should use frameworks' do

--- a/spec/podfile_spec.rb
+++ b/spec/podfile_spec.rb
@@ -288,6 +288,23 @@ module Pod
         }
       end
 
+      it 'excludes inhibit warnings per pod' do
+        podfile = Podfile.new do
+          pod 'ASIHTTPRequest', :inhibit_warnings => false
+          pod 'ObjectiveSugar'
+        end
+        podfile.to_hash.should == {
+          'target_definitions' => [
+            'name' => 'Pods',
+            'abstract' => true,
+            'inhibit_warnings' => {
+              'not_for_pods' => ['ASIHTTPRequest'],
+            },
+            'dependencies' => %w(ASIHTTPRequest ObjectiveSugar),
+          ],
+        }
+      end
+
       it 'includes inhibit all warnings' do
         podfile = Podfile.new do
           pod 'ObjectiveSugar'


### PR DESCRIPTION
This enables setting `:inhibit_warnings => false` option to pods in podfile.
Warnings from pods having above value will not surpass even if `inhibit_all_warnings!` is set.

- [x] Specs
- [x] Changelog