### PR TITLE
[Version] Stop parsing legacy HEAD versions

### DIFF
--- a/lib/cocoapods-core/version.rb
+++ b/lib/cocoapods-core/version.rb
@@ -43,14 +43,7 @@ module Pod
     # @param  [String,Version] version
     #         A string representing a version, or another version.
     #
-    # @todo   Remove the `HEAD` code once everyone has migrated past 1.0.
-    #
     def initialize(version)
-      if version.is_a?(String) && version =~ /HEAD based on (.*)/
-        CoreUI.warn "Ignoring obsolete HEAD specifier in `#{version}`"
-        version = Regexp.last_match[1]
-      end
-
       raise ArgumentError, "Malformed version number string #{version}" unless
         self.class.correct?(version)
 

--- a/spec/dependency_spec.rb
+++ b/spec/dependency_spec.rb
@@ -125,13 +125,6 @@ module Pod
         dependency.requirement.as_list.should == ['= 1.23']
       end
 
-      it 'warns with head information' do
-        dependency = Dependency.new('cocoapods', '> 1.0')
-        dependency.specific_version = Version.new('HEAD based on 1.23')
-        dependency.requirement.as_list.should == ['= 1.23']
-        CoreUI.warnings.should == 'Ignoring obsolete HEAD specifier in `HEAD based on 1.23`'
-      end
-
       #--------------------------------------#
 
       it 'preserves the external source on duplication' do

--- a/spec/specification_spec.rb
+++ b/spec/specification_spec.rb
@@ -169,12 +169,6 @@ module Pod
           version.should == Version.new('1.0')
         end
 
-        it 'takes into account head information while returning the name and the version' do
-          name, version = Specification.name_and_version_from_string('libPusher (HEAD based on 1.0)')
-          name.should == 'libPusher'
-          version.should == Version.new('HEAD based on 1.0')
-        end
-
         it 'takes into account the full name of the subspec returning the name and the version' do
           string = 'RestKit/JSON (1.0)'
           name = Specification.name_and_version_from_string(string).first

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -13,12 +13,6 @@ module Pod
         version.version.should == '1.2.3'
       end
 
-      it 'initializes from a string containing head information' do
-        version = Version.new('HEAD based on 1.2.3')
-        version.version.should == '1.2.3'
-        CoreUI.warnings.should == 'Ignoring obsolete HEAD specifier in `HEAD based on 1.2.3`'
-      end
-
       it 'serializes to a string' do
         version = Version.new('1.2.3')
         version.to_s.should == '1.2.3'


### PR DESCRIPTION
It's been 2 years since they were removed, and this saves a regexp match on every version allocation