### PR TITLE
Allow ActiveSupport 5+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ script: bundle exec rake spec
 git:
   submodules: false
 before_install:
+  - gem install bundler
   - |
       master_sha="$(ruby -e "puts '`git submodule status spec/fixtures/spec-repos/master`'.strip.sub(/^-/, '').split(/\s/, 2).first")"
       curl -ssL "https://github.com/CocoaPods/Specs/archive/$master_sha.tar.gz" | tar xz -C spec/fixtures/spec-repos

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gemspec
 gem 'json', :git => 'https://github.com/segiddins/json.git', :branch => 'seg-1.7.7-ruby-2.2'
 
 group :development do
+  gem 'activesupport', '>= 4.0.2', '< 5' # Pinned < 5 to ensure we're speccing 4.x.x
   gem 'bacon'
   gem 'mocha'
   gem 'mocha-on-bacon'
@@ -16,8 +17,8 @@ group :development do
   gem 'vcr'
   gem 'webmock'
 
-  gem 'codeclimate-test-reporter', :require => nil
-  gem 'rubocop'
+  gem 'codeclimate-test-reporter', '~> 0.4.1', :require => nil
+  gem 'rubocop', '~> 0.38.0'
 end
 
 group :debugging do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
   remote: .
   specs:
     cocoapods-core (1.2.1)
-      activesupport (>= 4.0.2, < 5)
+      activesupport (>= 4.0.2, < 6)
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)
 
@@ -45,7 +45,7 @@ GEM
       rb-kqueue (>= 0.2)
     metaclass (0.0.4)
     method_source (0.8.2)
-    minitest (5.10.1)
+    minitest (5.10.2)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     mocha-on-bacon (0.2.2)
@@ -98,10 +98,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport (>= 4.0.2, < 5)
   awesome_print
   bacon
   cocoapods-core!
-  codeclimate-test-reporter
+  codeclimate-test-reporter (~> 0.4.1)
   json!
   kicker
   mocha
@@ -110,9 +111,9 @@ DEPENDENCIES
   pry
   rake
   rb-fsevent
-  rubocop
+  rubocop (~> 0.38.0)
   vcr
   webmock
 
 BUNDLED WITH
-   1.13.6
+   1.15.0

--- a/cocoapods-core.gemspec
+++ b/cocoapods-core.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files         =  Dir["lib/**/*.rb"] + %w{ README.md LICENSE }
   s.require_paths =  %w{ lib }
 
-  s.add_runtime_dependency 'activesupport', '>= 4.0.2', '< 5'
+  s.add_runtime_dependency 'activesupport', '>= 4.0.2', '< 6'
   s.add_runtime_dependency 'nap', '~> 1.0'
   s.add_runtime_dependency 'fuzzy_match', "~> 2.0.4"
 


### PR DESCRIPTION
Having looked through the previous conversation on locking ActiveSupport in CocoaPods ([here](https://github.com/CocoaPods/CocoaPods/pull/5602)) I can't see any reason why it should be locked in Core, too. Specs were previously failing on `2.0.0-p481`, which had a buggy version of Bundler on Travis (presumably the same buggy version which was causing the issue on clean installs in the first place), but I think it should be fine to unlock the gem here and just fix the spec setup. Won't affect CocoaPods since that has a tighter specification in its gemspec.