### PR TITLE
Correctly include parent dependencies when parsing testspecs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@
 
 ##### Bug Fixes
 
+* Correctly include parent dependencies when parsing testspecs
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#384](https://github.com/CocoaPods/Core/pull/384)
+
 * Fix typo in `specification.rb`  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#376](https://github.com/CocoaPods/Core/pull/376)

--- a/lib/cocoapods-core/podfile/target_definition.rb
+++ b/lib/cocoapods-core/podfile/target_definition.rb
@@ -852,8 +852,8 @@ module Pod
         requirements.pop if options.empty?
       end
 
-      # Removes :subspecs from the requirements list, and stores the pods
-      # with the given subspecs as dependencies.
+      # Removes :subspecs and :testspecs from the requirements list, and stores the pods
+      # with the given subspecs or test specs as dependencies.
       #
       # @param  [String] name
       #
@@ -879,7 +879,7 @@ module Pod
         end if test_specs
 
         requirements.pop if options.empty?
-        !subspecs.nil? || !test_specs.nil?
+        !subspecs.nil?
       end
 
       #-----------------------------------------------------------------------#

--- a/spec/podfile/target_definition_spec.rb
+++ b/spec/podfile/target_definition_spec.rb
@@ -234,13 +234,13 @@ module Pod
 
       it 'allows depending on testspecs' do
         @parent.store_pod('RestKit', :testspecs => %w(Tests))
-        @parent.dependencies.map(&:name).sort.should == %w(RestKit/Tests)
+        @parent.dependencies.map(&:name).sort.should == %w(RestKit RestKit/Tests)
       end
 
       it 'allows depending on both subspecs and testspecs' do
         @parent.store_pod('RestKit', :subspecs => %w(Networking))
         @parent.store_pod('RestKit', :testspecs => %w(Tests))
-        @parent.dependencies.map(&:name).sort.should == %w(RestKit/Networking RestKit/Tests)
+        @parent.dependencies.map(&:name).sort.should == %w(RestKit RestKit/Networking RestKit/Tests)
       end
 
       it 'allows depending on both subspecs and testspecs in chaining' do


### PR DESCRIPTION
This is now correct.

