### PR TITLE
Cache result of `Specification#checksum` and `Podfile#checksum` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 
 ##### Bug Fixes
 
-* None.  
+* Cache result of `Specification#checksum` and `Podfile#checksum` methods  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [CocoaPods#7854](https://github.com/CocoaPods/CocoaPods/issues/7854)
 
 
 ## 1.5.3 (2018-05-25)

--- a/lib/cocoapods-core/podfile.rb
+++ b/lib/cocoapods-core/podfile.rb
@@ -223,11 +223,13 @@ module Pod
     # @return [Nil] If the podfile is not defined in a file.
     #
     def checksum
-      unless defined_in_file.nil?
-        require 'digest'
-        checksum = Digest::SHA1.hexdigest(File.read(defined_in_file))
-        checksum = checksum.encode('UTF-8') if checksum.respond_to?(:encode)
-        checksum
+      @checksum ||= begin
+        unless defined_in_file.nil?
+          require 'digest'
+          checksum = Digest::SHA1.hexdigest(File.read(defined_in_file))
+          checksum = checksum.encode('UTF-8') if checksum.respond_to?(:encode)
+          checksum
+        end
       end
     end
 

--- a/lib/cocoapods-core/specification.rb
+++ b/lib/cocoapods-core/specification.rb
@@ -561,11 +561,17 @@ module Pod
     # @return [Nil] If the specification is not defined in a file.
     #
     def checksum
-      unless defined_in_file.nil?
-        require 'digest'
-        checksum = Digest::SHA1.hexdigest(File.read(defined_in_file))
-        checksum = checksum.encode('UTF-8') if checksum.respond_to?(:encode)
-        checksum
+      @checksum ||= begin
+        if root?
+          unless defined_in_file.nil?
+            require 'digest'
+            checksum = Digest::SHA1.hexdigest(File.read(defined_in_file))
+            checksum = checksum.encode('UTF-8') if checksum.respond_to?(:encode)
+            checksum
+          end
+        else
+          root.checksum
+        end
       end
     end
 


### PR DESCRIPTION
closes https://github.com/CocoaPods/CocoaPods/issues/7854

On a large project I noticed this gets called multiple times for the same specification which can be costly.

/cc @Whirlwind