### PR TITLE
Change dsl docs to reflect changes to pods_project

### DIFF
--- a/lib/cocoapods-core/podfile/dsl.rb
+++ b/lib/cocoapods-core/podfile/dsl.rb
@@ -27,7 +27,7 @@ module Pod
     #     end
     #
     #     post_install do |installer|
-    #       installer.pods_project.pod_targets.each do |target|
+    #       installer.pods_project.targets.each do |target|
     #         puts "#{target.name}"
     #       end
     #     end


### PR DESCRIPTION
Hey,

I was looking at putting a `post_install` hook on a podfile and reading the docs [here](https://guides.cocoapods.org/syntax/podfile.html#podfile) I used:

```ruby
post_install do |installer|
  installer.pods_project.pod_targets.each do |target|
    puts "#{target.name}"
  end
end
```

But got:

```
[!] An error occurred while processing the post-install hook of the Podfile.

undefined method `pod_targets' for #<Pod::Project:0x007fddbb1efc58>

/Users/k.miller/work/01-Mobile/pod-nap-searchService/Example/Podfile:13:in `block (2 levels) in from_ruby'
/Library/Ruby/Gems/2.0.0/gems/cocoapods-core-1.0.1/lib/cocoapods-core/podfile.rb:180:in `call'
/Library/Ruby/Gems/2.0.0/gems/cocoapods-core-1.0.1/lib/cocoapods-core/podfile.rb:180:in `post_install!'
/Library/Ruby/Gems/2.0.0/gems/cocoapods-1.0.1/lib/cocoapods/installer.rb:823:in `run_podfile_post_install_hook'
/Library/Ruby/Gems/2.0.0/gems/cocoapods-1.0.1/lib/cocoapods/installer.rb:811:in `block in run_podfile_post_install_hooks'
/Library/Ruby/Gems/2.0.0/gems/cocoapods-1.0.1/lib/cocoapods/user_interface.rb:141:in `message'
/Library/Ruby/Gems/2.0.0/gems/cocoapods-1.0.1/lib/cocoapods/installer.rb:810:in `run_podfile_post_install_hooks'
/Library/Ruby/Gems/2.0.0/gems/cocoapods-1.0.1/lib/cocoapods/installer.rb:172:in `block in generate_pods_project'
/Library/Ruby/Gems/2.0.0/gems/cocoapods-1.0.1/lib/cocoapods/user_interface.rb:63:in `section'
/Library/Ruby/Gems/2.0.0/gems/cocoapods-1.0.1/lib/cocoapods/installer.rb:167:in `generate_pods_project'
/Library/Ruby/Gems/2.0.0/gems/cocoapods-1.0.1/lib/cocoapods/installer.rb:119:in `install!'
/Library/Ruby/Gems/2.0.0/gems/cocoapods-1.0.1/lib/cocoapods/command/install.rb:37:in `run'
/Library/Ruby/Gems/2.0.0/gems/claide-1.0.0/lib/claide/command.rb:334:in `run'
/Library/Ruby/Gems/2.0.0/gems/cocoapods-1.0.1/lib/cocoapods/command.rb:50:in `run'
/Library/Ruby/Gems/2.0.0/gems/cocoapods-1.0.1/bin/pod:55:in `<top (required)>'
/usr/local/bin/pod:23:in `load'
/usr/local/bin/pod:23:in `<main>'
```

Looks like the `pod_targets` method no longer exists and is replaced by `targets`. This (hopefully) changes the documentation for the website to reflect that.

Cheers