### PR TITLE
Fix requirements cloning for `:testspecs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ##### Enhancements
 
+* Fix requirements cloning for `:testspecs`  
+  [Justin Martin](https://github.com/justinseanmartin)
+  [#401](https://github.com/CocoaPods/Core/pull/401)
+
 * Add Podfile DSL for `script_phase`  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#389](https://github.com/CocoaPods/Core/pull/389)

--- a/lib/cocoapods-core/podfile/target_definition.rb
+++ b/lib/cocoapods-core/podfile/target_definition.rb
@@ -921,7 +921,8 @@ module Pod
         end if subspecs
 
         test_specs.each do |ss|
-          store_pod("#{name}/#{ss}", *requirements.dup)
+          requirements_copy = requirements.map(&:dup)
+          store_pod("#{name}/#{ss}", *requirements_copy)
         end if test_specs
 
         requirements.pop if options.empty?

--- a/spec/podfile/target_definition_spec.rb
+++ b/spec/podfile/target_definition_spec.rb
@@ -409,6 +409,15 @@ module Pod
         @child.all_whitelisted_configurations.sort.should == %w(Debug Release)
       end
 
+      it 'whitelistes pod configurations with testspecs' do
+        @parent.build_configurations = { 'Debug' => :debug, 'Release' => :release }
+        @parent.store_pod('RestKit', :testspecs => %w(Tests), :configuration => 'Debug')
+        @parent.should.pod_whitelisted_for_configuration?('RestKit', 'Debug')
+        @parent.should.pod_whitelisted_for_configuration?('RestKit/Tests', 'Debug')
+        @parent.should.not.pod_whitelisted_for_configuration?('RestKit', 'Release')
+        @parent.should.not.pod_whitelisted_for_configuration?('RestKit/Tests', 'Release')
+      end
+
       #--------------------------------------#
 
       it 'returns its platform' do


### PR DESCRIPTION
🌈

Found an issue where the requirements weren't being deep copied when using the `:testspecs` directive in combination with the `:configurations` directive. It would lead to an error message showing up with:

> [!] The subspecs of `MyPod` are linked to different build configurations for the `Pods-MyApp` target. CocoaPods does not currently support subspecs across different build configurations.

This addresses the issue by deep copying the requirements Hash contained within the Array instead of just copying the array containing those requirements.