### PR TITLE
[docs] example on main Podfile section is invalid

### DIFF
--- a/lib/cocoapods-core/podfile/dsl.rb
+++ b/lib/cocoapods-core/podfile/dsl.rb
@@ -27,7 +27,7 @@ module Pod
     #     end
     #
     #     post_install do |installer|
-    #       installer.pods_project.pod_targets.each do |target|
+    #       installer.pods_project.targets.each do |target|
     #         puts "#{target.name}"
     #       end
     #     end


### PR DESCRIPTION
🌈

There is a discrepancy between the example for post_hook and the "complex" example on the main Podfile Syntax Reference