### PR TITLE
Check requires arc true false strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@
 
 ##### Bug Fixes
 
-* None.  
-
+* Check requires_arc for true/false strings
+  [Vinay Guthal](https://github.com/VinayGuthal)
+  [#393](https://github.com/CocoaPods/Core/pull/393)
 
 ## 1.3.0.beta.2 (2017-06-22)
 

--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -48,6 +48,7 @@ module Pod
         if spec
           validate_root_name
           check_required_attributes
+          check_requires_arc_attribute
           run_root_validation_hooks
           perform_all_specs_analysis
         else
@@ -95,6 +96,20 @@ module Pod
           unless names_match
             results.add_error('name', 'The name of the spec should match the ' \
                               'name of the file.')
+          end
+        end
+      end
+
+      # Generates a warning if the requires_arc attribute has true or false string values.
+      #
+      # @return [void]
+      #
+      def check_requires_arc_attribute
+        attribute = DSL.attributes.values.find { |attr| attr.name == :requires_arc }
+        if attribute
+          value = spec.send(attribute.name)
+          if value == 'true' || value == 'false'
+            results.add_warning('requires_arc', value + ' is considered to be the name of a file.')
           end
         end
       end
@@ -370,8 +385,10 @@ module Pod
           return
         end
         supported_test_types = Specification::DSL::SUPPORTED_TEST_TYPES
-        results.add_error('test_type', "The test type `#{t}` is not supported. " \
-          "Supported test type values are #{supported_test_types}.") unless supported_test_types.include?(t)
+        unless supported_test_types.include?(t)
+          results.add_error('test_type', "The test type `#{t}` is not supported. " \
+            "Supported test type values are #{supported_test_types}.")
+        end
       end
 
       # Performs validations related to github sources.

--- a/lib/cocoapods-core/specification/root_attribute_accessors.rb
+++ b/lib/cocoapods-core/specification/root_attribute_accessors.rb
@@ -19,6 +19,12 @@ module Pod
           parent ? "#{parent.name}/#{base_name}" : base_name
         end
 
+        # @return [Bool, String, Array<String>] The requires_arc value.
+        #
+        def requires_arc
+          attributes_hash['requires_arc']
+        end
+
         # @return [Version] The version of the Pod.
         #
         # @todo   The version is memoized because the Resolvers sets the head

--- a/spec/fixtures/spec-repos/test_repo/Specs/BananaLib/0.8/BananaLib.podspec
+++ b/spec/fixtures/spec-repos/test_repo/Specs/BananaLib/0.8/BananaLib.podspec
@@ -1,0 +1,20 @@
+Pod::Spec.new do |s|
+  s.name         = 'BananaLib'
+  s.version      = '0.8'
+  s.authors      = 'Banana Corp', { 'Monkey Boy' => 'monkey@banana-corp.local' }
+  s.homepage     = 'http://banana-corp.local/banana-lib.html'
+  s.summary      = 'Chunky bananas!'
+  s.description  = 'Full of chunky bananas.'
+  s.source       = { :git => 'http://banana-corp.local/banana-lib.git', :tag => 'v1.0' }
+  s.source_files = 'Classes/*.{h,m}', 'Vendor'
+  s.xcconfig     = { 'OTHER_LDFLAGS' => '-framework SystemConfiguration' }
+  s.prefix_header_file = 'Classes/BananaLib.pch'
+  s.resources    = 'Resources/*.png'
+  s.requires_arc = 'true'
+  s.dependency   'monkey', '~> 1.0.1', '< 1.0.9'
+  s.license = {
+    :type => 'MIT',
+    :file => 'LICENSE',
+    :text => 'Permission is hereby granted ...',
+  }
+end

--- a/spec/source/health_reporter_spec.rb
+++ b/spec/source/health_reporter_spec.rb
@@ -23,7 +23,7 @@ module Pod
 
       it 'analyzes all the specifications of a repo' do
         @reporter.analyze
-        @reporter.report.analyzed_paths.count.should == 10
+        @reporter.report.analyzed_paths.count.should == 11
       end
 
       it 'is robust against malformed specifications' do
@@ -42,6 +42,12 @@ module Pod
         @reporter.analyze
         errors = @reporter.report.pods_by_error.keys.join("\n")
         errors.should.match /Incorrect path/
+      end
+
+      it 'checks if requires_arc has the string value of true or false' do
+        @reporter.analyze
+        warnings = @reporter.report.pods_by_warning.keys.join("\n")
+        warnings.should.match /true is considered to be the name of a file/
       end
 
       it 'checks for any stray specifications' do

--- a/spec/specification/root_attribute_accessors_spec.rb
+++ b/spec/specification/root_attribute_accessors_spec.rb
@@ -6,6 +6,7 @@ module Pod
       @spec = Spec.new do |s|
         s.name = 'Pod'
         s.version = '1.0'
+        s.requires_arc = true
         s.subspec 'Subspec' do
         end
       end
@@ -167,6 +168,10 @@ module Pod
     it 'returns the custom module map file, if specified' do
       @spec.module_map = 'module.modulemap'
       @spec.module_map.should == 'module.modulemap'
+    end
+
+    it 'returns the correct requires_arc value, if specified' do
+      @spec.requires_arc.should == true
     end
   end
 end


### PR DESCRIPTION
This fixes https://github.com/CocoaPods/CocoaPods/issues/6701.
Add a warning if the strings` 'true'` or `'false' ` are being used instead of boolean `true` or `false`  as the value for 'requires_arc' in the pod spec file.