### PR TITLE
Improve performance of `Pod::Source#search`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@
 
 ##### Bug Fixes
 
-* None.  
-
+* Improve performance of `Pod::Source#search`  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#416](https://github.com/CocoaPods/Core/pull/416)
 
 ## 1.4.0.beta.1 (2017-09-24)
 

--- a/lib/cocoapods-core/source.rb
+++ b/lib/cocoapods-core/source.rb
@@ -263,7 +263,7 @@ module Pod
       found = Pathname.glob(pod_path(query)).map { |path| path.basename.to_s }
       if [query] == found
         set = set(query)
-        set if set.specification.name == query
+        set if set.specification_name == query
       end
     end
 

--- a/lib/cocoapods-core/specification/set.rb
+++ b/lib/cocoapods-core/specification/set.rb
@@ -30,7 +30,7 @@ module Pod
       #         the sources that contain a Pod.
       #
       def initialize(name, sources = [])
-        @name    = name
+        @name = name
         @sources = Array(sources)
       end
 
@@ -48,6 +48,12 @@ module Pod
         end
 
         Specification.from_file(highest_version_spec_path)
+      end
+
+      # @return [Specification] the top level specification for this set for any version.
+      #
+      def specification_name
+        Specification.from_file(specification_paths_for_version(any_version).first).name
       end
 
       # @return [Array<String>] the paths to specifications for the given
@@ -78,18 +84,16 @@ module Pod
       #         is used to disambiguate.
       #
       def highest_version_spec_path
-        specification_paths_for_version(highest_version).first
+        @highest_version_spec_path ||= specification_paths_for_version(highest_version).first
       end
 
       # @return [Hash{Source => Version}] all the available versions for the
       #         Pod grouped by source.
       #
       def versions_by_source
-        result = {}
-        sources.each do |source|
+        @versions_by_source ||= sources.each_with_object({}) do |source, result|
           result[source] = source.versions(name)
         end
-        result
       end
 
       def ==(other)
@@ -125,6 +129,14 @@ module Pod
           'highest_version' => highest_version.to_s,
           'highest_version_spec' => highest_version_spec_path.to_s,
         }
+      end
+
+      private
+
+      # @return [Version] A version known for this specification.
+      #
+      def any_version
+        versions_by_source.values.flatten.uniq.first
       end
 
       #-----------------------------------------------------------------------#

--- a/spec/specification/set_spec.rb
+++ b/spec/specification/set_spec.rb
@@ -21,6 +21,10 @@ module Pod
         @set.highest_version.should == Version.new('1.6.2')
       end
 
+      it 'returns a version available for the pod' do
+        @set.send(:any_version).should == Version.new('1.6.2')
+      end
+
       it 'returns the path of the spec with the highest version' do
         @set.highest_version_spec_path.should == @source.repo + 'CocoaLumberjack/1.6.2/CocoaLumberjack.podspec'
       end


### PR DESCRIPTION
![screen_shot_2017-10-09_at_10_12_57_am](https://user-images.githubusercontent.com/310370/31350054-83752440-acda-11e7-862c-2e39c3a5f6ff.png)

Within `source.rb`, just by calling:
```ruby
    def search(query)
      unless specs_dir
        raise Informative, "Unable to find a source named: `#{name}`"
      end
      if query.is_a?(Dependency)
        query = query.root_name
      end
      found = Pathname.glob(pod_path(query)).map { |path| path.basename.to_s }
      if [query] == found
        set = set(query)
        set if set.specification.name == query # <----------------- this line
      end
    end
```
It calls `Pod::Specification::Set#specification` which will call twice the expensive `highest_version_spec_path` method.

There is no need for us to get the highest version spec if the only thing we need is the name of the specification, which should not be any different given all Podspec names are unique.

This actually saves about 7%-9% in `pod install` time for a large project that contains a specific pod with 200+ versions (we publish a version nightly). It brought down our `pod install` from ~53 seconds to ~48 seconds.

`set.rb` appears immutable so there is no need to evict any of the caching.
