### PR TITLE
Add Range header to HTTP::perform_head_request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ##### Enhancements
 
+* `HTTP::perform_head_request` now includes a 1-byte `Range` header in the fallback GET
+  request.
+  [Kyle Fleming](https://github.com/kylefleming)
+  [#425](https://github.com/CocoaPods/Core/pull/425)
+
 * Update Podfile Reference Guide to include `:source` parameter for the `pod` statement  
   [Mark Woollard](https://github.com/mwoollard)
   [#7359](https://github.com/CocoaPods/CocoaPods/issues/7359)

--- a/lib/cocoapods-core/http.rb
+++ b/lib/cocoapods-core/http.rb
@@ -44,7 +44,7 @@ module Pod
       begin
         url = get_actual_url(url)
         resp = perform_head_request(url)
-      rescue SocketError, URI::InvalidURIError, REST::Error, REST::DisconnectedError
+      rescue SocketError, URI::InvalidURIError, REST::Error, REST::Error::Connection
         resp = nil
       end
 
@@ -65,7 +65,12 @@ module Pod
       resp = ::REST.head(url, 'User-Agent' => USER_AGENT)
 
       if resp.status_code >= 400
-        resp = ::REST.get(url, 'User-Agent' => USER_AGENT)
+        resp = ::REST.get(url, 'User-Agent' => USER_AGENT,
+                               'Range' => 'bytes=0-0')
+
+        if resp.status_code >= 400
+          resp = ::REST.get(url, 'User-Agent' => USER_AGENT)
+        end
       end
 
       resp

--- a/spec/http_spec.rb
+++ b/spec/http_spec.rb
@@ -2,6 +2,10 @@ require File.expand_path('../spec_helper', __FILE__)
 
 module Pod
   describe HTTP do
+    after do
+      WebMock.reset!
+    end
+
     describe 'In general' do
       it 'can resolve redirects' do
         WebMock::API.stub_request(:head, /redirect/).to_return(
@@ -28,7 +32,7 @@ module Pod
         response.success?.should.be.true
       end
 
-      it 'is resilient to HEAD errros' do
+      it 'is resilient to HEAD errors' do
         WebMock::API.stub_request(:head, /foo/).to_return(:status => 404)
         WebMock::API.stub_request(:get, /foo/).to_return(:status => 200)
 
@@ -50,9 +54,33 @@ module Pod
       end
 
       it 'uses a browser user-agent to validate URLs' do
-        WebMock::API.stub_request(:get, 'http://SOME-URL/foo').
+        WebMock::API.stub_request(:head, /foo/).to_return(:status => 404)
+        WebMock::API.stub_request(:get, /foo/).
           with(:headers => { :user_agent => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10) AppleWebKit/538.43.40 (KHTML, like Gecko) Version/8.0 Safari/538.43.40' }).
           to_return(:status => 200, :body => '')
+
+        response = HTTP.validate_url('http://SOME-URL/foo')
+        response.success?.should.be.true
+      end
+
+      it 'uses GET with Range of 1 byte' do
+        WebMock::API.stub_request(:head, /foo/).to_return(:status => 404)
+        WebMock::API.stub_request(:get, /foo/).
+            with(:headers => { :range => 'bytes=0-0' }).
+            to_return(:status => 200, :body => ' ')
+
+        response = HTTP.validate_url('http://SOME-URL/foo')
+        response.success?.should.be.true
+      end
+
+      it 'uses GET without Range if server rejects Range' do
+        WebMock::API.stub_request(:head, /foo/).to_return(:status => 404)
+        WebMock::API.stub_request(:get, /foo/).
+            with(:headers => { :range => 'bytes=0-0' }).
+            to_return(:status => 500)
+        WebMock::API.stub_request(:get, /foo/).
+            with { |request| request.headers.nil? || !request.headers.key?('Range') }.
+            to_return(:status => 200, :body => '')
 
         response = HTTP.validate_url('http://SOME-URL/foo')
         response.success?.should.be.true


### PR DESCRIPTION
Uses a GET request with a 1 byte Range header if the initial HEAD request fails. Falls back to a GET request without a Range header if that also fails.

Closes #420

### Discussion
I've added the GET request with a Range header as an additional fallback and kept the original non-Range GET request as the final fallback. This is because I wasn't sure if we should expect that a server might respond to a normal GET request but return an error if the GET request includes a Range header.

My intuition would say that almost all servers that don't respond to a Range header would just ignore it and proceed as if it didn't exist. In this case, we wouldn't need the third non-Range fallback. Do we think this is a case that we would want to support? Having all 3 is the more conservative route, but adds additional latency in returning a result if the server doesn't have the content at all.

I think ideally we'd remove the third non-Range fallback, but I wanted to submit this PR with it in, in case it is decided that it's necessary.