### PR TITLE
Fix source specs

### DIFF
--- a/lib/cocoapods-core/source.rb
+++ b/lib/cocoapods-core/source.rb
@@ -441,7 +441,6 @@ module Pod
     end
 
     def unchanged_github_repo?
-      url = repo_git(%w(config --get remote.origin.url))
       return unless url =~ /github.com/
       !GitHub.modified_since_commit(url, git_commit_hash)
     end

--- a/spec/source_spec.rb
+++ b/spec/source_spec.rb
@@ -241,6 +241,7 @@ module Pod
 
       describe 'for a non-GitHub source' do
         it 'always calls update_git_repo' do
+          @source.expects(:url).returns('https://myhost.com/myorg/myrepo.git')
           @source.expects(:update_git_repo)
           @source.send :update, true
         end


### PR DESCRIPTION
This makes `unchanged_github_repo?` use the pre-exisiting `url` method
for retreiving the source URL, and stubs this in the tests, as
previously we were pointing to a github repo here, which is:
a) not the goal of the test
b) doing networking during tests (which is 😢 and breaks working on CocoaPods offline)