### PR TITLE
Cache result of Podfile dependencies

### DIFF
--- a/lib/cocoapods-core/podfile.rb
+++ b/lib/cocoapods-core/podfile.rb
@@ -87,7 +87,8 @@ module Pod
     #         definitions.
     #
     def dependencies
-      target_definition_list.map(&:dependencies).flatten.uniq
+      return @podfile_dependencies if defined? @podfile_dependencies
+      @podfile_dependencies = target_definition_list.map(&:dependencies).flatten.uniq
     end
 
     #-------------------------------------------------------------------------#


### PR DESCRIPTION
This is probably the final caching improvement we found for reducing our `pod install` time.

It seems that with a large number of pods in a `Podfile` things can get slow. This caching improves `pod install` by about 10%.

@orta @benasher44 @neonichu @segiddins my only question to you is if you can think of any cases where the dependencies in a `Podfile` instance can ever change and so caching should be invalidated or most probably be removed entirely.

FYI our series of changes have caused our `pod install` time overall to drop from 1m 40seconds to about 30seconds a huge improvement and makes working on a large project much better.