### PR TITLE
Removed reference of OS_OBJECT_USE_OBJC from deployment_target doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Improved warning message for the renaming of `xcodeproj` to `project` in the `Podfile` DSL.  
   [Olivier Halligon](https://github.com/AliSoftware)
   [#327](https://github.com/CocoaPods/Core/pull/327)
+* Improved documentation of the `deployment_target` attribute in the `Podspec` DSL.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#329](https://github.com/CocoaPods/Core/pull/329)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -524,36 +524,9 @@ module Pod
 
       # The minimum deployment targets of the supported platforms.
       #
-      # ---
-      #
-      # The following behavior is regarding the use of GCD and the
-      # `OS_OBJECT_USE_OBJC` flag. When set to `0`, it will allow code to use
-      # `dispatch_release()` on >= iOS 6.0 and OS X >= 10.8.
-      #
-      # * New libraries that do *not* require ARC don’t need to care about this
-      #   issue at all.
-      #
-      # * New libraries that *do* require ARC _and_ have a deployment target of
-      #   >= iOS 6.0 or OS X >= 10.8:
-      #
-      #   These *no longer* use `dispatch_release()` and should have the
-      #   `OS_OBJECT_USE_OBJC` flag set to `1`.
-      #
-      #   **Note:** this means that these libraries *have* to specify the
-      #             deployment target in their specifications in order to have
-      #             CocoaPods set the flag to `1` and ensure proper behaviour.
-      #
-      # * New libraries that *do* require ARC, but have a deployment target of
-      #   < iOS 6.0 or OS X < 10.8:
-      #
-      #   These contain `dispatch_release()` calls and as such need the
-      #   `OS_OBJECT_USE_OBJC` flag set to `0`.
-      #
-      #   **Note:** libraries that do *not* specify a platform version are
-      #             assumed to have a deployment target of < iOS 6.0 or OS X < 10.8.
-      #
-      #  For more information, see: http://opensource.apple.com/source/libdispatch/libdispatch-228.18/os/object.h
-      #
+      # As opposed to the `platform` attribute, the `deployment_target`
+      # attribute allows to specify multiple platforms on which this pod
+      # is supported — specifying a different deployment target for each.
       #
       # @example
       #


### PR DESCRIPTION
to reduce doc pollution, as discussed in Slack.