### PR TITLE
Strip newlines for Specification#version

### DIFF
--- a/lib/cocoapods-core/specification.rb
+++ b/lib/cocoapods-core/specification.rb
@@ -615,7 +615,7 @@ module Pod
     #
     def version=(version)
       @hash_value = nil
-      attributes_hash['version'] = version
+      store_attribute(:version, version)
       @version = nil
     end
 

--- a/spec/specification_spec.rb
+++ b/spec/specification_spec.rb
@@ -79,6 +79,15 @@ module Pod
         hash[spec_1].should == 'VALUE_2'
       end
 
+      it 'strips newlines from versions' do
+        spec = Spec.new do |s|
+          s.name = 'Pod'
+          s.version = "1.2.0\n"
+        end
+
+        spec.to_hash['version'].should == '1.2.0'
+      end
+
       it 'resets hash value when name changes' do
         @spec.hash_value.should.be.nil?
         original_hash = @spec.hash


### PR DESCRIPTION
Ensures that newlines are stripped for `Specification#version`. This was a regression in #358 that broke CocoaPods/CocoaPods integration tests with `RealmSwift.podspec`.