### PR TITLE
Introduce Source::Metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,24 @@
 
 ##### Enhancements
 
-* None.  
+* Add support for sharded `Specs` directories in a source.  
+  [Samuel Giddins](https://github.com/segiddins)
+  [CocoaPods#5002](https://github.com/CocoaPods/CocoaPods/issues/5002)
+
+* Migrate the `Pod::SourcesManager` singleton to be the `Pod::Source::Manager`
+  class.  
+  [Samuel Giddins](https://github.com/segiddins)
+
+* Add support for specifying a list of tags in a source for breaking backwards
+  compatibility with old CocoaPods versions.  
+  [Samuel Giddins](https://github.com/segiddins)
+  [CocoaPods#5002](https://github.com/CocoaPods/CocoaPods/issues/5002)
 
 ##### Bug Fixes
 
-* None.  
+* Allow the master specs repo to be cloned using a `git://` URL.  
+  [Samuel Giddins](https://github.com/segiddins)
+  [CocoaPods#5062](https://github.com/CocoaPods/CocoaPods/issues/5062)
 
 
 ## 1.0.0.beta.6 (2016-03-15)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,4 +112,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.11.2
+   1.12.0.rc

--- a/lib/cocoapods-core/core_ui.rb
+++ b/lib/cocoapods-core/core_ui.rb
@@ -6,6 +6,10 @@ module Pod
       STDOUT.puts message
     end
 
+    def self.print(message)
+      STDOUT.print(message)
+    end
+
     def self.warn(message)
       STDERR.puts message
     end

--- a/lib/cocoapods-core/source.rb
+++ b/lib/cocoapods-core/source.rb
@@ -300,7 +300,10 @@ module Pod
         update_git_repo(show_output)
         refresh_metadata
         if version = metadata.last_compatible_version(Version.new(CORE_VERSION))
-          git(['checkout', "v#{version}"])
+          tag = "v#{version}"
+          CoreUI.warn "Using the `#{tag}` tag of the `#{name}` source because " \
+            "it is the last version compatible with CocoaPods #{CORE_VERSION}."
+          git(['checkout', tag])
         end
         changed_spec_paths = diff_until_commit_hash(prev_commit_hash)
       end

--- a/lib/cocoapods-core/source/aggregate.rb
+++ b/lib/cocoapods-core/source/aggregate.rb
@@ -10,6 +10,7 @@ module Pod
       # @param  [Array<Source>] repos_dirs @see Sources
       #
       def initialize(sources)
+        raise "Cannot initialize an aggregate with a nil source: (#{sources})" if sources.include?(nil)
         @sources = sources
       end
 

--- a/lib/cocoapods-core/source/manager.rb
+++ b/lib/cocoapods-core/source/manager.rb
@@ -1,0 +1,375 @@
+module Pod
+  class Source
+    class Manager
+      # @return [Pathname] The directory that contains the source repo
+      #         directories.
+      #
+      attr_reader :repos_dir
+
+      def initialize(repos_dir)
+        @repos_dir = Pathname(repos_dir).expand_path
+      end
+
+      # @return [Array<Pathname>] The source repo directories.
+      #
+      def source_repos
+        repos_dir.exist? ? repos_dir.children.select(&:directory?) : []
+      end
+
+      # @return [Source::Aggregate] The aggregate of all the sources with the
+      #         known Pods.
+      #
+      def aggregate
+        aggregate_with_repos(source_repos)
+      end
+
+      # @return [Source::Aggregate] The aggregate of the sources from repos.
+      #
+      # @param  [Dependency] dependency
+      #         The dependency for which to find or build the appropriate.
+      #         aggregate. If the dependency specifies a source podspec repo
+      #         then only that source will be used, otherwise all sources
+      #         will be used.
+      #
+      def aggregate_for_dependency(dependency)
+        if dependency.podspec_repo
+          source = source_with_url(dependency.podspec_repo)
+          raise StandardError, '[Bug] Failed to find known source with the URL ' \
+            "#{dependency.podspec_repo.inspect}" if source.nil?
+
+          aggregate_with_repos([source.repo])
+        else
+          aggregate
+        end
+      end
+
+      # @return [Array<Source>] The list of the sources with the given names.
+      #
+      # @param  [Array<#to_s>] names
+      #         The names of the sources.
+      #
+      def sources(names)
+        dirs = names.map { |name| source_dir(name) }
+        dirs.map { |repo| source_from_path(repo) }
+      end
+
+      # @return [Array<Source>] The list of all the sources known to this
+      #         installation of CocoaPods.
+      #
+      def all
+        aggregate.sources
+      end
+
+      # @return [Array<Source>] The CocoaPods Master Repo source.
+      #
+      def master
+        sources(['master']).select { |s| s.repo.directory? }
+      end
+
+      # @!group Master repo
+
+      # @return [Pathname] The path of the master repo.
+      #
+      def master_repo_dir
+        repos_dir + 'master'
+      end
+
+      # @return [Bool] Checks if the master repo is usable.
+      #
+      # @note   Note this is used to automatically setup the master repo if
+      #         needed.
+      #
+      def master_repo_functional?
+        return false unless master_repo = master.first
+        master_repo.metadata.compatible?(CORE_VERSION)
+      end
+
+      # Search the appropriate sources to match the set for the given dependency.
+      #
+      # @return [Set, nil] a set for a given dependency including all the
+      #         {Source} that contain the Pod. If no sources containing the
+      #         Pod where found it returns nil.
+      #
+      # @raise  If no source can be found that includes the dependency.
+      #
+      def search(dependency)
+        aggregate_for_dependency(dependency).search(dependency)
+      end
+
+      # Search all the sources with the given search term.
+      #
+      # @param  [String] query
+      #         The search term.
+      #
+      # @param  [Bool] full_text_search
+      #         Whether the search should be limited to the name of the Pod or
+      #         should include also the author, the summary, and the
+      #         description.
+      #
+      # @raise  If no source including the set can be found.
+      #
+      # @return [Array<Set>]  The sets that contain the search term.
+      #
+      def search_by_name(query, full_text_search = false)
+        query_word_regexps = query.split.map { |word| /#{word}/i }
+        if full_text_search
+          query_word_results_hash = {}
+          updated_search_index.each_value do |word_spec_hash|
+            word_spec_hash.each_pair do |word, spec_symbols|
+              query_word_regexps.each do |query_word_regexp|
+                set = (query_word_results_hash[query_word_regexp] ||= Set.new)
+                set.merge(spec_symbols) if word =~ query_word_regexp
+              end
+            end
+          end
+          found_set_symbols = query_word_results_hash.values.reduce(:&)
+          found_set_symbols ||= []
+          sets = found_set_symbols.map do |symbol|
+            aggregate.representative_set(symbol.to_s)
+          end
+          # Remove nil values because representative_set return nil if no pod is found in any of the sources.
+          sets.compact!
+        else
+          sets = aggregate.search_by_name(query, false)
+        end
+        if sets.empty?
+          extra = ', author, summary, or description' if full_text_search
+          raise Informative, "Unable to find a pod with name#{extra}" \
+            "matching `#{query}`"
+        end
+        sorted_sets(sets, query_word_regexps)
+      end
+
+      # Returns given set array by sorting it in-place.
+      #
+      # @param  [Array<Set>] sets
+      #         Array of sets to be sorted.
+      #
+      # @param  [Array<Regexp>] query_word_regexps
+      #         Array of regexp objects for user query.
+      #
+      # @return [Array<Set>]  Given sets parameter itself after sorting it in-place.
+      #
+      def sorted_sets(sets, query_word_regexps)
+        sets.sort_by! do |set|
+          pre_match_length = nil
+          found_query_index = nil
+          found_query_count = 0
+          query_word_regexps.each_with_index do |q, idx|
+            if (m = set.name.match(/#{q}/i))
+              pre_match_length ||= m.pre_match.length
+              found_query_index ||= idx
+              found_query_count += 1
+            end
+          end
+          pre_match_length ||= 1000
+          found_query_index ||= 1000
+          [-found_query_count, pre_match_length, found_query_index, set.name.downcase]
+        end
+        sets
+      end
+
+      # Returns the search data. If a saved search data exists, retrieves it from file and returns it.
+      # Else, creates the search data from scratch, saves it to file system, and returns it.
+      # Search data is grouped by source repos. For each source, it contains a hash where keys are words
+      # and values are the pod names containing corresponding word.
+      #
+      # For each source, list of unique words are generated from the following spec information.
+      #   - version
+      #   - summary
+      #   - description
+      #   - authors
+      #
+      # @return [Hash{String => Hash{String => Array<String>}}] The up to date search data.
+      #
+      def updated_search_index
+        index = stored_search_index || {}
+        all.each do |source|
+          source_name = source.name
+          unless index[source_name]
+            CoreUI.print "Creating search index for spec repo '#{source_name}'.."
+            index[source_name] = aggregate.generate_search_index_for_source(source)
+            CoreUI.puts ' Done!'
+          end
+        end
+        save_search_index(index)
+        index
+      end
+
+      # Updates the stored search index if there are changes in spec repos while updating them.
+      # Update is performed incrementally. Only the changed pods' search data is re-generated and updated.
+      # @param  [Hash{Source => Array<String>}] changed_spec_paths
+      #                  A hash containing changed specification paths for each source.
+      #
+      def update_search_index_if_needed(changed_spec_paths)
+        search_index = stored_search_index
+        return unless search_index
+        changed_spec_paths.each_pair do |source, spec_paths|
+          index_for_source = search_index[source.name]
+          next unless index_for_source && !spec_paths.empty?
+          updated_pods = source.pods_for_specification_paths(spec_paths)
+
+          new_index = aggregate.generate_search_index_for_changes_in_source(source, spec_paths)
+          # First traverse search_index and update existing words
+          # Removed traversed words from new_index after adding to search_index,
+          # so that only non existing words will remain in new_index after enumeration completes.
+          index_for_source.each_pair do |word, _|
+            if new_index[word]
+              index_for_source[word] |= new_index[word]
+            else
+              index_for_source[word] -= updated_pods
+            end
+          end
+          # Now add non existing words remained in new_index to search_index
+          index_for_source.merge!(new_index)
+        end
+        save_search_index(search_index)
+      end
+
+      # Updates search index for changed pods in background
+      # @param  [Hash{Source => Array<String>}] changed_spec_paths
+      #                  A hash containing changed specification paths for each source.
+      #
+      def update_search_index_if_needed_in_background(changed_spec_paths)
+        Process.fork do
+          Process.daemon
+          update_search_index_if_needed(changed_spec_paths)
+          exit
+        end
+      end
+
+      private
+
+      # @return [Source] The Source at a given path.
+      #
+      # @param [Pathname] path
+      #        The local file path to one podspec repo.
+      #
+      def source_from_path(path)
+        @sources_by_path ||= Hash.new do |hash, key|
+          hash[key] = if key.basename.to_s == 'master'
+                        MasterSource.new(key)
+                      else
+                        Source.new(key)
+                      end
+        end
+        @sources_by_path[path]
+      end
+
+      # @return [Source::Aggregate] The aggregate of the sources from repos.
+      #
+      # @param  [Array<Pathname>] repos
+      #         The local file paths to one or more podspec repo caches.
+      #
+      def aggregate_with_repos(repos)
+        sources = repos.map { |path| source_from_path(path) }
+        @aggregates_by_repos ||= {}
+        @aggregates_by_repos[repos] ||= Source::Aggregate.new(sources)
+      end
+
+      # @return [Source] The git source with the given name. If no git source
+      #         with given name is found it raises.
+      #
+      # @param  [String] name
+      #         The name of the source.
+      #
+      def git_source_named(name)
+        specified_source = sources([name]).first
+        unless specified_source
+          raise Informative, "Unable to find the `#{name}` repo."
+        end
+        unless specified_source.git?
+          raise Informative, "The `#{name}` repo is not a git repo."
+        end
+        specified_source
+      end
+
+      # @return [Source] The list of the git sources.
+      #
+      def git_sources
+        all.select(&:git?)
+      end
+
+      # @return [Pathname] The path of the source with the given name.
+      #
+      # @param  [String] name
+      #         The name of the source.
+      #
+      def source_dir(name)
+        repos_dir + name
+      end
+
+      # @return [Source] The source whose {Source#url} is equal to `url`.
+      #
+      # @param  [String] url
+      #         The URL of the source.
+      #
+      def source_with_url(url)
+        url = url.downcase.gsub(/.git$/, '')
+        all.find do |source|
+          source.url && source.url.downcase.gsub(/.git$/, '') == url
+        end
+      end
+
+      # Returns a suitable repository name for `url`.
+      #
+      # @example A GitHub.com URL
+      #
+      #          name_for_url('https://github.com/Artsy/Specs.git')
+      #            # "artsy"
+      #          name_for_url('https://github.com/Artsy/Specs.git')
+      #            # "artsy-1"
+      #
+      # @example A non-Github.com URL
+      #
+      #          name_for_url('https://sourceforge.org/Artsy/Specs.git')
+      #            # sourceforge-artsy-specs
+      #
+      # @example A file URL
+      #
+      #           name_for_url('file:///Artsy/Specs.git')
+      #             # artsy-specs
+      #
+      # @param  [#to_s] url
+      #         The URL of the source.
+      #
+      # @return [String] A suitable repository name for `url`.
+      #
+      def name_for_url(url)
+        base_from_host_and_path = lambda do |host, path|
+          if host
+            base = host.split('.')[-2] || host
+            base += '-'
+          else
+            base = ''
+          end
+
+          base + path.gsub(/.git$/, '').gsub(%r{^/}, '').split('/').join('-')
+        end
+
+        case url.to_s.downcase
+        when %r{github.com[:/]+cocoapods/specs}
+          base = 'master'
+        when %r{github.com[:/]+(.+)/(.+)}
+          base = Regexp.last_match[1]
+        when %r{^\S+@(\S+)[:/]+(.+)$}
+          host, path = Regexp.last_match.captures
+          base = base_from_host_and_path[host, path]
+        when URI.regexp
+          url = URI(url.downcase)
+          base = base_from_host_and_path[url.host, url.path]
+        else
+          base = url.to_s.downcase
+        end
+
+        name = base
+        infinity = 1.0 / 0
+        (1..infinity).each do |i|
+          break unless source_dir(name).exist?
+          name = "#{base}-#{i}"
+        end
+        name
+      end
+    end
+  end
+end

--- a/lib/cocoapods-core/source/manager.rb
+++ b/lib/cocoapods-core/source/manager.rb
@@ -238,6 +238,39 @@ module Pod
         end
       end
 
+      # Returns the search data stored in the file system.
+      # If existing data in the file system is not valid, returns nil.
+      #
+      def stored_search_index
+        @updated_search_index ||= begin
+          if search_index_path.exist?
+            require 'json'
+            index = JSON.parse(search_index_path.read)
+            index if index.is_a?(Hash) # TODO: should we also check if hash has correct hierarchy?
+          end
+        end
+      end
+
+      # Stores given search data in the file system.
+      # @param [Hash] index
+      #        Index to be saved in file system
+      #
+      def save_search_index(index)
+        require 'json'
+        @updated_search_index = index
+        search_index_path.open('w') do |io|
+          io.write(@updated_search_index.to_json)
+        end
+      end
+
+      # Allows to clear the search index.
+      #
+      attr_writer :updated_search_index
+
+      # @return [Pathname] The path where the search index should be stored.
+      #
+      attr_accessor :search_index_path
+
       private
 
       # @return [Source] The Source at a given path.

--- a/lib/cocoapods-core/source/manager.rb
+++ b/lib/cocoapods-core/source/manager.rb
@@ -72,7 +72,7 @@ module Pod
       # @return [Pathname] The path of the master repo.
       #
       def master_repo_dir
-        repos_dir + 'master'
+        source_dir('master')
       end
 
       # @return [Bool] Checks if the master repo is usable.

--- a/lib/cocoapods-core/source/manager.rb
+++ b/lib/cocoapods-core/source/manager.rb
@@ -340,6 +340,7 @@ module Pod
       #
       def source_with_url(url)
         url = url.downcase.gsub(/.git$/, '')
+        url = 'https://github.com/cocoapods/specs' if url =~ %r{github.com[:/]+cocoapods/specs}
         all.find do |source|
           source.url && source.url.downcase.gsub(/.git$/, '') == url
         end

--- a/lib/cocoapods-core/source/manager.rb
+++ b/lib/cocoapods-core/source/manager.rb
@@ -13,7 +13,8 @@ module Pod
       # @return [Array<Pathname>] The source repo directories.
       #
       def source_repos
-        repos_dir.exist? ? repos_dir.children.select(&:directory?) : []
+        return [] unless repos_dir.exist?
+        repos_dir.children.select(&:directory?).sort_by { |d| d.basename.to_s.downcase }
       end
 
       # @return [Source::Aggregate] The aggregate of all the sources with the

--- a/lib/cocoapods-core/source/metadata.rb
+++ b/lib/cocoapods-core/source/metadata.rb
@@ -1,0 +1,46 @@
+autoload :Digest, 'digest/md5'
+
+module Pod
+  class Source
+    class Metadata
+      attr_reader :minimum_cocoapods_version
+      attr_reader :latest_cocoapods_version
+      attr_reader :prefix_lengths
+      attr_reader :last_compatible_versions
+
+      def initialize(hash = {})
+        @minimum_cocoapods_version = hash['min']
+        @minimum_cocoapods_version &&= Pod::Version.new(@minimum_cocoapods_version)
+        @latest_cocoapods_version = hash['last']
+        @latest_cocoapods_version &&= Pod::Version.new(@latest_cocoapods_version)
+        @prefix_lengths = Array(hash['prefix_lengths']).map!(&:to_i)
+        @last_compatible_versions = Array(hash['last_compatible_versions']).map(&Pod::Version.method(:new)).sort
+      end
+
+      def self.from_file(file)
+        hash = file.file? ? YAMLHelper.load_file(file) : {}
+        new(hash)
+      end
+
+      def path_fragment(pod_name, version = nil)
+        prefixes = if prefix_lengths.empty?
+                     []
+                   else
+                     hashed = Digest::MD5.hexdigest(pod_name)
+                     prefix_lengths.map do |length|
+                       hashed.slice!(0, length)
+                     end
+                   end
+        prefixes.concat([pod_name, version]).compact.join(File::SEPARATOR)
+      end
+
+      def last_compatible_version(target_version)
+        return unless minimum_cocoapods_version
+        return if minimum_cocoapods_version <= target_version
+        @last_compatible_versions.reverse_each.bsearch { |v| v <= target_version }.tap do |version|
+          raise Informative, 'Unable to find compatible version' unless version
+        end
+      end
+    end
+  end
+end

--- a/lib/cocoapods-core/source/metadata.rb
+++ b/lib/cocoapods-core/source/metadata.rb
@@ -1,4 +1,6 @@
 autoload :Digest, 'digest/md5'
+require 'active_support/hash_with_indifferent_access'
+require 'active_support/core_ext/hash/indifferent_access'
 
 module Pod
   class Source
@@ -10,6 +12,7 @@ module Pod
       attr_reader :last_compatible_versions
 
       def initialize(hash = {})
+        hash = hash.with_indifferent_access
         @minimum_cocoapods_version = hash['min']
         @minimum_cocoapods_version &&= Pod::Version.new(@minimum_cocoapods_version)
         @maximum_cocoapods_version = hash['max']
@@ -26,7 +29,7 @@ module Pod
       end
 
       def to_hash
-        hash = {}
+        hash = ActiveSupport::HashWithIndifferentAccess.new
         hash['min'] = @minimum_cocoapods_version.to_s if @minimum_cocoapods_version
         hash['max'] = @maximum_cocoapods_version.to_s if @maximum_cocoapods_version
         hash['last'] = @latest_cocoapods_version.to_s if @latest_cocoapods_version

--- a/lib/cocoapods-core/source/metadata.rb
+++ b/lib/cocoapods-core/source/metadata.rb
@@ -25,6 +25,16 @@ module Pod
         new(hash)
       end
 
+      def to_hash
+        hash = {}
+        hash['min'] = @minimum_cocoapods_version.to_s if @minimum_cocoapods_version
+        hash['max'] = @maximum_cocoapods_version.to_s if @maximum_cocoapods_version
+        hash['last'] = @latest_cocoapods_version.to_s if @latest_cocoapods_version
+        hash['prefix_lengths'] = @prefix_lengths unless @prefix_lengths.empty?
+        hash['last_compatible_versions'] = @last_compatible_versions.map(&:to_s) unless @last_compatible_versions.empty?
+        hash
+      end
+
       def path_fragment(pod_name, version = nil)
         prefixes = if prefix_lengths.empty?
                      []

--- a/lib/cocoapods-core/source/metadata.rb
+++ b/lib/cocoapods-core/source/metadata.rb
@@ -4,6 +4,7 @@ module Pod
   class Source
     class Metadata
       attr_reader :minimum_cocoapods_version
+      attr_reader :maximum_cocoapods_version
       attr_reader :latest_cocoapods_version
       attr_reader :prefix_lengths
       attr_reader :last_compatible_versions
@@ -11,6 +12,8 @@ module Pod
       def initialize(hash = {})
         @minimum_cocoapods_version = hash['min']
         @minimum_cocoapods_version &&= Pod::Version.new(@minimum_cocoapods_version)
+        @maximum_cocoapods_version = hash['max']
+        @maximum_cocoapods_version &&= Pod::Version.new(@maximum_cocoapods_version)
         @latest_cocoapods_version = hash['last']
         @latest_cocoapods_version &&= Pod::Version.new(@latest_cocoapods_version)
         @prefix_lengths = Array(hash['prefix_lengths']).map!(&:to_i)
@@ -40,6 +43,23 @@ module Pod
         @last_compatible_versions.reverse_each.bsearch { |v| v <= target_version }.tap do |version|
           raise Informative, 'Unable to find compatible version' unless version
         end
+      end
+
+      # Returns whether a source is compatible with the current version of
+      # CocoaPods.
+      #
+      # @param  [Pathname] dir
+      #         The directory where the source is stored.
+      #
+      # @return [Bool] whether the source is compatible.
+      #
+      def compatible?(version)
+        bin_version  = Gem::Version.new(version)
+        supports_min = !minimum_cocoapods_version ||
+          (bin_version >= Gem::Version.new(minimum_cocoapods_version))
+        supports_max = !maximum_cocoapods_version ||
+          (bin_version <= Gem::Version.new(maximum_cocoapods_version))
+        supports_min && supports_max
       end
     end
   end

--- a/spec/fixtures/spec-repos/test_prefixed_repo/CocoaPods-version.yml
+++ b/spec/fixtures/spec-repos/test_prefixed_repo/CocoaPods-version.yml
@@ -1,0 +1,7 @@
+---
+min: 1.0.0
+last: 1.9.9
+prefix_lengths:
+  - 1
+  - 1
+  - 1

--- a/spec/fixtures/spec-repos/test_prefixed_repo/Specs/1/3/f/JSONKit/1.13/JSONKit.podspec
+++ b/spec/fixtures/spec-repos/test_prefixed_repo/Specs/1/3/f/JSONKit/1.13/JSONKit.podspec
@@ -1,0 +1,11 @@
+Pod::Spec.new do |s|
+  s.name     = 'JSONKit'
+  s.version  = '1.13'
+  s.license  = 'BSD / Apache License, Version 2.0'
+  s.summary  = 'A Very High Performance Objective-C JSON Library.'
+  s.homepage = 'https://github.com/johnezang/JSONKit'
+  s.author   = 'John Engelhart'
+  s.source   = { :git => 'https://github.com/johnezang/JSONKit.git', :tag => 'v1.13' }
+
+  s.source_files = 'JSONKit.*'
+end

--- a/spec/fixtures/spec-repos/test_prefixed_repo/Specs/1/3/f/JSONKit/1.4/JSONKit.podspec
+++ b/spec/fixtures/spec-repos/test_prefixed_repo/Specs/1/3/f/JSONKit/1.4/JSONKit.podspec
@@ -1,0 +1,11 @@
+Pod::Spec.new do |s|
+  s.name     = 'JSONKit'
+  s.version  = '1.4'
+  s.license  = 'BSD / Apache License, Version 2.0'
+  s.summary  = 'A Very High Performance Objective-C JSON Library.'
+  s.homepage = 'https://github.com/johnezang/JSONKit'
+  s.author   = 'John Engelhart'
+  s.source   = { :git => 'https://github.com/johnezang/JSONKit.git', :tag => 'v1.4' }
+
+  s.source_files = 'JSONKit.*'
+end

--- a/spec/fixtures/spec-repos/test_prefixed_repo/Specs/1/3/f/JSONKit/999.999.999/JSONKit.podspec
+++ b/spec/fixtures/spec-repos/test_prefixed_repo/Specs/1/3/f/JSONKit/999.999.999/JSONKit.podspec
@@ -1,0 +1,12 @@
+Pod::Spec.new do |s|
+  s.name     = 'JSONKit'
+  s.version  = '999.999.999'
+  s.license  = 'BSD / Apache License, Version 2.0'
+  s.summary  = 'A Very High Performance Objective-C JSON Library.'
+  s.homepage = 'https://github.com/johnezang/JSONKit'
+  s.author   = 'John Engelhart'
+  s.source   = { :git => 'https://github.com/johnezang/JSONKit.git', :commit => '0aff3deb5e1bb2bbc88a83fd71c8ad5550185cce' }
+
+  s.source_files   = 'JSONKit.*'
+  s.compiler_flags = '-Wno-deprecated-objc-isa-usage', '-Wno-format'
+end

--- a/spec/fixtures/spec-repos/test_prefixed_repo/Specs/3/8/e/BananaLib/0.0.1/BananaLib.podspec
+++ b/spec/fixtures/spec-repos/test_prefixed_repo/Specs/3/8/e/BananaLib/0.0.1/BananaLib.podspec
@@ -1,0 +1,19 @@
+Pod::Spec.new do |s|
+  s.name         = 'BananaLib'
+  s.version      = '0.0.1'
+  s.authors      = 'Banana Corp', { 'Monkey Boy' => 'monkey@banana-corp.local' }
+  s.homepage     = 'http://banana-corp.local/banana-lib.html'
+  s.summary      = 'Chunky bananas!'
+  s.description  = 'Full of chunky bananas.'
+  s.source       = { :git => 'http://banana-corp.local/banana-lib.git', :commit => 'dbf863b4d7cf6c22d4bf89969fe7505c61950958' }
+  s.source_files = 'Classes/*.{h,m}', 'Vendor'
+  s.xcconfig     = { 'OTHER_LDFLAGS' => '-framework SystemConfiguration' }
+  s.prefix_header_file = 'Classes/BananaLib.pch'
+  s.resources    = "Resources/*.png"
+  s.dependency   'monkey', '~> 1.0.1', '< 1.0.9'
+  s.license      = {
+    :type => 'MIT',
+    :file => 'LICENSE',
+    :text => 'Permission is hereby granted ...'
+  }
+end

--- a/spec/fixtures/spec-repos/test_prefixed_repo/Specs/3/8/e/BananaLib/0.9/BananaLib.podspec
+++ b/spec/fixtures/spec-repos/test_prefixed_repo/Specs/3/8/e/BananaLib/0.9/BananaLib.podspec
@@ -1,0 +1,19 @@
+Pod::Spec.new do |s|
+  s.name         = 'BananaLib'
+  s.version      = '0.9'
+  s.authors      = 'Banana Corp', { 'Monkey Boy' => 'monkey@banana-corp.local' }
+  s.homepage     = 'http://banana-corp.local/banana-lib.html'
+  s.summary      = 'Chunky bananas!'
+  s.description  = 'Full of chunky bananas.'
+  s.source       = { :git => 'http://banana-corp.local/banana-lib.git', :tag => 'v1.0' }
+  s.source_files = 'Classes/*.{h,m}', 'Vendor'
+  s.xcconfig     = { 'OTHER_LDFLAGS' => '-framework SystemConfiguration' }
+  s.prefix_header_file = 'Classes/BananaLib.pch'
+  s.resources    = "Resources/*.png"
+  s.dependency   'monkey', '~> 1.0.1', '< 1.0.9'
+  s.license      = {
+    :type => 'MIT',
+    :file => 'LICENSE',
+    :text => 'Permission is hereby granted ...'
+  }
+end

--- a/spec/fixtures/spec-repos/test_prefixed_repo/Specs/3/8/e/BananaLib/1.0/BananaLib.podspec
+++ b/spec/fixtures/spec-repos/test_prefixed_repo/Specs/3/8/e/BananaLib/1.0/BananaLib.podspec
@@ -1,0 +1,20 @@
+Pod::Spec.new do |s|
+  s.name         = 'BananaLib'
+  s.version      = '1.0'
+  s.authors      = 'Banana Corp', { 'Monkey Boy' => 'monkey@banana-corp.local' }
+  s.homepage     = 'http://banana-corp.local/banana-lib.html'
+  s.summary      = 'Chunky bananas!'
+  s.description  = 'Full of chunky bananas.'
+  s.source       = { :git => 'http://banana-corp.local/banana-lib.git', :tag => 'v1.0' }
+  s.source_files = 'Classes/*.{h,m}', 'Vendor'
+  s.xcconfig     = { 'OTHER_LDFLAGS' => '-framework SystemConfiguration' }
+  s.prefix_header_file = 'Classes/BananaLib.pch'
+  s.resources    = "Resources/*.png"
+  s.requires_arc = true
+  s.dependency   'monkey', '~> 1.0.1', '< 1.0.9'
+  s.license      = {
+    :type => 'MIT',
+    :file => 'LICENSE',
+    :text => 'Permission is hereby granted ...'
+  }
+end

--- a/spec/fixtures/spec-repos/test_prefixed_repo/Specs/9/0/c/IncorrectPath/1.0/IncorrectPath.podspec
+++ b/spec/fixtures/spec-repos/test_prefixed_repo/Specs/9/0/c/IncorrectPath/1.0/IncorrectPath.podspec
@@ -1,0 +1,4 @@
+Pod::Spec.new do |s|
+  s.name         = 'IncorrectPath'
+  s.version      = '0.9'
+end

--- a/spec/fixtures/spec-repos/test_prefixed_repo/Specs/d/8/d/JSONSpec/0.9/JSONSpec.podspec.json
+++ b/spec/fixtures/spec-repos/test_prefixed_repo/Specs/d/8/d/JSONSpec/0.9/JSONSpec.podspec.json
@@ -1,0 +1,4 @@
+{
+  "name": "JSONSpec",
+  "version": "0.9"
+}

--- a/spec/fixtures/spec-repos/test_prefixed_repo/Specs/d/8/d/JSONSpec/1.0/JSONSpec.podspec.json
+++ b/spec/fixtures/spec-repos/test_prefixed_repo/Specs/d/8/d/JSONSpec/1.0/JSONSpec.podspec.json
@@ -1,0 +1,4 @@
+{
+  "name": "JSONSpec",
+  "version": "1.0"
+}

--- a/spec/master_source_spec.rb
+++ b/spec/master_source_spec.rb
@@ -29,7 +29,8 @@ module Pod
       end
 
       it 'uses the only fast forward git option' do
-        @source.expects(:`).with { |cmd| cmd.should.include('--ff-only') }
+        @source.expects(:`).with('git checkout master')
+        @source.expects(:`).with('git pull --ff-only 2>&1')
         @source.send :update_git_repo
       end
 

--- a/spec/source/manager_spec.rb
+++ b/spec/source/manager_spec.rb
@@ -1,0 +1,270 @@
+require File.expand_path('../../spec_helper', __FILE__)
+
+module Pod
+  describe Source::Manager do
+    extend SpecHelper::TemporaryDirectory
+
+    before do
+      @test_source = Source.new(fixture('spec-repos/test_repo'))
+      @sources_manager = Source::Manager.new(fixture('spec-repos'))
+      @sources_manager.search_index_path = SpecHelper.temporary_directory + 'search_index.json'
+    end
+
+    #-------------------------------------------------------------------------#
+
+    describe 'In general' do
+      it 'does not fail if the repos directory does not exist' do
+        @sources_manager.stubs(:repos_dir).returns(Pathname.new('/foo/bar'))
+        @sources_manager.aggregate.sources.should == []
+        @sources_manager.all.should == []
+      end
+
+      it 'returns all the sources' do
+        @sources_manager.all.map(&:name).should == %w(master test_prefixed_repo test_repo)
+      end
+
+      it 'includes all sources in an aggregate for a dependency if no source is specified' do
+        dependency = Dependency.new('JSONKit', '1.4')
+        aggregate = @sources_manager.aggregate_for_dependency(dependency)
+        aggregate.sources.map(&:name).should == %w(master test_prefixed_repo test_repo)
+      end
+
+      it 'includes only the one source in an aggregate for a dependency if a source is specified' do
+        repo_url = 'https://url/to/specs.git'
+        dependency = Dependency.new('JSONKit', '1.4', :source => repo_url)
+
+        source = mock
+        source.stubs(:name).returns('repo')
+        source.stubs(:repo).returns('path')
+
+        @sources_manager.expects(:source_with_url).with(repo_url).returns(source)
+        @sources_manager.expects(:source_from_path).with('path').returns(source)
+
+        aggregate = @sources_manager.aggregate_for_dependency(dependency)
+        aggregate.sources.map(&:name).should == [source.name]
+      end
+
+      it 'searches for the set of a dependency' do
+        set = @sources_manager.search(Dependency.new('BananaLib'))
+        set.class.should == Specification::Set
+        set.name.should == 'BananaLib'
+      end
+
+      it 'returns nil if it is not able to find a pod for the given dependency' do
+        set = @sources_manager.search(Dependency.new('Windows-Lib'))
+        set.should.be.nil
+      end
+
+      it 'searches sets by name' do
+        sets = @sources_manager.search_by_name('BananaLib')
+        sets.all? { |s| s.class == Specification::Set }.should.be.true
+        sets.any? { |s| s.name == 'BananaLib' }.should.be.true
+      end
+
+      it 'can perform a full text search of the sets' do
+        @sources_manager.stubs(:all).returns([@test_source])
+        sets = @sources_manager.search_by_name('Chunky', true)
+        sets.all? { |s| s.class == Specification::Set }.should.be.true
+        sets.any? { |s| s.name == 'BananaLib' }.should.be.true
+      end
+
+      it 'can perform a full text regexp search of the sets' do
+        @sources_manager.stubs(:all).returns([@test_source])
+        sets = @sources_manager.search_by_name('Ch[aeiou]nky', true)
+        sets.all? { |s| s.class == Specification::Set }.should.be.true
+        sets.any? { |s| s.name == 'BananaLib' }.should.be.true
+      end
+
+      describe 'Sorting algorithm' do
+        before do
+          @test_search_results = %w(HockeyKit DLSuit VCLReachability NPReachability AVReachability PYNetwork
+                                    SCNetworkReachability AFNetworking Networking).map do |name|
+            Specification::Set.new(name)
+          end
+        end
+
+        it 'puts pod with exact match at the first index while sorting' do
+          regexps = [/networking/i]
+          sets = @sources_manager.sorted_sets(@test_search_results, regexps)
+          sets[0].name.should == 'Networking'
+        end
+
+        it 'puts pod with less prefix length before pods with more prefix length in search results' do
+          regexps = [/reachability/i]
+          sets = @sources_manager.sorted_sets(@test_search_results, regexps)
+          sets.index { |s| s.name == 'AVReachability' }.should.be < sets.index { |s| s.name == 'VCLReachability' }
+        end
+
+        it 'puts pod with more query word match before pods with less match in multi word query search results' do
+          regexps = [/network/i, /reachability/i]
+          sets = @sources_manager.sorted_sets(@test_search_results, regexps)
+          sets.index { |s| s.name == 'SCNetworkReachability' }.should.be < sets.index { |s| s.name == 'AVReachability' }
+        end
+
+        it 'puts pod matching first query word before pods matching later words in multi word query search results' do
+          regexps = [/network/i, /reachability/i]
+          sets = @sources_manager.sorted_sets(@test_search_results, regexps)
+          sets.index { |s| s.name == 'PYNetwork' }.should.be < sets.index { |s| s.name == 'AVReachability' }
+        end
+
+        it 'puts pod matching first query word before pods matching later words in multi word query search results' do
+          regexps = [/network/i, /reachability/i]
+          sets = @sources_manager.sorted_sets(@test_search_results, regexps)
+          sets.index { |s| s.name == 'PYNetwork' }.should.be < sets.index { |s| s.name == 'AVReachability' }
+        end
+
+        it 'alphabetically sorts pods having exact other conditions' do
+          regexps = [/reachability/i]
+          sets = @sources_manager.sorted_sets(@test_search_results, regexps)
+          sets.index { |s| s.name == 'AVReachability' }.should.be < sets.index { |s| s.name == 'NPReachability' }
+        end
+
+        it 'alphabetically sorts pods whose names does not match query' do
+          regexps = [/reachability/i]
+          sets = @sources_manager.sorted_sets(@test_search_results, regexps)
+          sets.index { |s| s.name == 'DLSuit' }.should.be < sets.index { |s| s.name == 'HockeyKit' }
+        end
+      end
+
+      it "generates the search index before performing a search if it doesn't exist" do
+        @sources_manager.stubs(:all).returns([@test_source])
+        Source::Aggregate.any_instance.expects(:generate_search_index_for_source).with(@test_source).returns('BananaLib' => ['BananaLib'])
+        @sources_manager.updated_search_index = nil
+        @sources_manager.search_by_name('BananaLib', true)
+      end
+
+      describe 'managing sources by URL' do
+        describe 'generating a repo name from a URL' do
+          it 'uses `master` for the master CocoaPods repository' do
+            url = 'https://github.com/CocoaPods/Specs.git'
+            Pathname.any_instance.stubs(:exist?).
+              returns(false).then.returns(true)
+            @sources_manager.send(:name_for_url, url).should == 'master'
+
+            url = 'git@github.com:CocoaPods/Specs.git'
+            Pathname.any_instance.stubs(:exist?).
+              returns(false).then.returns(true)
+            @sources_manager.send(:name_for_url, url).should == 'master'
+
+            url = 'git@github.com:/CocoaPods/Specs.git'
+            Pathname.any_instance.stubs(:exist?).
+              returns(false).then.returns(true)
+            @sources_manager.send(:name_for_url, url).should == 'master'
+          end
+
+          it 'uses the organization name for github.com URLs' do
+            url = 'https://github.com/segiddins/banana.git'
+            @sources_manager.send(:name_for_url, url).should == 'segiddins'
+          end
+
+          it 'uses a combination of host and path for other URLs' do
+            url = 'https://sourceforge.org/Artsy/Specs.git'
+            @sources_manager.send(:name_for_url, url).
+              should == 'sourceforge-artsy-specs'
+          end
+
+          it 'supports scp-style URLs' do
+            url = 'git@git-host.com:specs.git'
+            @sources_manager.send(:name_for_url, url).
+              should == 'git-host-specs'
+
+            url = 'git@git-host.com/specs.git'
+            @sources_manager.send(:name_for_url, url).
+              should == 'git-host-specs'
+
+            url = 'git@git-host.com:/specs.git'
+            @sources_manager.send(:name_for_url, url).
+              should == 'git-host-specs'
+          end
+
+          it 'supports ssh URLs with an aliased hostname' do
+            url = 'ssh://user@companyalias/pod-specs'
+            @sources_manager.send(:name_for_url, url).
+              should == 'companyalias-pod-specs'
+          end
+
+          it 'supports file URLs' do
+            url = 'file:///Users/kurrytran/pod-specs'
+            @sources_manager.send(:name_for_url, url).
+              should == 'users-kurrytran-pod-specs'
+          end
+
+          it 'uses the repo name if no parent directory' do
+            url = 'file:///pod-specs'
+            @sources_manager.send(:name_for_url, url).
+              should == 'pod-specs'
+          end
+
+          it 'supports ssh URLs with no user component' do
+            url = 'ssh://company.com/pods/specs.git'
+            @sources_manager.send(:name_for_url, url).
+              should == 'company-pods-specs'
+          end
+
+          it 'appends a number to the name if the base name dir exists' do
+            url = 'https://github.com/segiddins/banana.git'
+            Pathname.any_instance.stubs(:exist?).
+              returns(true).then.returns(false)
+            @sources_manager.send(:name_for_url, url).should == 'segiddins-1'
+
+            url = 'https://sourceforge.org/Artsy/Specs.git'
+            Pathname.any_instance.stubs(:exist?).
+              returns(true).then.returns(false)
+            @sources_manager.send(:name_for_url, url).
+              should == 'sourceforge-artsy-specs-1'
+          end
+        end
+      end
+    end
+
+    #-------------------------------------------------------------------------#
+
+    describe 'Updating Sources' do
+      before do
+        MasterSource.any_instance.stubs(:requires_update?).returns(true)
+      end
+
+      it 'updates search index for changed paths if source is updated' do
+        prev_index = { @test_source.name => {} }
+        @sources_manager.expects(:stored_search_index).returns(prev_index)
+
+        @sources_manager.expects(:save_search_index).with do |value|
+          value[@test_source.name]['BananaLib'].should.include(:BananaLib)
+          value[@test_source.name]['JSONKit'].should.include(:JSONKit)
+        end
+        changed_paths = { @test_source => %w(Specs/BananaLib/1.0/BananaLib.podspec Specs/JSONKit/1.4/JSONKit.podspec) }
+        @sources_manager.update_search_index_if_needed(changed_paths)
+      end
+
+      it 'does not update search index if it does not contain source even if there are changes in source' do
+        prev_index = {}
+        @sources_manager.expects(:stored_search_index).returns(prev_index)
+
+        @sources_manager.expects(:save_search_index).with do |value|
+          value[@test_source.name].should.be.nil
+        end
+        changed_paths = { @test_source => %w(Specs/BananaLib/1.0/BananaLib.podspec Specs/JSONKit/1.4/JSONKit.podspec) }
+        @sources_manager.update_search_index_if_needed(changed_paths)
+      end
+    end
+
+    #-------------------------------------------------------------------------#
+
+    describe 'Master repo' do
+      it 'returns the master repo dir' do
+        @sources_manager.master_repo_dir.to_s.should.match %r{fixtures/spec-repos/master}
+      end
+
+      it 'returns an empty array for master sources when the master repo has not been set up' do
+        Pathname.any_instance.stubs(:directory?).returns(false)
+        @sources_manager.master.should == []
+      end
+
+      it 'returns whether the master repo is functional' do
+        @sources_manager.master_repo_functional?.should.be.true
+        @sources_manager.stubs(:repos_dir).returns(SpecHelper.temporary_directory)
+        @sources_manager.master_repo_functional?.should.be.false
+      end
+    end
+  end
+end

--- a/spec/source/metadata_spec.rb
+++ b/spec/source/metadata_spec.rb
@@ -1,0 +1,58 @@
+require File.expand_path('../../spec_helper', __FILE__)
+
+module Pod
+  describe Source::Metadata do
+    before do
+      @metadata_hash = {
+        'min' => '0.33.1',
+        'max' => '1.9.9',
+        'last' => CORE_VERSION,
+        'prefix_lengths' => [1, 1, 1],
+        'last_compatible_versions' => ['0.22.0', '0.11.0', '0.20.5'],
+      }
+      @metadata = Source::Metadata.new(@metadata_hash)
+    end
+
+    describe '#initialize' do
+      it 'sets the minimum_cocoapods_version' do
+        @metadata.minimum_cocoapods_version.should == Version.new('0.33.1')
+      end
+
+      it 'sets the maximum_cocoapods_version' do
+        @metadata.maximum_cocoapods_version.should == Version.new('1.9.9')
+      end
+
+      it 'sets the prefix_lengths' do
+        @metadata.prefix_lengths.should == [1, 1, 1]
+      end
+
+      it 'sets the latest_cocoapods_version' do
+        @metadata.latest_cocoapods_version.should == Version.new(CORE_VERSION)
+      end
+
+      it 'sets the last_compatible_versions' do
+        @metadata.last_compatible_versions.should == [
+          Pod::Version.new('0.11.0'),
+          Pod::Version.new('0.20.5'),
+          Pod::Version.new('0.22.0'),
+        ]
+      end
+    end
+
+    describe '#compatible?' do
+      it 'returns whether a repository is compatible' do
+        @metadata = Source::Metadata.new('min' => '0.0.1')
+        @metadata.compatible?('1.0.0').should.be.true
+
+        @metadata = Source::Metadata.new('max' => '999.0')
+        @metadata.compatible?('1.0.0').should.be.true
+
+        @metadata = Source::Metadata.new('min' => '999.0')
+        @metadata.compatible?('1.0.0').should.be.false
+
+        @metadata = Source::Metadata.new('max' => '0.0.1')
+        @metadata.compatible?('1.0.0').should.be.false
+      end
+    end
+  end
+end

--- a/spec/source/metadata_spec.rb
+++ b/spec/source/metadata_spec.rb
@@ -54,5 +54,24 @@ module Pod
         @metadata.compatible?('1.0.0').should.be.false
       end
     end
+
+    describe '#to_hash' do
+      it 'returns a hash representation of the metadata' do
+        @metadata.to_hash.should == {
+          'min' => '0.33.1',
+          'max' => '1.9.9',
+          'last' => '1.0.0.beta.6',
+          'prefix_lengths' => [1, 1, 1],
+          'last_compatible_versions' => ['0.11.0', '0.20.5', '0.22.0'],
+        }
+      end
+
+      it 'excludes missing properties' do
+        @metadata = Source::Metadata.new('min' => '999.0')
+        @metadata.to_hash.should == {
+          'min' => '999.0',
+        }
+      end
+    end
   end
 end

--- a/spec/source_spec.rb
+++ b/spec/source_spec.rb
@@ -200,8 +200,22 @@ module Pod
       end
 
       it 'uses the only fast forward git option' do
-        @source.expects(:`).with { |cmd| cmd.should.include('--ff-only') }
+        @source.expects(:`).with('git checkout master')
+        @source.expects(:`).with('git pull --ff-only 2>&1')
         @source.send :update_git_repo
+      end
+
+      it 'checks out the appropriate branch' do
+        path = @source.repo.join('.git', 'cocoapods_branch')
+        path.dirname.mkpath
+        path.open('w') { |f| f << 'random_branch' }
+        @source.expects(:`).with('git checkout random_branch')
+        @source.expects(:`).with('git pull --ff-only 2>&1')
+        begin
+          @source.send(:update_git_repo)
+        ensure
+          path.delete if path.file?
+        end
       end
 
       it 'uses git diff with name only option' do
@@ -266,6 +280,7 @@ module Pod
 
       it 'only consider directories' do
         File.stubs(:directory?).returns(false)
+        Pathname.any_instance.stubs(:directory?).returns(false)
         @source.pods.should == []
       end
 
@@ -368,5 +383,240 @@ module Pod
     end
 
     #-------------------------------------------------------------------------#
+
+    describe 'with non-empty prefix lengths' do
+      before do
+        @path = fixture('spec-repos/test_prefixed_repo')
+        @source = Source.new(@path)
+      end
+
+      describe '#pods' do
+        it 'returns the available Pods' do
+          @source.pods.should == %w(BananaLib Faulty_spec IncorrectPath JSONKit JSONSpec)
+        end
+
+        it 'returns corresponding pods for given specification paths' do
+          paths = %w(Specs/BananaLib/1.0/BananaLib.podspec)
+          @source.pods_for_specification_paths(paths).should == %w(BananaLib)
+          paths = %w(Specs/monkey/1.0.2/monkey.podspec Specs/JSONKit/1.4/JSONKit.podspec)
+          @source.pods_for_specification_paths(paths).should == %w(monkey JSONKit)
+        end
+      end
+
+      #-------------------------------------------------------------------------#
+
+      describe '#versions' do
+        it 'returns the available versions of a Pod' do
+          @source.versions('JSONKit').map(&:to_s).should == ['999.999.999', '1.13', '1.4']
+        end
+
+        it 'returns nil if the Pod could not be found' do
+          @source.versions('Unknown_Pod').should.be.nil
+        end
+      end
+
+      #-------------------------------------------------------------------------#
+
+      describe '#specification' do
+        it 'returns the specification for the given name and version' do
+          spec = @source.specification('JSONKit', Version.new('1.4'))
+          spec.name.should == 'JSONKit'
+          spec.version.should.to_s == '1.4'
+        end
+      end
+
+      #-------------------------------------------------------------------------#
+
+      describe '#all_specs' do
+        it 'returns all the specifications' do
+          expected = %w(BananaLib IncorrectPath JSONKit JSONSpec)
+          @source.all_specs.map(&:name).sort.uniq.should == expected
+        end
+      end
+
+      #-------------------------------------------------------------------------#
+
+      describe '#set' do
+        it 'returns the set of a given Pod' do
+          set = @source.set('BananaLib')
+          set.name.should == 'BananaLib'
+          set.sources.should == [@source]
+        end
+      end
+
+      #-------------------------------------------------------------------------#
+
+      describe '#pod_sets' do
+        it 'returns all the pod sets' do
+          expected = %w(BananaLib Faulty_spec IncorrectPath JSONKit JSONSpec)
+          @source.pod_sets.map(&:name).sort.uniq.should == expected
+        end
+      end
+
+      #-------------------------------------------------------------------------#
+
+      describe '#search' do
+        it 'searches for the Pod with the given name' do
+          @source.search('BananaLib').name.should == 'BananaLib'
+        end
+
+        it 'matches case' do
+          @source.search('bAnAnAlIb').should.be.nil?
+        end
+
+        describe '#search_by_name' do
+          it 'properly configures the sources of a set in search by name' do
+            sets = @source.search_by_name('monkey', true)
+            sets.count.should == 1
+            set = sets.first
+            set.name.should == 'BananaLib'
+            set.sources.map(&:name).should == %w(test_prefixed_repo)
+          end
+
+          it 'can use regular expressions' do
+            sets = @source.search_by_name('mon[ijk]ey', true)
+            sets.first.name.should == 'BananaLib'
+          end
+        end
+      end
+
+      #-------------------------------------------------------------------------#
+
+      describe '#search_by_name' do
+        it 'supports full text search' do
+          sets = @source.search_by_name('monkey', true)
+          sets.map(&:name).should == ['BananaLib']
+          sets.map(&:sources).should == [[@source]]
+        end
+
+        it 'The search is case insensitive' do
+          pods = @source.search_by_name('MONKEY', true)
+          pods.map(&:name).should == ['BananaLib']
+        end
+
+        it 'supports partial matches' do
+          pods = @source.search_by_name('MON', true)
+          pods.map(&:name).should == ['BananaLib']
+        end
+
+        it "handles gracefully specification which can't be loaded" do
+          should.raise Informative do
+            @source.specification('Faulty_spec', '1.0.0')
+          end.message.should.include 'Invalid podspec'
+
+          should.not.raise do
+            @source.search_by_name('monkey', true)
+          end
+        end
+      end
+
+      #-------------------------------------------------------------------------#
+
+      describe '#fuzzy_search' do
+        it 'is case insensitive' do
+          @source.fuzzy_search('bananalib').name.should == 'BananaLib'
+        end
+
+        it 'matches misspells' do
+          @source.fuzzy_search('banalib').name.should == 'BananaLib'
+        end
+
+        it 'matches suffixes' do
+          @source.fuzzy_search('Lib').name.should == 'BananaLib'
+        end
+
+        it 'returns nil if there is no match' do
+          @source.fuzzy_search('12345').should.be.nil
+        end
+
+        it 'matches abbreviations' do
+          @source.fuzzy_search('BLib').name.should == 'BananaLib'
+        end
+      end
+
+      #-------------------------------------------------------------------------#
+
+      describe 'Representations' do
+        it 'returns the hash representation' do
+          @source.to_hash['BananaLib']['1.0']['name'].should == 'BananaLib'
+        end
+
+        it 'returns the yaml representation' do
+          yaml = @source.to_yaml
+          yaml.should.match /---/
+          yaml.should.match /BananaLib:/
+        end
+      end
+
+      #-------------------------------------------------------------------------#
+
+      describe '#pods' do
+        it 'returns the available Pods' do
+          @source.pods.should == %w(BananaLib Faulty_spec IncorrectPath JSONKit JSONSpec)
+        end
+
+        it "doesn't include the `.` and the `..` dir entries" do
+          @source.pods.should.not.include?('.')
+          @source.pods.should.not.include?('..')
+        end
+
+        it 'only consider directories' do
+          File.stubs(:directory?).returns(false)
+          Pathname.any_instance.stubs(:directory?).returns(false)
+          @source.pods.should == []
+        end
+      end
+
+      #-------------------------------------------------------------------------#
+
+      describe '#versions' do
+        it 'returns the versions for the given Pod' do
+          @source.versions('JSONKit').map(&:to_s).should == ['999.999.999', '1.13', '1.4']
+        end
+
+        it 'returns nil the Pod is unknown' do
+          @source.versions('Unknown_Pod').should.be.nil
+        end
+
+        it 'raises if a non-version-name directory is encountered' do
+          Pathname.any_instance.stubs(:children).returns([Pathname.new('/Hello')])
+          Pathname.any_instance.stubs(:directory?).returns(true)
+          e = lambda { @source.versions('JSONKit') }.should.raise Informative
+          e.message.should.match /Hello/
+          e.message.should.not.match /Malformed version number string/
+        end
+      end
+
+      #-------------------------------------------------------------------------#
+
+      describe '#specification' do
+        it 'returns the specification for the given version of a Pod' do
+          spec = @source.specification('JSONKit', '1.4')
+          spec.name.should == 'JSONKit'
+          spec.version.to_s.should == '1.4'
+        end
+
+        it 'returns nil if the Pod is unknown' do
+          should.raise StandardError do
+            @source.specification('Unknown_Pod', '1.4')
+          end.message.should.match /Unable to find the specification Unknown_Pod/
+        end
+
+        it "raises if the version of the Pod doesn't exists" do
+          should.raise StandardError do
+            @source.specification('JSONKit', '0.99.0')
+          end.message.should.match /Unable to find the specification JSONKit/
+        end
+      end
+
+      #-------------------------------------------------------------------------#
+
+      describe '#specification_path' do
+        it 'returns the path of a specification' do
+          path = @source.specification_path('JSONKit', '1.4')
+          path.to_s.should.end_with?('test_prefixed_repo/Specs/1/3/f/JSONKit/1.4/JSONKit.podspec')
+        end
+      end
+    end
   end
 end

--- a/spec/source_spec.rb
+++ b/spec/source_spec.rb
@@ -229,6 +229,21 @@ module Pod
       end
     end
 
+    #-------------------------------------------------------------------------#
+
+    describe '#verify_compatibility!' do
+      it 'raises while asked to version information of a source if it is not compatible' do
+        @source.stubs(:metadata).returns(Source::Metadata.new('min' => '999.0'))
+        e = lambda { @source.verify_compatibility! }.should.raise Informative
+        e.message.should.match /Update CocoaPods/
+        e.message.should.match /(currently using #{CORE_VERSION})/
+        @source.stubs(:metadata).returns(Source::Metadata.new('max' => '0.0.1'))
+        e = lambda { @source.verify_compatibility! }.should.raise Informative
+        e.message.should.match /Update CocoaPods/
+        e.message.should.match /(currently using #{CORE_VERSION})/
+      end
+    end
+
     # #-------------------------------------------------------------------------#
 
     describe 'Representations' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -62,6 +62,10 @@ module Pod
     end
 
     def self.puts(message)
+      @output << message << "\n"
+    end
+
+    def self.print(message)
       @output << message
     end
 

--- a/spec/spec_helper/temporary_directory.rb
+++ b/spec/spec_helper/temporary_directory.rb
@@ -6,10 +6,11 @@ module SpecHelper
   end
 
   module TemporaryDirectory
+    module_function
+
     def temporary_directory
       ROOT + 'tmp'
     end
-    module_function :temporary_directory
 
     def setup_temporary_directory
       temporary_directory.mkpath
@@ -21,8 +22,8 @@ module SpecHelper
 
     def self.extended(base)
       base.before do
-        teardown_temporary_directory
-        setup_temporary_directory
+        TemporaryDirectory.teardown_temporary_directory
+        TemporaryDirectory.setup_temporary_directory
       end
     end
   end


### PR DESCRIPTION
* [x] CHANGELOG
* [x] Make metadata take a hash with indifferent access?

In doing so, we've migrated `Pod::SourcesManager` from CocoaPods/CocoaPods as a singleton to be a proper class, and also added support for sharded specs directories.

Fixes https://github.com/CocoaPods/CocoaPods/issues/5062.