### PR TITLE
Introduce `test_specification` DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 ##### Enhancements
 
-* None.  
+* Introduce `test_specification` DSL  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [Kyle Fuller](https://github.com/kylef)
+  [#369](https://github.com/CocoaPods/Core/pull/369)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods-core/specification/consumer.rb
+++ b/lib/cocoapods-core/specification/consumer.rb
@@ -136,6 +136,14 @@ module Pod
 
       #-----------------------------------------------------------------------#
 
+      # @!group Test Support
+
+      # @return [Symbol] the test type supported by this Pod.
+      #
+      spec_attr_accessor :test_type
+
+      #-----------------------------------------------------------------------#
+
       # @!group File patterns
 
       # @return [Array<String>] the source files of the Pod.

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -1324,6 +1324,47 @@ module Pod
         subspec
       end
 
+      # The list of the test types currently supported.
+      #
+      SUPPORTED_TEST_TYPES = [:unit].freeze
+
+      # The test type this specification supports. This only applies to test specifications.
+      #
+      # ---
+      #
+      # @example
+      #
+      #   test_spec.test_type = :unit
+      #
+      # @param  [Symbol] type
+      #         The test type to use.
+      attribute :test_type,
+                :default_value => :unit,
+                :types => [Symbol],
+                :multi_platform => false
+
+      # Represents a test specification for the library. Here you can place all
+      # your tests for your podspec along with the test dependencies.
+      #
+      # ---
+      #
+      # @example
+      #
+      #   Pod::Spec.new do |spec|
+      #     spec.name = 'NSAttributedString+CCLFormat'
+      #
+      #     spec.test_spec do |test_spec|
+      #       test_spec.source_files = 'NSAttributedString+CCLFormatTests.m'
+      #       test_spec.dependency 'Expecta'
+      #     end
+      #   end
+      #
+      def test_spec(name = 'Tests', &block)
+        subspec = Specification.new(self, name, true, &block)
+        @subspecs << subspec
+        subspec
+      end
+
       #------------------#
 
       # @!method default_subspecs=(subspec_array)

--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -128,7 +128,7 @@ module Pod
         run_validation_hooks(attributes, spec)
       end
 
-      # Run validations for multi-platform attributes activating .
+      # Run validations for multi-platform attributes activating.
       #
       # @return [void]
       #
@@ -362,6 +362,12 @@ module Pod
           results.add_error('deprecated_in_favor_of', 'a spec cannot be ' \
             'deprecated in favor of itself')
         end
+      end
+
+      def _validate_test_type(t)
+        supported_test_types = Specification::DSL::SUPPORTED_TEST_TYPES
+        results.add_error('test_type', "The test type `#{t}` is not supported. " \
+          "Supported test type values are #{supported_test_types}.") unless supported_test_types.include?(t)
       end
 
       # Performs validations related to github sources.

--- a/spec/specification/consumer_spec.rb
+++ b/spec/specification/consumer_spec.rb
@@ -246,6 +246,13 @@ module Pod
         @spec.header_mappings_dir = 'src/include'
         @subspec_consumer.header_mappings_dir.should == 'src/include'
       end
+
+      #------------------#
+
+      it 'allows to specify the test type' do
+        @subspec.test_type = :unit
+        @subspec_consumer.test_type.should == :unit
+      end
     end
 
     #-------------------------------------------------------------------------#

--- a/spec/specification/dsl_spec.rb
+++ b/spec/specification/dsl_spec.rb
@@ -368,6 +368,27 @@ module Pod
 
     #-----------------------------------------------------------------------------#
 
+    describe 'Test specs' do
+      before do
+        @spec = Spec.new do |spec|
+          spec.name = 'Spec'
+          spec.test_spec do |test_spec|
+            test_spec.test_type = :unit
+          end
+        end
+      end
+
+      it 'allows you to specify a test spec' do
+        test_spec = @spec.subspecs.first
+        test_spec.class.should == Specification
+        test_spec.name.should == 'Spec/Tests'
+        test_spec.test_specification?.should == true
+        test_spec.test_type.should == :unit
+      end
+    end
+
+    #-----------------------------------------------------------------------------#
+
     describe 'Multi-Platform' do
       before do
         @spec = Spec.new do |s|

--- a/spec/specification/linter_spec.rb
+++ b/spec/specification/linter_spec.rb
@@ -253,6 +253,19 @@ module Pod
 
       #------------------#
 
+      it 'checks the test type' do
+        podspec = 'Pod::Spec.new do |s|; s.test_spec do |ts|; ts.test_type = :unknown; end end'
+        path = SpecHelper.temporary_directory + 'BananaLib.podspec'
+        File.open(path, 'w') { |f| f.write(podspec) }
+        linter = Specification::Linter.new(path)
+        linter.lint
+        results = linter.results
+        test_type_error = results.find { |result| result.to_s.downcase.include?('test_type') }
+        test_type_error.message.should.include?('The test type `unknown` is not supported.')
+      end
+
+      #------------------#
+
       it 'checks if the description is not an empty string' do
         @spec.stubs(:description).returns('')
         result_should_include('description', 'empty')

--- a/spec/specification_spec.rb
+++ b/spec/specification_spec.rb
@@ -217,23 +217,30 @@ module Pod
           s.name = 'Pod'
           s.subspec 'Subspec' do |_sp|
           end
+          s.test_spec do |_tsp|
+          end
         end
         @subspec = @spec.subspecs.first
+        @test_subspec = @spec.test_specs.first
       end
 
       it 'returns the root spec' do
         @spec.root.should == @spec
         @subspec.root.should == @spec
+        @test_subspec.root.should == @spec
       end
 
       it 'returns whether it is a root spec' do
         @spec.root?.should.be.true
         @subspec.root?.should.be.false
+        @test_subspec.root?.should.be.false
       end
 
       it 'returns whether it is a subspec' do
         @spec.subspec?.should.be.false
         @subspec.subspec?.should.be.true
+        @test_subspec.subspec?.should.be.true
+        @test_subspec.test_specification?.should.be.true
       end
     end
 
@@ -271,6 +278,17 @@ module Pod
       it 'returns a subspec given the absolute name' do
         @spec.subspec_by_name('Pod/Subspec').should == @subspec
         @spec.subspec_by_name('Pod/Subspec/Subsubspec').should == @subsubspec
+      end
+
+      it "doesn't return the test subspec given the Tests name" do
+        @spec = Spec.new do |s|
+          s.name = 'Pod'
+          s.version = '1.0'
+          s.dependency 'AFNetworking'
+          s.osx.dependency 'MagicalRecord'
+          s.test_spec {}
+        end
+        @spec.subspec_by_name('Pod/Tests', false).should. nil?
       end
 
       it 'returns a subspec given the relative name' do
@@ -327,10 +345,27 @@ module Pod
         ]
       end
 
+      it 'excludes the test subspec from the subspec dependencies' do
+        @spec.test_spec {}
+        @spec.subspec_dependencies.sort.should == [
+          Dependency.new('Pod/Subspec', '1.0'),
+          Dependency.new('Pod/SubspecOSX', '1.0'),
+          Dependency.new('Pod/SubspeciOS', '1.0')]
+      end
+
       it 'returns all the dependencies' do
         @spec.dependencies.sort.should == [
           Dependency.new('AFNetworking'),
           Dependency.new('MagicalRecord')]
+      end
+
+      it 'returns the test spec dependencies' do
+        test_spec = @spec.test_spec { |s| s.dependency 'OCMock' }
+        test_spec.dependencies.sort.should == [
+          Dependency.new('AFNetworking'),
+          Dependency.new('MagicalRecord'),
+          Dependency.new('OCMock'),
+        ]
       end
 
       it 'returns the dependencies given the platform' do


### PR DESCRIPTION
I'd like to re-open the "project" for adding test support to CocoaPods. 

We have 100s of projects that we typically end up having to include a `<ProjectName>Tests.xcodeproj` that includes all of our test sources and a `Podfile` that integrates it with the pod locally.

I've chatted with @orta and @benasher44 on bringing this back. It would be awesome for podspecs to become more self-contained and when consumed as development pods the `Pods.xcodeproj` can create a test bundle target to include test sources so you can run them.

We are also heavy users of development pods in our main project causing us to create multiple xcodeproj just to support our tests for pods we will never publish which also complicates CI further.

This is the first PR that brings back the DSL to include a `test_spec`.

We won't be going super advanced on this to begin with. Test specs should create a test bundle target in the Pods.xcodeproj and include the test sources. The validator should also be updated to run the tests if a `test_spec` is present before publishing a pod. If no `test_spec` is specified everything should continue to work the way it is today.