### PR TITLE
Handle :testspecs DSL for pod dependencies

### DIFF
--- a/lib/cocoapods-core/podfile/target_definition.rb
+++ b/lib/cocoapods-core/podfile/target_definition.rb
@@ -868,11 +868,18 @@ module Pod
         return false unless options.is_a?(Hash)
 
         subspecs = options.delete(:subspecs)
+        test_specs = options.delete(:testspecs)
+
         subspecs.each do |ss|
           store_pod("#{name}/#{ss}", *requirements.dup)
         end if subspecs
+
+        test_specs.each do |ss|
+          store_pod("#{name}/#{ss}", *requirements.dup)
+        end if test_specs
+
         requirements.pop if options.empty?
-        !subspecs.nil?
+        !subspecs.nil? || !test_specs.nil?
       end
 
       #-----------------------------------------------------------------------#

--- a/spec/podfile/target_definition_spec.rb
+++ b/spec/podfile/target_definition_spec.rb
@@ -232,6 +232,22 @@ module Pod
         @parent.dependencies.map(&:name).sort.should == %w(RestKit/Networking)
       end
 
+      it 'allows depending on testspecs' do
+        @parent.store_pod('RestKit', :testspecs => %w(Tests))
+        @parent.dependencies.map(&:name).sort.should == %w(RestKit/Tests)
+      end
+
+      it 'allows depending on both subspecs and testspecs' do
+        @parent.store_pod('RestKit', :subspecs => %w(Networking))
+        @parent.store_pod('RestKit', :testspecs => %w(Tests))
+        @parent.dependencies.map(&:name).sort.should == %w(RestKit/Networking RestKit/Tests)
+      end
+
+      it 'allows depending on both subspecs and testspecs in chaining' do
+        @parent.store_pod('RestKit', :subspecs => %w(Networking), :testspecs => %w(Tests))
+        @parent.dependencies.map(&:name).sort.should == %w(RestKit/Networking RestKit/Tests)
+      end
+
       #--------------------------------------#
 
       it "doesn't inhibit warnings per pod by default" do


### PR DESCRIPTION
```ruby
pod 'SamplePod', :path => 'SamplePod.podspec', :testspecs => ['Tests']
```

:D