### PR TITLE
fix Strange quotation marks in Podfile.lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,11 @@
 
 * Fix typo in `specification.rb`  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
-  [#376](https://github.com/CocoaPods/Core/pull/376)  
-
+  [#376](https://github.com/CocoaPods/Core/pull/376)
+  
+* Fix Strange quotation marks in `lockfile.rb`  
+  [Dacaiguoguo](https://github.com/dacaiguoguogmail)
+  [#377](https://github.com/CocoaPods/Core/pull/377) 
 
 ## 1.2.1 (2017-04-11)
 

--- a/lib/cocoapods-core/lockfile.rb
+++ b/lib/cocoapods-core/lockfile.rb
@@ -350,7 +350,15 @@ module Pod
     # @note   The YAML string is prettified.
     #
     def to_yaml
-      YAMLHelper.convert_hash(to_hash, HASH_KEY_ORDER, "\n\n")
+      yaml_string = YAMLHelper.convert_hash(to_hash, HASH_KEY_ORDER, "\n\n")
+      if to_hash['SPEC CHECKSUMS']
+        to_hash['SPEC CHECKSUMS'].each do |key, value|
+          wrong_fromat_string = key + ': \'' + value + '\''
+          right_fromat_string = key + ': ' + value
+          yaml_string = yaml_string.gsub(wrong_fromat_string, right_fromat_string) if yaml_string.include? wrong_fromat_string
+        end
+      end
+      yaml_string
     end
 
     #-------------------------------------------------------------------------#

--- a/spec/lockfile_spec.rb
+++ b/spec/lockfile_spec.rb
@@ -34,6 +34,36 @@ module Pod
       LOCKFILE
     end
 
+    def self.quotation_marks_yaml
+      <<-LOCKFILE.strip_heredoc
+        PODS:
+          - BananaLib (1.0):
+            - monkey (< 1.0.9, ~> 1.0.1)
+          - JSONKit (1.4)
+          - monkey (1.0.8)
+
+        DEPENDENCIES:
+          - BananaLib (~> 1.0)
+          - JSONKit (from `path/JSONKit.podspec`)
+
+        EXTERNAL SOURCES:
+          JSONKit:
+            :podspec: path/JSONKit.podspec
+
+        CHECKOUT OPTIONS:
+          JSONKit:
+            :podspec: path/JSONKit.podspec
+
+        SPEC CHECKSUMS:
+          BananaLib: d46ca864666e216300a0653de197668b12e732a1
+          JSONKit: '92ae5f71b77c8dec0cd8d0744adab79d38560949'
+
+        PODFILE CHECKSUM: podfile_checksum
+
+        COCOAPODS: #{CORE_VERSION}
+      LOCKFILE
+    end
+
     def self.podfile
       podfile = Podfile.new do
         platform :ios
@@ -313,6 +343,11 @@ module Pod
         @lockfile.write_to_disk(path)
 
         @lockfile.should == Lockfile.from_file(path)
+      end
+
+      it 'fix strange quotation marks in lockfile' do
+        @lockfile = Lockfile.new(YAMLHelper.load_string(Sample.quotation_marks_yaml))
+        @lockfile.to_yaml.should == Sample.yaml
       end
 
       it 'generates a hash representation' do


### PR DESCRIPTION
Strange quotation marks in 'SPEC CHECKSUMS' section
```
SPEC CHECKSUMS:
  SDWebImage: '098e97e6176540799c27e804c96653ee0833d13c'
```