### PR TITLE
Provide a helpful error message when attempting to assign a value to `dependency`

### DIFF
--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -666,6 +666,12 @@ module Pod
         attributes_hash['dependencies'][name] = version_requirements
       end
 
+      def dependency=(args)
+        joined = args.join('\', \'')
+        arguments = "\'#{joined}\'"
+        raise Informative, "Cannot assign value to `dependency`. Did you mean: `dependency #{arguments}`?"
+      end
+
       #------------------#
 
       # @!method requires_arc=(flag)

--- a/spec/specification/dsl_spec.rb
+++ b/spec/specification/dsl_spec.rb
@@ -217,6 +217,12 @@ module Pod
             @spec.dependency('SVProgressHUD', :head)
           end.message.should.match /Unsupported version requirements/
         end
+
+        it 'raises when attempting to assign a value to dependency' do
+          should.raise Informative do
+            @spec.dependency = 'JSONKit', '1.5'
+          end.message.should.match /Cannot assign value to `dependency`. Did you mean: `dependency 'JSONKit', '1.5'`?/
+        end
       end
 
       #------------------#


### PR DESCRIPTION
closes https://github.com/CocoaPods/CocoaPods/issues/7576

I've definitely made the same mistake before.