### PR TITLE
Use double quotes for yaml keys in Podfile.lock string representation

### DIFF
--- a/lib/cocoapods-core/lockfile.rb
+++ b/lib/cocoapods-core/lockfile.rb
@@ -351,8 +351,7 @@ module Pod
     #
     def to_yaml
       yaml_string = YAMLHelper.convert_hash(to_hash, HASH_KEY_ORDER, "\n\n")
-      yaml_string = yaml_string.tr("'", '')
-      yaml_string.tr('"', '')
+      yaml_string.tr("'", '"')
     end
 
     #-------------------------------------------------------------------------#

--- a/spec/fixtures/lock_files/Podfile.lock
+++ b/spec/fixtures/lock_files/Podfile.lock
@@ -1,0 +1,25 @@
+PODS:
+  - BananaLib (1.0):
+    - 'monkey (< 1.0.9, ~> 1.0.1)'
+  - JSONKit (1.4)
+  - monkey (1.0.8)
+
+DEPENDENCIES:
+  - BananaLib (~> 1.0)
+  - 'JSONKit (from `path/JSONKit.podspec`)'
+
+EXTERNAL SOURCES:
+  JSONKit:
+    :podspec: path/JSONKit.podspec
+
+CHECKOUT OPTIONS:
+  JSONKit:
+    :podspec: path/JSONKit.podspec
+
+SPEC CHECKSUMS:
+  BananaLib: d46ca864666e216300a0653de197668b12e732a1
+  JSONKit: 92ae5f71b77c8dec0cd8d0744adab79d38560949
+
+PODFILE CHECKSUM: podfile_checksum
+
+COCOAPODS: PLACEHOLDER_CORE_VERSION

--- a/spec/lockfile_spec.rb
+++ b/spec/lockfile_spec.rb
@@ -8,13 +8,13 @@ module Pod
       <<-LOCKFILE.strip_heredoc
         PODS:
           - BananaLib (1.0):
-            - monkey (< 1.0.9, ~> 1.0.1)
+            - "monkey (< 1.0.9, ~> 1.0.1)"
           - JSONKit (1.4)
           - monkey (1.0.8)
 
         DEPENDENCIES:
           - BananaLib (~> 1.0)
-          - JSONKit (from `path/JSONKit.podspec`)
+          - "JSONKit (from `path/JSONKit.podspec`)"
 
         EXTERNAL SOURCES:
           JSONKit:
@@ -27,36 +27,6 @@ module Pod
         SPEC CHECKSUMS:
           BananaLib: d46ca864666e216300a0653de197668b12e732a1
           JSONKit: 92ae5f71b77c8dec0cd8d0744adab79d38560949
-
-        PODFILE CHECKSUM: podfile_checksum
-
-        COCOAPODS: #{CORE_VERSION}
-      LOCKFILE
-    end
-
-    def self.quotation_marks_yaml
-      <<-LOCKFILE.strip_heredoc
-        PODS:
-          - BananaLib (1.0):
-            - monkey (< 1.0.9, ~> 1.0.1)
-          - JSONKit (1.4)
-          - monkey (1.0.8)
-
-        DEPENDENCIES:
-          - BananaLib (~> 1.0)
-          - JSONKit (from `path/JSONKit.podspec`)
-
-        EXTERNAL SOURCES:
-          JSONKit:
-            :podspec: "path/JSONKit.podspec"
-
-        CHECKOUT OPTIONS:
-          JSONKit:
-            :podspec: path/JSONKit.podspec
-
-        SPEC CHECKSUMS:
-          BananaLib: d46ca864666e216300a0653de197668b12e732a1
-          JSONKit: '92ae5f71b77c8dec0cd8d0744adab79d38560949'
 
         PODFILE CHECKSUM: podfile_checksum
 
@@ -346,10 +316,10 @@ module Pod
       end
 
       it 'fix strange quotation marks in lockfile' do
-        yaml_string = Sample.quotation_marks_yaml
-        yaml_string = yaml_string.tr("'", '')
-        yaml_string = yaml_string.tr('"', '')
-        yaml_string.should == Sample.yaml
+        file_path = fixture('lock_files/Podfile.lock')
+        lockfile = Lockfile.from_file(file_path)
+        lockfile_yaml = lockfile.to_yaml.gsub('PLACEHOLDER_CORE_VERSION', CORE_VERSION)
+        lockfile_yaml.should == Sample.yaml
       end
 
       it 'generates a hash representation' do


### PR DESCRIPTION
This should fix an issue introduced by #381 with keys that contain !, also reported by @lcniles [here](https://github.com/CocoaPods/Core/pull/381#commitcomment-23725675).

To reproduce the problem: 
- Checkout https://github.com/Ruenzuo/reimagined-guide
- Run `bundle exec pod install`, CocoaPods will fail because Psych can't parse the Podfile.lock with keys stating with [exclamation mark](https://github.com/Ruenzuo/reimagined-guide/blob/master/Podfile.lock#L2). Error raised by Psych:

```
Psych::SyntaxError: (<unknown>): mapping values are not allowed in this context at line 48 column 28
from /Users/crisosto/.rbenv/versions/2.2.7/lib/ruby/2.2.0/psych.rb:370:in `parse'
```

I think we should keep the double quotes, but replace all single quotes to be double quotes too, otherwise we'll run again into the issue described by @orta [here](https://github.com/CocoaPods/Core/pull/381#issuecomment-306116267).

The verify the fix:
- Checkout `fixed` branch, it uses this revision.
- Delete Podfile.lock from the sample project.
- Run `bundle exec pod install` twice. It works 🎉