### PR TITLE
[Linter] Check for presence of `summary` when validating descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 
 ##### Bug Fixes
 
-* None.  
+* Prevent crashing When a `Specification` has a `description` but no `summary`.  
+  [Danielle Tomlinson](https://github.com/dantoml)
+  [#6360](https://github.com/CocoaPods/CocoaPods/issues/6360)
 
 
 ## 1.2.0.beta.3 (2016-12-28)

--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -251,7 +251,7 @@ module Pod
 
         if d.strip.empty?
           results.add_error('description', 'The description is empty.')
-        elsif d.length < spec.summary.length
+        elsif spec.summary && d.length < spec.summary.length
           results.add_warning('description', 'The description is shorter ' \
           'than the summary.')
         end

--- a/spec/specification/linter_spec.rb
+++ b/spec/specification/linter_spec.rb
@@ -268,6 +268,12 @@ module Pod
         result_should_include('description', 'shorter', 'summary')
       end
 
+      it 'does not crash when there is a description but no summary' do
+        @spec.stubs(:description).returns('sample.')
+        @spec.stubs(:summary).returns(nil)
+        lambda { @linter.lint }.should.not.raise
+      end
+
       #------------------#
 
       it 'checks if the homepage has been changed from default' do


### PR DESCRIPTION
This fixes a crash when there is a `description` but no `summary`.

closes https://github.com/cocoapods/cocoapods/issues/6360