### PR TITLE
Improved warning message for DSL attribute renaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ##### Enhancements
 
-* None.  
+* Improved warning message for the renaming of `xcodeproj` to `project` in the `Podfile` DSL.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#327](https://github.com/CocoaPods/Core/pull/327)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods-core/podfile/dsl.rb
+++ b/lib/cocoapods-core/podfile/dsl.rb
@@ -513,7 +513,7 @@ module Pod
       # For pre-1.0 versions use `xcodeproj`.
       #
       def xcodeproj(*args)
-        CoreUI.warn 'xcodeproj was renamed to `project`. Please use that from now on.'
+        CoreUI.warn '`xcodeproj` was renamed to `project`. Please update your Podfile accordingly.'
         project(*args)
       end
 

--- a/spec/podfile/dsl_spec.rb
+++ b/spec/podfile/dsl_spec.rb
@@ -481,7 +481,7 @@ module Pod
         podfile = Podfile.new { xcodeproj 'App.xcodeproj', 'Test' => :debug }
         podfile.target_definitions['Pods'].user_project_path.should == 'App.xcodeproj'
         podfile.target_definitions['Pods'].build_configurations.should == { 'Test' => :debug }
-        CoreUI.warnings.should == 'xcodeproj was renamed to `project`. Please use that from now on.'
+        CoreUI.warnings.should == '`xcodeproj` was renamed to `project`. Please update your Podfile accordingly.'
       end
     end
 


### PR DESCRIPTION
A lot of my coworkers and friends saw the "xcodeproj was renamed to project" warning but thought it was a warning inside CocoaPods' own code, like some warning aimed at us and that we'd have to fix in the future.

They didn't understand that it was meant to suggest that **they** should update their `Podfile` to fix it. Hence that new message to make things clearer.