### PR TITLE
Improved handling of Semver pre-release versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ##### Enhancements
 
-* None.  
+* Improved comparison between Semver pre-release versions.  
+  [Ben Asher](https://github.com/benasher44)
+  [#350](https://github.com/CocoaPods/Core/pull/350)
 
 ##### Bug Fixes
 

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -95,6 +95,13 @@ module Pod
         Version.new('1.alpha.2').patch.should == 0
       end
 
+      it 'correctly makes basic version comparisons' do
+        Version.new('1.0.0').should.be < Version.new('2.0.0')
+        Version.new('1.0.0').should.be < Version.new('1.0.1')
+        Version.new('1.0.0').should.be < Version.new('1.1.0')
+        Version.new('1.1.0').should.be < Version.new('1.1.1')
+      end
+
       it 'ignores missing numeric identifiers while comparing' do
         Version.new('1.9.0-alpha').should.be < Version.new('1.9-beta')
         Version.new('2.0.0-beta').should.be < Version.new('2.0-rc')
@@ -106,6 +113,20 @@ module Pod
         Version.new('1.0').should.be < Version.new('1.0.0')
         Version.new('1.0-alpha').should.be < Version.new('1.0.0-alpha')
         Version.new('1.1.1.1-alpha').should.be < Version.new('1.1.1.1.0-alpha')
+      end
+
+      it 'Follows semver when comparing between pre-release versions' do
+        # Example from section 11 on semver.org
+        Version.new('1.0.0-alpha').should.be < Version.new('1.0.0-alpha.1')
+        Version.new('1.0.0-alpha.1').should.be < Version.new('1.0.0-alpha.beta')
+        Version.new('1.0.0-alpha.beta').should.be < Version.new('1.0.0-beta')
+        Version.new('1.0.0-beta').should.be < Version.new('1.0.0-beta.2')
+        Version.new('1.0.0-beta.2').should.be < Version.new('1.0.0-beta.11')
+        Version.new('1.0.0-beta.11').should.be < Version.new('1.0.0-rc.1')
+        Version.new('1.0.0-rc.1').should.be < Version.new('1.0.0')
+
+        # Example from CocoaPods/CocoaPods#5718
+        Version.new('1.0-beta.8').should.be < Version.new('1.0-beta.8a')
       end
     end
 


### PR DESCRIPTION
Fixes CocoaPods/CocoaPods#5718

- Handle special case of missing first segment of pre-release segments (doesn't mean it wasn't handled before, just calling out this part in the diff)
- Updated according to [Semver's predence spec](http://semver.org/#spec-item-11) (item 11 if it doesn't link you straight there):

> Numeric identifiers always have lower precedence than non-numeric identifiers.
