### PR TITLE
Add ancestor to return the outermost spec around a subspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ##### Enhancements
 
-* None.  
+* Add `ancestor` to return the outermost spec around a subspec  
+  [Paul Beusterien](https://github.com/paulb777)
+  [#407](https://github.com/CocoaPods/Core/pull/407)
 
 ##### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * Add `ancestor` to return the outermost spec around a subspec  
   [Paul Beusterien](https://github.com/paulb777)
-  [#407](https://github.com/CocoaPods/Core/pull/407)
+  [#411](https://github.com/CocoaPods/Core/pull/411)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods-core/specification/root_attribute_accessors.rb
+++ b/lib/cocoapods-core/specification/root_attribute_accessors.rb
@@ -152,6 +152,14 @@ module Pod
           command.strip_heredoc.chomp if command
         end
 
+        # @return [Hash] Return the outermost spec
+        #
+        def ancestor
+          ancestor = self
+          ancestor = ancestor.parent until ancestor.parent.nil?
+          ancestor
+        end
+
         # @return [Bool] Indicates, that if use_frameworks! is specified, the
         #         framework should include a static library.
         #

--- a/spec/specification/root_attribute_accessors_spec.rb
+++ b/spec/specification/root_attribute_accessors_spec.rb
@@ -178,5 +178,13 @@ module Pod
     it 'returns the correct requires_arc value, if specified' do
       @spec.requires_arc.should == true
     end
+
+    it 'checks that ancestor of a root is itself' do
+      @spec.ancestor.should == @spec
+    end
+
+    it 'checks that ancestor of a subspec is the base spec' do
+      @spec.subspecs.first.ancestor.should == @spec
+    end
   end
 end


### PR DESCRIPTION
This is being added for the upcoming CocoaPods PR to fix the static_framework attribute with subspecs. See https://github.com/CocoaPods/CocoaPods/pull/6811#issuecomment-331628583