### PR TITLE
[TargetDefinition] Safe access for bool values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@
   [Marius Rackwitz](https://github.com/mrackwitz)
   [Core#298](https://github.com/CocoaPods/Core/issues/298)
 
+##### Bug Fixes
+
+* Fix accessing `use_frameworks?` without accidentally clearing the value when
+  it was explicitly set to `false`, so that it would be evaluated as `true` on
+  the next access.  
+  [Marius Rackwitz](https://github.com/mrackwitz)
+  [Core#301](https://github.com/CocoaPods/Core/pull/301)
+
 
 ## 1.0.0.beta.2 (2016-01-05)
 

--- a/lib/cocoapods-core/podfile/target_definition.rb
+++ b/lib/cocoapods-core/podfile/target_definition.rb
@@ -637,7 +637,8 @@ module Pod
         unless HASH_KEYS.include?(key)
           raise StandardError, "Unsupported hash key `#{key}`"
         end
-        internal_hash[key] ||= base_value
+        internal_hash[key] = base_value if internal_hash[key].nil?
+        internal_hash[key]
       end
 
       def raw_inhibit_warnings_hash

--- a/spec/podfile/target_definition_spec.rb
+++ b/spec/podfile/target_definition_spec.rb
@@ -294,6 +294,8 @@ module Pod
         @parent.use_frameworks!
         @child.use_frameworks!(false)
         @child.should.not.uses_frameworks?
+        # make sure that the value is not accidentally overwritten on access
+        @child.should.not.uses_frameworks?
       end
 
       #--------------------------------------#


### PR DESCRIPTION
`false` values were set to nil, when they were read, so that `use_frameworks?` would be evaluated to `true` on the next access.