### PR TITLE
Add missing space to not-found message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@
 * Improved warning message for the renaming of `xcodeproj` to `project` in the `Podfile` DSL.  
   [Olivier Halligon](https://github.com/AliSoftware)
   [#327](https://github.com/CocoaPods/Core/pull/327)
+
 * Improved documentation of the `deployment_target` attribute in the `Podspec` DSL.  
   [Olivier Halligon](https://github.com/AliSoftware)
   [#329](https://github.com/CocoaPods/Core/pull/329)
+
+* Add missing space to not-found message.  
+  [Boris Bügling](https://github.com/neonichu)
+  [#330](https://github.com/CocoaPods/Core/pull/330)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods-core/source/manager.rb
+++ b/lib/cocoapods-core/source/manager.rb
@@ -135,7 +135,7 @@ module Pod
         end
         if sets.empty?
           extra = ', author, summary, or description' if full_text_search
-          raise Informative, "Unable to find a pod with name#{extra}" \
+          raise Informative, "Unable to find a pod with name#{extra} " \
             "matching `#{query}`"
         end
         sorted_sets(sets, query_word_regexps)


### PR DESCRIPTION
Before:

```
$ pod search foobar
[!] Unable to find a pod with name, author, summary, or descriptionmatching `foobar`
```

After:

```
$ pod search foobar
[!] Unable to find a pod with name, author, summary, or description matching `foobar`
```