### PR TITLE
[Aggregate] Convert search index value types to string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@
   [Samuel Giddins](https://github.com/segiddins)
   [CocoaPods#5062](https://github.com/CocoaPods/CocoaPods/issues/5062)
 
+* Appending to an existing search index will now make new pods visible via
+  search.  
+  [Muhammed Yavuz Nuzumlalı](https://github.com/manuyavuz)
+  [CocoaPods#5031](https://github.com/CocoaPods/CocoaPods/issues/5031)
+
 
 ## 1.0.0.beta.6 (2016-03-15)
 

--- a/lib/cocoapods-core/source/aggregate.rb
+++ b/lib/cocoapods-core/source/aggregate.rb
@@ -165,7 +165,7 @@ module Pod
         result = {}
         sets.each do |set|
           word_list_from_set(set).each do |w|
-            (result[w] ||= []).push(set.name.to_sym)
+            (result[w] ||= []).push(set.name)
           end
         end
         result

--- a/lib/cocoapods-core/source/manager.rb
+++ b/lib/cocoapods-core/source/manager.rb
@@ -116,17 +116,17 @@ module Pod
         if full_text_search
           query_word_results_hash = {}
           updated_search_index.each_value do |word_spec_hash|
-            word_spec_hash.each_pair do |word, spec_symbols|
+            word_spec_hash.each_pair do |word, spec_names|
               query_word_regexps.each do |query_word_regexp|
                 set = (query_word_results_hash[query_word_regexp] ||= Set.new)
-                set.merge(spec_symbols) if word =~ query_word_regexp
+                set.merge(spec_names) if word =~ query_word_regexp
               end
             end
           end
-          found_set_symbols = query_word_results_hash.values.reduce(:&)
-          found_set_symbols ||= []
-          sets = found_set_symbols.map do |symbol|
-            aggregate.representative_set(symbol.to_s)
+          found_set_names = query_word_results_hash.values.reduce(:&)
+          found_set_names ||= []
+          sets = found_set_names.map do |name|
+            aggregate.representative_set(name)
           end
           # Remove nil values because representative_set return nil if no pod is found in any of the sources.
           sets.compact!

--- a/lib/cocoapods-core/source/manager.rb
+++ b/lib/cocoapods-core/source/manager.rb
@@ -212,15 +212,17 @@ module Pod
 
           new_index = aggregate.generate_search_index_for_changes_in_source(source, spec_paths)
           # First traverse search_index and update existing words
-          # Removed traversed words from new_index after adding to search_index,
+          # Remove traversed words from new_index after adding to search_index,
           # so that only non existing words will remain in new_index after enumeration completes.
           index_for_source.each_pair do |word, _|
             if new_index[word]
               index_for_source[word] |= new_index[word]
+              new_index.delete(word)
             else
               index_for_source[word] -= updated_pods
             end
           end
+
           # Now add non existing words remained in new_index to search_index
           index_for_source.merge!(new_index)
         end

--- a/spec/source/aggregate_spec.rb
+++ b/spec/source/aggregate_spec.rb
@@ -105,7 +105,7 @@ module Pod
         index = @aggregate.generate_search_index_for_source(@test_source)
         text = 'BananaLib Chunky bananas! Full of chunky bananas. Banana Corp Monkey Boy monkey@banana-corp.local'
         text.split.each do |word|
-          index[word].should == [:BananaLib]
+          index[word].should == %w(BananaLib)
         end
         index['Faulty_spec'].should.be.nil
       end
@@ -113,7 +113,7 @@ module Pod
       it 'generates the search index for changes in source' do
         changed_paths = ['Specs/JSONKit/1.4/JSONKit.podspec']
         index = @aggregate.generate_search_index_for_changes_in_source(@test_source, changed_paths)
-        index['JSONKit'].should == [:JSONKit]
+        index['JSONKit'].should == %w(JSONKit)
         index['BananaLib'].should.be.nil
       end
 

--- a/spec/source/manager_spec.rb
+++ b/spec/source/manager_spec.rb
@@ -225,12 +225,17 @@ module Pod
       end
 
       it 'updates search index for changed paths if source is updated' do
-        prev_index = { @test_source.name => {} }
+        prev_index = { @test_source.name => { 'Banana' => %w(SOME_POD), 'NON_EXISTING_WORD' => %w(SOME_POD JSONKit BananaLib) } }
         @sources_manager.expects(:stored_search_index).returns(prev_index)
 
         @sources_manager.expects(:save_search_index).with do |value|
-          value[@test_source.name]['BananaLib'].should.include(:BananaLib)
-          value[@test_source.name]['JSONKit'].should.include(:JSONKit)
+          value[@test_source.name]['BananaLib'].should.include('BananaLib')
+          value[@test_source.name]['JSONKit'].should.include('JSONKit')
+          value[@test_source.name]['Banana'].should.include('SOME_POD')
+          value[@test_source.name]['Banana'].should.include('BananaLib')
+          value[@test_source.name]['NON_EXISTING_WORD'].should.not.include('JSONKit')
+          value[@test_source.name]['NON_EXISTING_WORD'].should.not.include('BananaLib')
+          value[@test_source.name]['NON_EXISTING_WORD'].should.include('SOME_POD')
         end
         changed_paths = { @test_source => %w(Specs/BananaLib/1.0/BananaLib.podspec Specs/JSONKit/1.4/JSONKit.podspec) }
         @sources_manager.update_search_index_if_needed(changed_paths)


### PR DESCRIPTION
Closes https://github.com/CocoaPods/CocoaPods/issues/5031.

This is needed because JSON does not support getting values as symbols during parse.