### PR TITLE
Static framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ##### Enhancements
 
-* None.  
+* Introduce `static_framework` podspec attribute
+  [Paul Beusterien](https://github.com/paulb777)
+  [#386](https://github.com/CocoaPods/Core/pull/386)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -458,6 +458,25 @@ module Pod
 
       #------------------#
 
+      # @!method static_framework=(flag)
+      #
+      #   Indicates, that if use_frameworks! is specified, the
+      #   pod should include a static library framework.
+      #
+      #   @example
+      #
+      #     spec.static_framework = true
+      #
+      #   @param [Bool] flag
+      #          Indicates, that if use_frameworks! is specified, the
+      #          pod should include a static library framework.
+      #
+      root_attribute :static_framework,
+                     :types => [TrueClass, FalseClass],
+                     :default_value => false
+
+      #------------------#
+
       # @!method deprecated=(flag)
       #
       #   Whether the library has been deprecated.

--- a/lib/cocoapods-core/specification/root_attribute_accessors.rb
+++ b/lib/cocoapods-core/specification/root_attribute_accessors.rb
@@ -152,6 +152,13 @@ module Pod
           command.strip_heredoc.chomp if command
         end
 
+        # @return [Bool] Indicates, that if use_frameworks! is specified, the
+        #         framework should include a static library.
+        #
+        def static_framework
+          attributes_hash['static_framework']
+        end
+
         # @return [Bool] Whether the Pod has been deprecated.
         #
         def deprecated

--- a/spec/specification/dsl_spec.rb
+++ b/spec/specification/dsl_spec.rb
@@ -76,6 +76,11 @@ module Pod
         @spec.attributes_hash['prepare_command'].should == 'ruby build_files.rb'
       end
 
+      it 'allows to specify whether the Pod has a static_framework' do
+        @spec.static_framework = true
+        @spec.attributes_hash['static_framework'].should == true
+      end
+
       it 'allows to specify whether the Pod has been deprecated' do
         @spec.deprecated = true
         @spec.attributes_hash['deprecated'].should == true

--- a/spec/specification/root_attribute_accessors_spec.rb
+++ b/spec/specification/root_attribute_accessors_spec.rb
@@ -143,6 +143,11 @@ module Pod
       @spec.prepare_command.should == 'ruby prepare_script.rb'
     end
 
+    it 'returns whether the Pod should build a static framework' do
+      @spec.static_framework = true
+      @spec.static_framework.should == true
+    end
+
     it 'returns whether the Pod has been deprecated' do
       @spec.deprecated = true
       @spec.deprecated.should == true


### PR DESCRIPTION
Introduce static_framework podspec attribute to indicate that a source CocoaPod should be built into a static library framework. 

More details in the corresponding CocoaPods PR - coming shortly.