### PR TITLE
Fix `requires_app_host` documentation

### DIFF
--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -1444,7 +1444,7 @@ module Pod
 
       # @!method requires_app_host=(flag)
       #
-      #  Whether a test specification requires an app host to run tests. This only applies to test specifications.
+      #   Whether a test specification requires an app host to run tests. This only applies to test specifications.
       #
       #   @example
       #


### PR DESCRIPTION
Bad
<img width="880" alt="screen shot 2018-03-25 at 9 17 01 am" src="https://user-images.githubusercontent.com/310370/37877294-ce3092b0-300d-11e8-9781-c1909e4e5ef3.png">

I think this fixes it?
