### PR TITLE
Split testspecs from subspecs during JSON serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ##### Bug Fixes
 
+* Split testspecs from subspecs during JSON serialization  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#398](https://github.com/CocoaPods/Core/pull/398)
+
 * Fix JSON deserialization for test specs  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#396](https://github.com/CocoaPods/Core/pull/396)

--- a/spec/specification/json_spec.rb
+++ b/spec/specification/json_spec.rb
@@ -121,7 +121,8 @@ module Pod
         hash['subspecs'].should == [{
           'name' => 'GreenBanana',
           'source_files' => 'GreenBanana',
-        }, {
+        }]
+        hash['testspecs'].should == [{
           'name' => 'Tests',
           'test_type' => :unit,
         }]
@@ -147,16 +148,39 @@ module Pod
         hash = {
           'name' => 'BananaLib',
           'version' => '1.0',
+          'subspecs' => [{ 'name' => 'GreenBanana', 'source_files' => 'GreenBanana' }],
+          'testspecs' => [{ 'name' => 'Tests', 'test_type' => :unit }],
+        }
+        result = Specification.from_hash(hash)
+        result.subspecs.count.should.equal 2
+        result.test_specs.count.should.equal 1
+        result.test_specs.first.test_specification?.should.be.true
+        result.test_specs.first.test_type.should.equal :unit
+      end
+
+      it 'can load test specification from 1.3.0 hash format' do
+        hash = {
+          'name' => 'BananaLib',
+          'version' => '1.0',
           'subspecs' => [{ 'name' => 'GreenBanana', 'source_files' => 'GreenBanana' }, { 'name' => 'Tests', 'test_type' => :unit }],
         }
         result = Specification.from_hash(hash)
+        result.subspecs.count.should.equal 2
+        result.test_specs.count.should.equal 1
+        result.test_specs.first.test_specification?.should.be.true
+        result.test_specs.first.test_type.should.equal :unit
+      end
+
+      it 'can load test specification from 1.3.0 JSON format' do
+        json = '{"subspecs": [{"name": "Tests","test_type": "unit","source_files": "Tests/**/*.{h,m}"}]}'
+        result = Specification.from_json(json)
         result.test_specs.count.should.equal 1
         result.test_specs.first.test_specification?.should.be.true
         result.test_specs.first.test_type.should.equal :unit
       end
 
       it 'can load test specification from json' do
-        json = '{"subspecs": [{"name": "Tests","test_type": "unit","source_files": "Tests/**/*.{h,m}"}]}'
+        json = '{"testspecs": [{"name": "Tests","test_type": "unit","source_files": "Tests/**/*.{h,m}"}]}'
         result = Specification.from_json(json)
         result.test_specs.count.should.equal 1
         result.test_specs.first.test_specification?.should.be.true

--- a/spec/specification/linter_spec.rb
+++ b/spec/specification/linter_spec.rb
@@ -287,6 +287,17 @@ module Pod
       end
 
       it 'checks the test type value is correct using a JSON podspec' do
+        podspec = '{"testspecs":[{"name": "Tests","test_type": "unit","source_files": "Tests/**/*.{h,m}"}]}'
+        path = SpecHelper.temporary_directory + 'BananaLib.podspec.json'
+        File.open(path, 'w') { |f| f.write(podspec) }
+        linter = Specification::Linter.new(path)
+        linter.lint
+        results = linter.results
+        test_type_error = results.find { |result| result.to_s.downcase.include?('test_type') }
+        test_type_error.should.be.nil
+      end
+
+      it 'checks the test type value is correctly set in a subspec using 1.3.0 JSON podspec' do
         podspec = '{"subspecs":[{"name": "Tests","test_type": "unit","source_files": "Tests/**/*.{h,m}"}]}'
         path = SpecHelper.temporary_directory + 'BananaLib.podspec.json'
         File.open(path, 'w') { |f| f.write(podspec) }


### PR DESCRIPTION
This fixes an issue where older versions of CocoaPods parse a podspec in JSON that was created and includes a test spec.

The end result is that the old version would treat the test spec as a subspec and attempt to load and link all test dependencies as normal dependencies.

This separation prevents this but it does create a separation and concern between 1.3.0 and 1.3.1. 1.3.1 *will* support 1.3.0 podspecs and then from now and on split the hash when serialized.