### PR TITLE
Fix typo when validating cocoapods version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 ##### Bug Fixes
 
+* Fix typo when validating cocoapods version  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#418](https://github.com/CocoaPods/Core/pull/418)
+
 * Improve performance of `Pod::Source#search`  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#416](https://github.com/CocoaPods/Core/pull/416)

--- a/lib/cocoapods-core/specification.rb
+++ b/lib/cocoapods-core/specification.rb
@@ -680,7 +680,7 @@ module Pod
     def validate_cocoapods_version
       unless cocoapods_version.satisfied_by?(Version.create(CORE_VERSION))
         raise Informative, "`#{name}` requires CocoaPods version `#{cocoapods_version}`, " \
-                           "which is not satisified by your current version, `#{CORE_VERSION}`."
+                           "which is not satisfied by your current version, `#{CORE_VERSION}`."
       end
     end
   end


### PR DESCRIPTION
...ironically the branch name used has a typo. ¯\\\_(ツ)_/¯