### PR TITLE
Fix crash when there's an empty source spec directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
   
 ##### Bug Fixes
 
+* Fix crash when there's an empty source spec directory  
+  [Paul Beusterien](https://github.com/paulb777)
+  [#6381](https://github.com/CocoaPods/CocoaPods/issues/6381)
+
 * The `Dependency#merge` method takes into account any `podspec_repo`s the dependencies
   may have set.  
   [Samuel Giddins](https://github.com/segiddins)

--- a/lib/cocoapods-core/source.rb
+++ b/lib/cocoapods-core/source.rb
@@ -262,7 +262,13 @@ module Pod
       if query.is_a?(Dependency)
         query = query.root_name
       end
-      found = Pathname.glob(pod_path(query)).map { |path| path.basename.to_s }
+
+      found = []
+      Pathname.glob(pod_path(query)) do |path|
+        next unless Dir.foreach(path).any? { |child| child != '.' && child != '..' }
+        found << path.basename.to_s
+      end
+
       if [query] == found
         set = set(query)
         set if set.specification_name == query

--- a/spec/source_spec.rb
+++ b/spec/source_spec.rb
@@ -131,6 +131,15 @@ module Pod
         @source.search('bAnAnAlIb').should.be.nil?
       end
 
+      describe 'when there is an empty directory' do
+        before { @empty_dir = @path.join('Specs', 'Empty').tap(&:mkpath) }
+        after { FileUtils.rm_r @empty_dir }
+
+        it 'returns nil' do
+          @source.search('Empty').should.be.nil
+        end
+      end
+
       describe '#search_by_name' do
         it 'properly configures the sources of a set in search by name' do
           source = Source.new(fixture('spec-repos/test_repo'))


### PR DESCRIPTION
Fix https://github.com/CocoaPods/CocoaPods/issues/6381

If a source spec directory has had all of its version subdirectories removed, `pod install` would crash with `TypeError - no implicit conversion of nil into String` at `cocoapods-core/specification.rb:584`.

The empty directory would occur if a Spec repo previously had one or more versions of a particular pod and then all of the versions were removed.

The workaround was to delete ~/.cocoapods/repos/{repo}/ or just the offending empty directory.