### PR TITLE
Raise an error if `inherit!` is used on an abstract target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 ##### Bug Fixes
 
-* None.  
+* Raise an error if `inherit!` is used on an abstract target.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#5342](https://github.com/CocoaPods/CocoaPods/issues/5342)
 
 
 ## 1.2.0.beta.1 (2016-10-28)

--- a/lib/cocoapods-core/podfile/target_definition.rb
+++ b/lib/cocoapods-core/podfile/target_definition.rb
@@ -193,6 +193,9 @@ module Pod
         if root?
           raise Informative, 'Cannot set inheritance for the root target definition.'
         end
+        if abstract?
+          raise Informative, 'Cannot set inheritance for abstract target definition.'
+        end
         set_hash_value('inheritance', inheritance)
       end
 

--- a/spec/podfile/target_definition_spec.rb
+++ b/spec/podfile/target_definition_spec.rb
@@ -8,6 +8,8 @@ module Pod
       @parent = Podfile::TargetDefinition.new('MyApp', @root)
       @child = Podfile::TargetDefinition.new('MyAppTests', @parent)
       @child.inheritance = :search_paths
+      @abstract = Podfile::TargetDefinition.new('MyAbstractTarget', @root)
+      @abstract.abstract = true
       @parent.set_platform(:ios, '6.0')
     end
 
@@ -153,6 +155,11 @@ module Pod
       it 'raises when setting an inheritance mode on a root target definition' do
         exception = should.raise(Informative) { @root.inheritance = :none }
         exception.message.should == 'Cannot set inheritance for the root target definition.'
+      end
+
+      it 'raises when setting an inheritance mode on a abstract target definition' do
+        exception = should.raise(Informative) { @abstract.inheritance = :none }
+        exception.message.should == 'Cannot set inheritance for abstract target definition.'
       end
 
       #--------------------------------------#
@@ -431,6 +438,7 @@ module Pod
         @child.set_platform(:ios)
         @child.to_hash.should == {
           'name' => 'MyAppTests',
+          'abstract' => false,
           'inheritance' => 'search_paths',
           'dependencies' => ['BlocksKit'],
           'platform' => 'ios',
@@ -448,6 +456,7 @@ module Pod
           'children' => [
             {
               'name' => 'MyAppTests',
+              'abstract' => false,
               'inheritance' => 'search_paths',
               'dependencies' => ['RestKit'],
             },

--- a/spec/podfile_spec.rb
+++ b/spec/podfile_spec.rb
@@ -217,6 +217,7 @@ module Pod
                   'children' => [
                     {
                       'name' => 'test_target',
+                      'abstract' => false,
                       'inheritance' => 'search_paths',
                     },
                   ],


### PR DESCRIPTION
closes https://github.com/CocoaPods/CocoaPods/issues/5342