### PR TITLE
Update travis.yml with latest Ruby, and fix README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ addons:
    repo_token: 186c49521e629c51591c86f057f49fe388ce87603e04b5486f0c92f26f2a455f
 rvm:
   # Latest stable Ruby
-  - 2.4.0
+  - 2.4.1
   # OS X 10.9.5-10.10.0 (2.0.0-p481)
   - 2.0.0-p481
   # OS X 10.9.3-10.9.4

--- a/README.md
+++ b/README.md
@@ -25,10 +25,7 @@ files.
 $ [sudo] gem install cocoapods-core
 ```
 
-The `cocoapods-core` gem requires either:
-
-- Ruby 1.8.7 (shipped with OS X 10.8).
-- Ruby 1.9.3 (recommended).
+The `cocoapods-core` gem requires Ruby 2.0.0 or later.
 
 ## Collaborate
 


### PR DESCRIPTION
Just cosmetics. The [gemspec](https://github.com/CocoaPods/Core/blob/master/cocoapods-core.gemspec#L31) actually already require Ruby 2.0.0 or greater.