### PR TITLE
GitHub error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ##### Enhancements
 
-* None.  
+* Improve error message on MasterSource networking errors.
+  [Daniel Tomlinson](https://github.com/DanielTomlinson)
+  [CocoaPods#5175](https://github.com/CocoaPods/CocoaPods/issues/5175)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods-core/github.rb
+++ b/lib/cocoapods-core/github.rb
@@ -96,10 +96,14 @@ module Pod
         'Accept' => 'application/vnd.github.chitauri-preview+sha',
         'If-None-Match' => %("#{commit}"),
       }
-      response = REST.get(request_url, headers)
-      code = response.status_code
 
-      code != 304
+      begin
+        response = REST.get(request_url, headers)
+        code = response.status_code
+        code != 304
+      rescue
+        raise Informative, "Failed to connect to GitHub to update the #{repo_id} specs repo - Please check if you are offline, or that GitHub is down"
+      end
     end
 
     private

--- a/spec/master_source_spec.rb
+++ b/spec/master_source_spec.rb
@@ -43,6 +43,12 @@ module Pod
         @source.expects(:`).with { |cmd| cmd.should.include('DUMMY_HASH..HEAD') }.returns('')
         @source.send :diff_until_commit_hash, 'DUMMY_HASH'
       end
+
+      it 'raises if there is a network failure when checking for updates' do
+        WebMock::API.stub_request(:get, '/repos/CocoaPods/Specs/commits/master').to_timeout
+        @source.expects(:update_git_repo).never
+        should.raise(Informative) { @source.send :update, true }
+      end
     end
 
     #-------------------------------------------------------------------------#


### PR DESCRIPTION
Closes https://github.com/CocoaPods/CocoaPods/issues/5175

Not sure if just warning and returning false is correct, because at that point it's an actual failure of `pod repo update`