### PR TITLE
Unset GIT_CONFIG when running commands

### DIFF
--- a/lib/cocoapods-core/source.rb
+++ b/lib/cocoapods-core/source.rb
@@ -435,7 +435,7 @@ module Pod
     end
 
     def repo_git(args, include_error: false)
-      command = "git -C \"#{repo}\" " << args.join(' ')
+      command = "env -u GIT_CONFIG git -C \"#{repo}\" " << args.join(' ')
       command << ' 2>&1' if include_error
       (`#{command}` || '').strip
     end

--- a/spec/master_source_spec.rb
+++ b/spec/master_source_spec.rb
@@ -25,8 +25,8 @@ module Pod
       end
 
       it 'uses the only fast forward git option' do
-        @source.expects(:`).with("git -C \"#{@path}\" checkout master")
-        @source.expects(:`).with("git -C \"#{@path}\" pull --ff-only 2>&1")
+        @source.expects(:`).with("env -u GIT_CONFIG git -C \"#{@path}\" checkout master")
+        @source.expects(:`).with("env -u GIT_CONFIG git -C \"#{@path}\" pull --ff-only 2>&1")
         @source.send :update_git_repo
       end
 

--- a/spec/source_spec.rb
+++ b/spec/source_spec.rb
@@ -248,8 +248,8 @@ module Pod
       end
 
       it 'uses the only fast forward git option' do
-        @source.expects(:`).with("git -C \"#{@path}\" checkout master")
-        @source.expects(:`).with("git -C \"#{@path}\" pull --ff-only 2>&1")
+        @source.expects(:`).with("env -u GIT_CONFIG git -C \"#{@path}\" checkout master")
+        @source.expects(:`).with("env -u GIT_CONFIG git -C \"#{@path}\" pull --ff-only 2>&1")
         @source.send :update_git_repo
       end
 
@@ -257,8 +257,8 @@ module Pod
         path = @source.repo.join('.git', 'cocoapods_branch')
         path.dirname.mkpath
         path.open('w') { |f| f << 'random_branch' }
-        @source.expects(:`).with("git -C \"#{@path}\" checkout random_branch")
-        @source.expects(:`).with("git -C \"#{@path}\" pull --ff-only 2>&1")
+        @source.expects(:`).with("env -u GIT_CONFIG git -C \"#{@path}\" checkout random_branch")
+        @source.expects(:`).with("env -u GIT_CONFIG git -C \"#{@path}\" pull --ff-only 2>&1")
         begin
           @source.send(:update_git_repo)
         ensure


### PR DESCRIPTION
GIT_CONFIG is an environment variable that overrides which files `config
--get` actually fetches from. The benefit in setting this is that if you
want to add configuration, you don't have to use `--global`. I would
never recommend anyone set this, but in the case that you do, CocoaPods
can never find local specs repos by matching URLs, since getting
remote.origin.url will come from a different file, and likely always be
empty.

There's a `--local` flag that is also supposed to be the opposite of
`--global` for this, but setting this when GIT_CONFIG is set results in
an error. The other option would be to pass the file explicitly with
`--file .git/config`, but this feels more fragile.