### PR TITLE
Apply GitHub checking logic to all GitHub hosted sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ coverage/
 .coveralls.yml
 .idea/
 documentation/
+.bundle/

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,3 +33,8 @@ before_install:
         git remote add origin https://github.com/CocoaPods/Specs.git
       )
       git submodule update --init
+      (
+        cd spec/fixtures/spec-repos/test_repo
+        git init
+        git remote add origin https://bitbucket.com/test/test_repo.git
+      )

--- a/lib/cocoapods-core/github.rb
+++ b/lib/cocoapods-core/github.rb
@@ -131,7 +131,7 @@ module Pod
     # @return [Nil] if the given url is not a valid github repo url.
     #
     def self.repo_id_from_url(url)
-      url[%r{github.com/([^/]*/[^/]*)\.*}, 1]
+      url[%r{github.com[/:]([^/]*/(?:(?!\.git)[^/])*)\.*}, 1]
     end
 
     # Performs a get request with the given URL.

--- a/lib/cocoapods-core/master_source.rb
+++ b/lib/cocoapods-core/master_source.rb
@@ -1,35 +1,7 @@
 module Pod
   class MasterSource < Source
-    # @!group Updating the source
-    #-------------------------------------------------------------------------#
-
-    # Updates the local clone of the source repo.
-    #
-    # @param  [Bool] show_output
-    #
-    # @return  [Array<String>] changed_spec_paths
-    #          Returns the list of changed spec paths.
-    #
-    def update(show_output)
-      if requires_update?
-        super
-      else
-        []
-      end
-    end
-
-    private
-
-    # Returns whether a source requires updating.
-    #
-    # @param [Source] source
-    #        The source to check.
-    #
-    # @return [Bool] Whether the given source should be updated.
-    #
-    def requires_update?
-      commit_hash = git_commit_hash
-      GitHub.modified_since_commit('CocoaPods/Specs', commit_hash)
-    end
+    # For now, the MasterSource behaves exactly the same as any other Source.
+    # In the future we may apply separate logic to the MasterSource that doesn't
+    # depend on the file system.
   end
 end

--- a/lib/cocoapods-core/source.rb
+++ b/lib/cocoapods-core/source.rb
@@ -330,6 +330,7 @@ module Pod
     #          Returns the list of changed spec paths.
     #
     def update(show_output)
+      return [] if unchanged_github_repo?
       prev_commit_hash = git_commit_hash
       update_git_repo(show_output)
       refresh_metadata
@@ -435,6 +436,12 @@ module Pod
       command = "git -C \"#{repo}\" " << args.join(' ')
       command << ' 2>&1' if include_error
       (`#{command}` || '').strip
+    end
+
+    def unchanged_github_repo?
+      url = repo_git(%w(config --get remote.origin.url))
+      return unless url =~ /github.com/
+      !GitHub.modified_since_commit(url, git_commit_hash)
     end
 
     #-------------------------------------------------------------------------#

--- a/spec/github_spec.rb
+++ b/spec/github_spec.rb
@@ -17,6 +17,20 @@ module Pod
         end
       end
 
+      it 'handles SSH as well as HTTP' do
+        VCR.use_cassette('GitHub', :record => :new_episodes) do
+          repo = GitHub.repo('git@github.com:CocoaPods/CocoaPods')
+          repo['name'].should == 'CocoaPods'
+        end
+      end
+
+      it 'strips any trailing .git suffix' do
+        VCR.use_cassette('GitHub', :record => :new_episodes) do
+          repo = GitHub.repo('git@github.com:CocoaPods/CocoaPods.git')
+          repo['name'].should == 'CocoaPods'
+        end
+      end
+
       it 'returns the information of a repo with dots in the name' do
         VCR.use_cassette('GitHub', :record => :new_episodes) do
           repo = GitHub.repo('https://github.com/contentful/contentful.objc')

--- a/spec/master_source_spec.rb
+++ b/spec/master_source_spec.rb
@@ -17,7 +17,7 @@ module Pod
         end
       end
 
-      it 'fetches if the GitHub API returns not-modified' do
+      it 'fetches if the GitHub API returns modified' do
         VCR.use_cassette('MasterSource_fetch', :record => :new_episodes) do
           @source.expects(:update_git_repo)
           @source.send :update, true

--- a/spec/source/manager_spec.rb
+++ b/spec/source/manager_spec.rb
@@ -221,7 +221,7 @@ module Pod
 
     describe 'Updating Sources' do
       before do
-        MasterSource.any_instance.stubs(:requires_update?).returns(true)
+        Source.any_instance.stubs(:unchanged_github_repo?).returns(false)
       end
 
       it 'updates search index for changed paths if source is updated' do


### PR DESCRIPTION
Applies the GitHub efficiency check added in https://github.com/CocoaPods/Core/pull/313 to any spec repo which is hosted on GitHub.

Wanted to check approach before I add specs (i.e., move them from the ones currently on `MasterSource`). Are you guys OK with the above in principle, and do you see any reason for the continuing existence of `MasterSource` once it's done?
