### PR TITLE
[TargetDefinition] Allow inheriting root-only attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ##### Enhancements
 
-* None.  
+* Allow a specification's root attributes to be accessible from a `consumer`.  
+  [Samuel Giddins](https://github.com/segiddins)
 
 ##### Bug Fixes
 
@@ -17,6 +18,10 @@
   their YAML.  
   [Samuel Giddins](https://github.com/segiddins)
   [CocoaPods#4740](https://github.com/CocoaPods/CocoaPods/issues/4740)
+
+* Make a spec's custom `module_map` accessible from a `consumer` in a
+  multi-platform compatible manner.  
+  [Samuel Giddins](https://github.com/segiddins)
 
 
 ## 1.0.0.beta.4 (2016-02-24)

--- a/lib/cocoapods-core/specification/consumer.rb
+++ b/lib/cocoapods-core/specification/consumer.rb
@@ -1,3 +1,5 @@
+require 'cocoapods-core/specification/root_attribute_accessors'
+
 module Pod
   class Specification
     # Allows to conveniently access a Specification programmatically.
@@ -48,6 +50,12 @@ module Pod
       def self.spec_attr_accessor(name)
         define_method(name) do
           value_for_attribute(name)
+        end
+      end
+
+      DSL::RootAttributesAccessors.instance_methods.each do |root_accessor|
+        define_method(root_accessor) do
+          spec.root.send(root_accessor)
         end
       end
 

--- a/lib/cocoapods-core/specification/consumer.rb
+++ b/lib/cocoapods-core/specification/consumer.rb
@@ -113,6 +113,10 @@ module Pod
       #
       spec_attr_accessor :module_name
 
+      # @return [String] the path of the module map file.
+      #
+      spec_attr_accessor :module_map
+
       # @return [String] the headers directory.
       #
       spec_attr_accessor :header_dir


### PR DESCRIPTION
Allows scoping root-only attributes per-platform, and cleaning up some usage of the spec consumer.

- [x] Add `spec_attr_accessor :license`
- [x] Specs
- [x] CHANGELOG