### PR TITLE
Update DSL for `spec.source`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 
 ##### Bug Fixes
 
-* None.  
+* Cleanup DSL for `spec.source` - remove mentioning of `:path`.
+  [Maksym Komarychev](https://github.com/maxkomarychev)
+  [#388](https://github.com/CocoaPods/Core/pull/388)
 
 
 ## 1.3.0.beta.1 (2017-06-06)

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -273,7 +273,6 @@ module Pod
         :svn  => [:folder, :tag, :revision].freeze,
         :hg   => [:revision].freeze,
         :http => [:flatten, :type, :sha256, :sha1].freeze,
-        :path => nil,
       }.freeze
 
       # @!method source=(source)
@@ -333,10 +332,6 @@ module Pod
       #     @option http [String] :http compressed source URL
       #     @option http [String] :type file type. Supports zip, tgz, bz2, txz and tar
       #     @option http [String] :sha1 SHA hash. Supports SHA1 and SHA256
-      #
-      #   @overload source=(path)
-      #     @param  [Hash] path
-      #     @option path [String] :path local source path
       #
       root_attribute :source,
                      :container => Hash,


### PR DESCRIPTION
According to current implementation of downloader https://github.com/CocoaPods/cocoapods-downloader/blob/978dfcd59e028db875cd4bb191ebbf3195b6fc26/lib/cocoapods-downloader.rb#L21-L29 the `:path` key is not supported for `spec.source` and the doc available [here](https://guides.cocoapods.org/syntax/podspec.html#source) is misleading.

Couple of related issues:
https://github.com/CocoaPods/CocoaPods/issues/4937
https://github.com/CocoaPods/cocoapods-packager/issues/32

// disclaimer
I quite far away from ruby development and mostly do mobile. Please let me know if there any more places where this should be cleaned up.

Thanks for great tool.