### PR TITLE
Update docs for build configurations

### DIFF
--- a/lib/cocoapods-core/podfile/dsl.rb
+++ b/lib/cocoapods-core/podfile/dsl.rb
@@ -117,12 +117,6 @@ module Pod
       #
       # ### Build configurations
       #
-      # *IMPORTANT*: the following syntax is tentative and might change without
-      # notice in future. This feature is released in this state due to
-      # the strong demand for it. You can use it but you might need to change
-      # your Podfile to use future versions of CocoaPods. Anyway a clear and
-      # simple upgrade path will be provided.
-      #
       # By default dependencies are installed in all the build configurations
       # of the target. For debug purposes or for other reasons, they can be
       # only enabled on a list of build configurations.

--- a/lib/cocoapods-core/podfile/dsl.rb
+++ b/lib/cocoapods-core/podfile/dsl.rb
@@ -128,6 +128,10 @@ module Pod
       #
       #     pod 'PonyDebugger', :configuration => 'Debug'
       #
+      # Note that transitive dependencies are included in all configurations,
+      # you have to manually specify build configurations for them as well in
+      # case this is not desired.
+      #
       # ------
       #
       # ### Subspecs


### PR DESCRIPTION
This removes an old remark that shouldn't be there anymore considering 1.0 and adds a new one on the handling of transitive dependencies when using build configurations.