### PR TITLE
[YAMLHelper] Implement consistent string processing

### DIFF
--- a/lib/cocoapods-core/yaml_helper.rb
+++ b/lib/cocoapods-core/yaml_helper.rb
@@ -275,11 +275,26 @@ module Pod
         end
       end
 
+      RESOLVED_TAGS = [
+        'null', 'Null', 'NULL', '~', '', # resolve to null
+        'true', 'True', 'TRUE', 'false', 'False', 'FALSE', # bool
+        /[-+]?[0-9]+/, # base 10 int
+        /00[0-7]+/, # base 8 int
+        /0x[0-9a-fA-F]+/, # base 16 int
+        /[-+]?(\.[0-9]+|[0-9]+(\.[0-9]*)?)([eE][-+]?[0-9]+)?/, # float
+        /[-+]?\.(inf|Inf|INF)/, # infinity
+        /\.(nan|NaN|NAN)/, # NaN
+      ].freeze
+      private_constant :RESOLVED_TAGS
+
+      RESOLVED_TAGS_PATTERN = /\A#{Regexp.union(RESOLVED_TAGS)}\z/
+      private_constant :RESOLVED_TAGS_PATTERN
+
       def process_string(string)
         case string
         when /\A\s*\z/
           string.inspect
-        when /\A\d+(\.\d+)?\z/
+        when RESOLVED_TAGS_PATTERN
           "'#{string}'"
         when %r{\A\w[\w/ \(\)~<>=\.-]*\z}
           string

--- a/lib/cocoapods-core/yaml_helper.rb
+++ b/lib/cocoapods-core/yaml_helper.rb
@@ -96,6 +96,7 @@ module Pod
         case value
         when Array      then process_array(value)
         when Hash       then process_hash(value, hash_keys_hint)
+        when String     then process_string(value)
         else                 YAML.dump(value, :line_width => 2**31 - 1).sub(/\A---/, '').sub(/[.]{3}\s*\Z/, '')
         end.strip
       end
@@ -270,6 +271,20 @@ module Pod
         when Symbol then sorting_string(value.to_s)
         when Array  then sorting_string(value.first)
         when Hash   then value.keys.map { |key| key.to_s.downcase }.sort.first
+        else             raise "Cannot sort #{value.inspect}"
+        end
+      end
+
+      def process_string(string)
+        case string
+        when /\A\s*\z/
+          string.inspect
+        when /\A\d+(\.\d+)?\z/
+          "'#{string}'"
+        when %r{\A\w[\w/ \(\)~<>=\.-]*\z}
+          string
+        else
+          string.inspect
         end
       end
     end

--- a/spec/yaml_helper_spec.rb
+++ b/spec/yaml_helper_spec.rb
@@ -94,6 +94,28 @@ module Pod
         EOT
       end
 
+      it 'converts a hash with complex keys' do
+        value = { 'Key' => {
+          "\n\t  \r\t\b\r\n  " => 'spaces galore',
+          '!abc' => 'abc',
+          '!ABC' => 'ABC',
+          '123' => '123',
+          "a # 'comment'?" => "a # 'comment'?",
+          %q('"' lotsa '"""'''" quotes) => %q('"' lotsa '"""'''" quotes),
+        } }
+        result = YAMLHelper.convert(value)
+        result.should == <<-EOT.strip_heredoc
+          Key:
+            "\\n\\t  \\r\\t\\b\\r\\n  ": spaces galore
+            "!abc": abc
+            "!ABC": ABC
+            "'\\"' lotsa '\\"\\"\\"'''\\" quotes": "'\\"' lotsa '\\"\\"\\"'''\\" quotes"
+            '123': '123'
+            "a # 'comment'?": "a # 'comment'?"
+        EOT
+        YAMLHelper.load_string(result).should == value
+      end
+
       it 'handles nil' do
         value = { 'foo' => nil }
         result = YAMLHelper.convert(value)

--- a/spec/yaml_helper_spec.rb
+++ b/spec/yaml_helper_spec.rb
@@ -39,6 +39,22 @@ module Pod
         YAMLHelper.load_string(result).should == value
       end
 
+      it 'converts weird strings' do
+        {
+          'true' => "'true'",
+          'false' => "'false'",
+          'null' => "'null'",
+          '-1' => "'-1'",
+          '' => '""',
+          '!' => '"!"',
+          '~' => "'~'",
+        }.each do |given, expected|
+          converted = YAMLHelper.convert(given)
+          converted[0..-2].should == expected
+          YAMLHelper.load_string("---\n#{converted}").should == given
+        end
+      end
+
       it 'converts a symbol' do
         value = :value
         result = YAMLHelper.convert(value)


### PR DESCRIPTION
This should fix https://github.com/CocoaPods/CocoaPods/issues/6925 regardless of the ruby/psych being used.

I went for an overly conservative approach (that is, more strings might be quotes than necessary), but I think given the structure of lockfiles this should cause minimum disruption from the status quo.