### PR TITLE
[Dependency] Fix obsolete HEAD string check for lockfile entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 ##### Bug Fixes
 
+* Fix parsing of dependencies created from a string that includes `HEAD` specifier and version information.  
+  [Muhammed Yavuz Nuzumlalı](https://github.com/manuyavuz)
+  [CocoaPods#4710](https://github.com/CocoaPods/CocoaPods/issues/4710)
+
 * Fix specifying `configuration(s)` for a pod inside a target block.   
   [Samuel Giddins](https://github.com/segiddins)
   [CocoaPods#4707](https://github.com/CocoaPods/CocoaPods/issues/4707)

--- a/lib/cocoapods-core/dependency.rb
+++ b/lib/cocoapods-core/dependency.rb
@@ -350,7 +350,7 @@ module Pod
       version = match_data[2]
       version = version.gsub(/[()]/, '') if version
       case version
-      when ' HEAD'
+      when / HEAD( \(based on #{Pod::Version::VERSION_PATTERN}\))?/
         CoreUI.warn "Ignoring obsolete `HEAD` specifier in `#{string}`"
         Dependency.new(name)
       when nil, /from `(.*)(`|')/


### PR DESCRIPTION
Fixes #291.

This check was failing for lockfile entries like `Expecta (HEAD based on 1.0.5)`. We should if entry actually includes `HEAD`