### PR TITLE
[Docs] Typo and outdated link

### DIFF
--- a/lib/cocoapods-core/podfile/dsl.rb
+++ b/lib/cocoapods-core/podfile/dsl.rb
@@ -1,8 +1,8 @@
 module Pod
   class Podfile
-    # The of the methods defined in this file and the order of the methods is
+    # The methods defined in this file and the order of the methods is
     # relevant for the documentation generated on
-    # CocoaPods/cocoapods.github.com.
+    # https://github.com/CocoaPods/guides.cocoapods.org.
 
     # The Podfile is a specification that describes the dependencies of the
     # targets of one or more Xcode projects.


### PR DESCRIPTION
I noticed this typo, but it seemed to include old, no longer relevant information (as the site has been deprecated and changed to guides.cocoapods.org). 