### PR TITLE
Cache version result for each pod and segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@
 
 ##### Bug Fixes
 
+* Cache version result for each pod and segments  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#385](https://github.com/CocoaPods/Core/pull/385)
+
 * Correctly include parent dependencies when parsing testspecs
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#384](https://github.com/CocoaPods/Core/pull/384)

--- a/lib/cocoapods-core/source.rb
+++ b/lib/cocoapods-core/source.rb
@@ -24,6 +24,7 @@ module Pod
     #
     def initialize(repo)
       @repo = Pathname(repo).expand_path
+      @versions_by_name = {}
       refresh_metadata
     end
 
@@ -160,7 +161,7 @@ module Pod
       raise ArgumentError, 'No name' unless name
       pod_dir = pod_path(name)
       return unless pod_dir.exist?
-      pod_dir.children.map do |v|
+      @versions_by_name[name] ||= pod_dir.children.map do |v|
         basename = v.basename.to_s
         begin
           Version.new(basename) if v.directory? && basename[0, 1] != '.'
@@ -333,6 +334,7 @@ module Pod
       return [] if unchanged_github_repo?
       prev_commit_hash = git_commit_hash
       update_git_repo(show_output)
+      @versions_by_name.clear
       refresh_metadata
       if version = metadata.last_compatible_version(Version.new(CORE_VERSION))
         tag = "v#{version}"

--- a/lib/cocoapods-core/version.rb
+++ b/lib/cocoapods-core/version.rb
@@ -198,11 +198,11 @@ module Pod
     end
 
     def numeric_segments
-      segments.take_while { |s| s.is_a?(Numeric) }.reverse_each.drop_while { |s| s == 0 }.reverse
+      @numeric_segments ||= segments.take_while { |s| s.is_a?(Numeric) }.reverse_each.drop_while { |s| s == 0 }.reverse
     end
 
     def prerelease_segments
-      segments.drop_while { |s| s.is_a?(Numeric) }
+      @prerelease_segments ||= segments.drop_while { |s| s.is_a?(Numeric) }
     end
 
     def compare_segments(other)


### PR DESCRIPTION
The bigger our internal repo gets the more version comparisons occur. I profiled and saw a 17-20% increase by caching those results which seem safe to cache.

<img width="600" alt="screen_shot_2017-06-16_at_10_24_19_pm" src="https://user-images.githubusercontent.com/310370/27250374-af46a262-52e2-11e7-82bc-610bd4d7e117.png">

Here's a medium size project 17% improvement.
```
Before:
real	0m10.410s
user	0m9.156s
sys	0m0.772s

After:
real	0m8.642s
user	0m7.322s
sys	0m0.866s
```

There is another PR I will do in the main project.