### PR TITLE
[Lockfile] Always serialize as valid YAML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 * Fix crash when there's an empty source spec directory  
   [Paul Beusterien](https://github.com/paulb777)
-  [#6381](https://github.com/CocoaPods/CocoaPods/issues/6381)
+  [CocoaPods#6381](https://github.com/CocoaPods/CocoaPods/issues/6381)
 
 * The `Dependency#merge` method takes into account any `podspec_repo`s the dependencies
   may have set.  
@@ -32,6 +32,11 @@
 
 * When evaluating `.podspec` files, ensure that `__FILE__` refers to the correct file.  
   [Samuel Giddins](https://github.com/segiddins)
+
+* Serialize lockfiles that contain Pods with non-alphanumeric characters 
+  (such as `!`) properly.  
+  [Samuel Giddins](https://github.com/segiddins)
+  [CocoaPods#7302](https://github.com/CocoaPods/CocoaPods/issues/7302)
 
 
 ## 1.4.0 (2018-01-18)

--- a/lib/cocoapods-core/lockfile.rb
+++ b/lib/cocoapods-core/lockfile.rb
@@ -385,9 +385,7 @@ module Pod
     # @note   The YAML string is prettified.
     #
     def to_yaml
-      yaml_string = YAMLHelper.convert_hash(to_hash, HASH_KEY_ORDER, "\n\n")
-      yaml_string = yaml_string.tr("'", '')
-      yaml_string.tr('"', '')
+      YAMLHelper.convert_hash(to_hash, HASH_KEY_ORDER, "\n\n")
     end
 
     #-------------------------------------------------------------------------#

--- a/spec/yaml_helper_spec.rb
+++ b/spec/yaml_helper_spec.rb
@@ -45,9 +45,14 @@ module Pod
           'false' => "'false'",
           'null' => "'null'",
           '-1' => "'-1'",
-          '' => '""',
+          '' => "''",
           '!' => '"!"',
+          '!ProtoCompiler' => '"!ProtoCompiler"',
           '~' => "'~'",
+          'foo:' => '"foo:"',
+          'https://github.com/CocoaPods/Core.git' => 'https://github.com/CocoaPods/Core.git',
+          'a (from `b`)' => 'a (from `b`)',
+          'monkey (< 1.0.9, ~> 1.0.1)' => 'monkey (< 1.0.9, ~> 1.0.1)',
         }.each do |given, expected|
           converted = YAMLHelper.convert(given)
           converted[0..-2].should == expected


### PR DESCRIPTION
even if it means there are some quotes

Some things simply cannot exist as plain, unquotes scalars in YAML. Instead of blindly stripping all quotes from the generated lockfile, we are instead more conservative when quoting string during generation. We still quote more than is technically necessary according to the YAML spec, but this is about as accurate as I was willing to get.

Closes https://github.com/CocoaPods/CocoaPods/issues/7302 by partially reverting https://github.com/CocoaPods/Core/pull/381/files