### PR TITLE
[Pod::Version] Add support for build metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#5180](https://github.com/CocoaPods/CocoaPods/issues/5180)
 
+* Add support for version metadata as specified by http://semver.org/#spec-item-10.  
+  [Danielle Tomlinson](https://github.com/dantoml)
+  [#6224](https://github.com/CocoaPods/CocoaPods/issues/6224)
+
 ##### Bug Fixes
 
 * Raise an error if `inherit!` is used on an abstract target.  

--- a/lib/cocoapods-core/version.rb
+++ b/lib/cocoapods-core/version.rb
@@ -30,12 +30,14 @@ module Pod
   # 4. 0.9
   #
   class Version < Pod::Vendor::Gem::Version
-    # Override the constants defined by the superclass to add Semantic
-    # Versioning prerelease support (with a dash). E.g.: 1.0.0-alpha1
+    # Override the constants defined by the superclass to add:
+    # - Semantic Versioning prerelease support (with a dash). E.g.: 1.0.0-alpha1
+    # - Semantic Versioning metadata support (with a +) E.g: 1.0.0+96ef7ed
     #
     # For more info, see: http://semver.org
     #
-    VERSION_PATTERN = '[0-9]+(\.[0-9a-zA-Z\-]+)*'
+    METADATA_PATTERN = '(\+[0-9a-zA-Z\-\.]+)'
+    VERSION_PATTERN = "[0-9]+(\\.[0-9a-zA-Z\\-]+)*#{METADATA_PATTERN}?"
     ANCHORED_VERSION_PATTERN = /\A\s*(#{VERSION_PATTERN})*\s*\z/
 
     # @param  [String,Version] version
@@ -86,7 +88,7 @@ module Pod
 
     # @!group Semantic Versioning
 
-    SEMVER_PATTERN = '[0-9]+(\.[0-9]+(\.[0-9]+(-[0-9A-Za-z\-\.]+)?)?)?'
+    SEMVER_PATTERN = "[0-9]+(\\.[0-9]+(\\.[0-9]+(-[0-9A-Za-z\\-\\.]+)?#{METADATA_PATTERN}?)?)?"
     ANCHORED_SEMANTIC_VERSION_PATTERN = /\A\s*(#{SEMVER_PATTERN})*\s*\z/
 
     # @return [Bool] Whether the version conforms to the Semantic Versioning
@@ -181,6 +183,19 @@ module Pod
     end
 
     protected
+
+    # This overrides the Gem::Version implementation of `_segments` to drop the
+    # metadata from comparisons as per http://semver.org/#spec-item-10
+    #
+    def _segments
+      # segments is lazy so it can pick up version values that come from
+      # old marshaled versions, which don't go through marshal_load.
+      # since this version object is cached in @@all, its @segments should be frozen
+
+      @segments ||= @version.sub(/#{METADATA_PATTERN}$/, '').scan(/[0-9]+|[a-z]+/i).map do |s|
+        /^\d+$/ =~ s ? s.to_i : s
+      end.freeze
+    end
 
     def numeric_segments
       segments.take_while { |s| s.is_a?(Numeric) }.reverse_each.drop_while { |s| s == 0 }.reverse

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -66,6 +66,13 @@ module Pod
         Version.new('1.0.0-x.7.z.92').should.be.semantic
       end
 
+      it 'reports a version with metadata as semantic' do
+        # Examples from http://semver.org/#spec-item-10
+        Version.new('1.0.0+5').should.be.semantic
+        Version.new('1.0.0+5114f85').should.be.semantic
+        Version.new('1.0.0-alpha+exp.sha.5114f85').should.be.semantic
+      end
+
       it 'reports version with more than 3 segments not separated by a dash as non semantic' do
         Version.new('1.0.2.3').should.not.be.semantic
       end
@@ -102,6 +109,13 @@ module Pod
         Version.new('1.1.0').should.be < Version.new('1.1.1')
       end
 
+      it 'correctly ignores metadata in comparisons' do
+        Version.new('1.0.0+fff').should == Version.new('1.0.0')
+        Version.new('1.0.0+fff').should == Version.new('1.0.0+000')
+        Version.new('1.0.0-beta.1+fff').should == Version.new('1.0.0-beta.1+000')
+        Version.new('1.1.0+fff').should.be < Version.new('1.1.1+fff')
+      end
+
       it 'ignores missing numeric identifiers while comparing' do
         Version.new('1.9.0-alpha').should.be < Version.new('1.9-beta')
         Version.new('2.0.0-beta').should.be < Version.new('2.0-rc')
@@ -124,6 +138,8 @@ module Pod
         Version.new('1.0.0-beta.2').should.be < Version.new('1.0.0-beta.11')
         Version.new('1.0.0-beta.11').should.be < Version.new('1.0.0-rc.1')
         Version.new('1.0.0-rc.1').should.be < Version.new('1.0.0')
+
+        Version.new('1.0.0-beta+fff').should == Version.new('1.0.0-beta+000')
 
         # Example from CocoaPods/CocoaPods#5718
         Version.new('1.0-beta.8').should.be < Version.new('1.0-beta.8a')


### PR DESCRIPTION
closes https://github.com/CocoaPods/CocoaPods/issues/6224
implemented as per the specification: http://semver.org/#spec-item-10

Fortunately this doesn't actually effect comparison, so is a reasonably easy
change to make by dropping it from comparable segments, but maintaining it for
display.