### PR TITLE
[Lockfile] Only put root spec names under SPEC REPOS

### DIFF
--- a/lib/cocoapods-core/lockfile.rb
+++ b/lib/cocoapods-core/lockfile.rb
@@ -462,7 +462,9 @@ module Pod
         Hash[spec_repos.map do |source, specs|
           next unless source
           next if specs.empty?
-          [source.url || source.name, specs.map(&:name)]
+          key = source.url || source.name
+          value = specs.map { |s| s.root.name }.uniq
+          [key, value]
         end.compact]
       end
 

--- a/spec/lockfile_spec.rb
+++ b/spec/lockfile_spec.rb
@@ -205,6 +205,18 @@ module Pod
         end.compact]
       end
 
+      it 'only includes root names in spec repo sources' do
+        @lockfile = Lockfile.generate(Sample.podfile, [], {}, Source.new(fixture('spec-repos/master')) => Pod::Spec.new do |s|
+                                                                                                            s.name = 'foo'
+                                                                                                            s.version = '1.0.0'
+                                                                                                            s.subspec 'Core'
+                                                                                                            s.subspec 'NotCore'
+                                                                                                          end.recursive_subspecs)
+        @lockfile.pods_by_spec_repo.should == {
+          'https://github.com/CocoaPods/Specs.git' => %w(foo),
+        }
+      end
+
       it 'includes the external source information in the generated dependencies' do
         dep = @lockfile.dependencies.find { |d| d.name == 'JSONKit' }
         dep.external_source.should == { :podspec => 'path/JSONKit.podspec' }


### PR DESCRIPTION
Fixes a bug in an unreleased feature, hence no CHANGELOG