### PR TITLE
Ensure test_specification is part of the attributes hash

### DIFF
--- a/lib/cocoapods-core/specification/consumer.rb
+++ b/lib/cocoapods-core/specification/consumer.rb
@@ -138,7 +138,7 @@ module Pod
 
       # @!group Test Support
 
-      # @return [Symbol] the test type supported by this Pod.
+      # @return [Symbol] the test type supported by this specification.
       #
       spec_attr_accessor :test_type
 

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -1339,7 +1339,6 @@ module Pod
       # @param  [Symbol] type
       #         The test type to use.
       attribute :test_type,
-                :default_value => :unit,
                 :types => [Symbol],
                 :multi_platform => false
 

--- a/lib/cocoapods-core/specification/json.rb
+++ b/lib/cocoapods-core/specification/json.rb
@@ -59,6 +59,7 @@ module Pod
       attributes_hash = hash.dup
       subspecs = attributes_hash.delete('subspecs')
       spec.attributes_hash = attributes_hash
+      spec.test_specification = !attributes_hash['test_type'].nil?
       if subspecs
         spec.subspecs = subspecs.map do |s_hash|
           Specification.from_hash(s_hash, spec)

--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -365,6 +365,10 @@ module Pod
       end
 
       def _validate_test_type(t)
+        unless consumer.spec.test_specification?
+          results.add_error('test_type', 'Test type can only be used for test specifications.')
+          return
+        end
         supported_test_types = Specification::DSL::SUPPORTED_TEST_TYPES
         results.add_error('test_type', "The test type `#{t}` is not supported. " \
           "Supported test type values are #{supported_test_types}.") unless supported_test_types.include?(t)

--- a/spec/specification/consumer_spec.rb
+++ b/spec/specification/consumer_spec.rb
@@ -249,9 +249,27 @@ module Pod
 
       #------------------#
 
-      it 'allows to specify the test type' do
-        @subspec.test_type = :unit
-        @subspec_consumer.test_type.should == :unit
+      it 'returns nil for test type for a root spec' do
+        @consumer.test_type.should.be.nil
+      end
+
+      it 'returns nil for test type for subspec' do
+        @subspec_consumer.test_type.should.be.nil
+      end
+
+      it 'returns the default test type for a test subspec' do
+        @spec.test_spec {}
+        test_spec = @spec.test_specs.first
+        test_consumer = Specification::Consumer.new(test_spec, :ios)
+        test_consumer.test_type.should.be == :unit
+      end
+
+      it 'allows to specify the unit test type for a test subspec' do
+        @spec.test_spec {}
+        test_spec = @spec.test_specs.first
+        test_spec.test_type = :unit
+        test_consumer = Specification::Consumer.new(test_spec, :ios)
+        test_consumer.test_type.should.be == :unit
       end
     end
 

--- a/spec/specification/json_spec.rb
+++ b/spec/specification/json_spec.rb
@@ -115,6 +115,18 @@ module Pod
         }]
       end
 
+      it 'writes test type for test subspec' do
+        @spec.test_spec {}
+        hash = @spec.to_hash
+        hash['subspecs'].should == [{
+          'name' => 'GreenBanana',
+          'source_files' => 'GreenBanana',
+        }, {
+          'name' => 'Tests',
+          'test_type' => :unit,
+        }]
+      end
+
       it 'can be loaded from an hash' do
         hash = {
           'name' => 'BananaLib',
@@ -123,6 +135,18 @@ module Pod
         result = Specification.from_hash(hash)
         result.name.should == 'BananaLib'
         result.version.to_s.should == '1.0'
+      end
+
+      it 'can load test specification from hash' do
+        hash = {
+          'name' => 'BananaLib',
+          'version' => '1.0',
+          'subspecs' => [{ 'name' => 'GreenBanana', 'source_files' => 'GreenBanana' }, { 'name' => 'Tests', 'test_type' => :unit }],
+        }
+        result = Specification.from_hash(hash)
+        result.test_specs.count.should.equal 1
+        result.test_specs.first.test_specification?.should.be.true
+        result.test_specs.first.test_type.should.equal :unit
       end
 
       it 'can be safely converted back and forth to a hash' do

--- a/spec/specification/linter_spec.rb
+++ b/spec/specification/linter_spec.rb
@@ -253,7 +253,29 @@ module Pod
 
       #------------------#
 
-      it 'checks the test type' do
+      it 'checks that test type cannot be set at the root spec' do
+        podspec = 'Pod::Spec.new do |s|; s.test_type = :unit; end'
+        path = SpecHelper.temporary_directory + 'BananaLib.podspec'
+        File.open(path, 'w') { |f| f.write(podspec) }
+        linter = Specification::Linter.new(path)
+        linter.lint
+        results = linter.results
+        test_type_error = results.find { |result| result.to_s.downcase.include?('test_type') }
+        test_type_error.message.should == 'Test type can only be used for test specifications.'
+      end
+
+      it 'checks that test type cannot be set for subspecs' do
+        podspec = "Pod::Spec.new do |s|; s.subspec 'subspec' do |ss|; ss.test_type = :unit; end end"
+        path = SpecHelper.temporary_directory + 'BananaLib.podspec'
+        File.open(path, 'w') { |f| f.write(podspec) }
+        linter = Specification::Linter.new(path)
+        linter.lint
+        results = linter.results
+        test_type_error = results.find { |result| result.to_s.downcase.include?('test_type') }
+        test_type_error.message.should == 'Test type can only be used for test specifications.'
+      end
+
+      it 'checks the test type value is correct' do
         podspec = 'Pod::Spec.new do |s|; s.test_spec do |ts|; ts.test_type = :unknown; end end'
         path = SpecHelper.temporary_directory + 'BananaLib.podspec'
         File.open(path, 'w') { |f| f.write(podspec) }

--- a/spec/specification_spec.rb
+++ b/spec/specification_spec.rb
@@ -280,7 +280,7 @@ module Pod
         @spec.subspec_by_name('Pod/Subspec/Subsubspec').should == @subsubspec
       end
 
-      it "doesn't return the test subspec given the Tests name" do
+      it "doesn't return the test subspec given its name" do
         @spec = Spec.new do |s|
           s.name = 'Pod'
           s.version = '1.0'
@@ -289,6 +289,18 @@ module Pod
           s.test_spec {}
         end
         @spec.subspec_by_name('Pod/Tests', false).should. nil?
+      end
+
+      it "does return the test subspec given it's name when including test subspecs" do
+        @spec = Spec.new do |s|
+          s.name = 'Pod'
+          s.version = '1.0'
+          s.dependency 'AFNetworking'
+          s.osx.dependency 'MagicalRecord'
+          s.test_spec {}
+        end
+        test_spec = @spec.test_specs.first
+        @spec.subspec_by_name('Pod/Tests', false, true).should == test_spec
       end
 
       it 'returns a subspec given the relative name' do


### PR DESCRIPTION
I've started a bit of integration with the cocoapods project to add test targets into the project.

So far I've hit a couple of things that are needed to be fixed in the core which are requested here.