### PR TITLE
Use the `podspec :subspec=>'xx'` to load dependencies from a subspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ##### Enhancements
 
-* None.  
+* Add support for specifying subspecs when using the `podspec` Podfile attribute  
+  [Whirlwind](https://github.com/whirlwind)
+  [#456](https://github.com/CocoaPods/Core/pull/456)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods-core/podfile/target_definition.rb
+++ b/lib/cocoapods-core/podfile/target_definition.rb
@@ -663,15 +663,24 @@ module Pod
       # @return [void]
       #
       def store_podspec(options = nil)
-        if options
-          unless options.keys.all? { |key| [:name, :path].include?(key) }
-            raise StandardError, 'Unrecognized options for the podspec ' \
-              "method `#{options}`"
-          end
-          get_hash_value('podspecs', []) << options
-        else
-          get_hash_value('podspecs', []) << { :autodetect => true }
+        options ||= {}
+        unless options.keys.all? { |key| [:name, :path, :subspecs, :subspec].include?(key) }
+          raise StandardError, 'Unrecognized options for the podspec ' \
+            "method `#{options}`"
         end
+        if subspec_name = options[:subspec]
+          unless subspec_name.is_a?(String)
+            raise StandardError, "Option `:subspec => #{subspec_name.inspect}` should be a String"
+          end
+        end
+        if subspec_names = options[:subspecs]
+          if !subspec_names.is_a?(Array) || !subspec_names.all? { |name| name.is_a? String }
+            raise StandardError, "Option `:subspecs => #{subspec_names.inspect}` " \
+            'should be an Array of Strings'
+          end
+        end
+        options[:autodetect] = true if !options.include?(:name) && !options.include?(:path)
+        get_hash_value('podspecs', []) << options
       end
 
       #--------------------------------------#
@@ -907,9 +916,18 @@ module Pod
         podspecs.map do |options|
           file = podspec_path_from_options(options)
           spec = Specification.from_file(file)
-          all_specs = [spec, *spec.recursive_subspecs]
-          all_deps = all_specs.map { |s| s.dependencies(platform) }.flatten
-          all_deps.reject { |dep| dep.root_name == spec.root.name }
+          subspec_names = options[:subspecs] || options[:subspec]
+          specs = if subspec_names.blank?
+                    [spec]
+                  else
+                    subspec_names = [subspec_names] if subspec_names.is_a?(String)
+                    subspec_names.map { |subspec_name| spec.subspec_by_name("#{spec.name}/#{subspec_name}") }
+                  end
+          specs.map do |subspec|
+            all_specs = [subspec, *subspec.recursive_subspecs]
+            all_deps = all_specs.map { |s| s.dependencies(platform) }.flatten
+            all_deps.reject { |dep| dep.root_name == subspec.root.name }
+          end.flatten
         end.flatten.uniq
       end
 

--- a/spec/fixtures/BananaLib.podspec
+++ b/spec/fixtures/BananaLib.podspec
@@ -31,5 +31,11 @@ Pod::Spec.new do |s|
   s.dependency   'monkey', '~> 1.0.1', '< 1.0.9'
   s.subspec "GreenBanana" do |ss|
     ss.source_files = 'GreenBanana'
+    ss.dependency 'AFNetworking'
+  end
+
+  s.subspec "YellowBanana" do |ss|
+    ss.source_files = 'YellowBanana'
+    ss.dependency 'SDWebImage'
   end
 end

--- a/spec/fixtures/BananaLib.podspec.json
+++ b/spec/fixtures/BananaLib.podspec.json
@@ -44,7 +44,17 @@
   "subspecs": [
     {
       "name": "GreenBanana",
-      "source_files": "GreenBanana"
+      "source_files": "GreenBanana",
+      "dependencies": {
+        "AFNetworking": []
+      }
+    },
+    {
+      "name": "YellowBanana",
+      "source_files": "YellowBanana",
+      "dependencies": {
+        "SDWebImage": []
+      }
     }
   ]
 }

--- a/spec/podfile/dsl_spec.rb
+++ b/spec/podfile/dsl_spec.rb
@@ -405,7 +405,16 @@ module Pod
           platform :ios
           podspec :path => banalib_path
         end
-        podfile.dependencies.map(&:name).should == %w(monkey)
+        podfile.dependencies.map(&:name).should == %w(monkey AFNetworking SDWebImage)
+      end
+
+      it 'it can use use the dependencies of a podspec\'s subspec' do
+        banalib_path = fixture('BananaLib.podspec').to_s
+        podfile = Podfile.new(fixture('Podfile')) do
+          platform :ios
+          podspec :path => banalib_path, :subspec => 'GreenBanana'
+        end
+        podfile.dependencies.map(&:name).should == %w(monkey AFNetworking)
       end
 
       it 'allows specifying a child target definition' do

--- a/spec/podfile/target_definition_spec.rb
+++ b/spec/podfile/target_definition_spec.rb
@@ -554,6 +554,35 @@ module Pod
         ]
       end
 
+      it 'stores a dependency on a podspec\'s subspec' do
+        @parent.store_podspec(:subspec => 'Subspec')
+        @parent.send(:get_hash_value, 'podspecs').should == [
+          { :autodetect => true,
+            :subspec => 'Subspec',
+           },
+        ]
+      end
+
+      it 'stores a dependency on a podspec\'s subspecs' do
+        @parent.store_podspec(:subspecs => ['Subspec'])
+        @parent.send(:get_hash_value, 'podspecs').should == [
+          { :autodetect => true,
+            :subspecs => ['Subspec'],
+           },
+        ]
+      end
+
+      it 'raises if the provided podspec option type is error' do
+        e = lambda { @parent.store_podspec(:subspec => 123) }.should.raise Podfile::StandardError
+        e.message.should.match /should be a String/
+
+        e = lambda { @parent.store_podspec(:subspecs => 123) }.should.raise Podfile::StandardError
+        e.message.should.match /should be an Array of Strings/
+
+        e = lambda { @parent.store_podspec(:subspecs => ['a', 123]) }.should.raise Podfile::StandardError
+        e.message.should.match /should be an Array of Strings/
+      end
+
       it 'raises if the provided podspec options are unsupported' do
         e = lambda { @parent.store_podspec(:invent => 'BlocksKit') }.should.raise Podfile::StandardError
         e.message.should.match /Unrecognized options/
@@ -671,6 +700,17 @@ module Pod
           @parent.store_podspec(:path => path)
           @parent.send(:podspec_dependencies).should == [
             Dependency.new('monkey', '< 1.0.9', '~> 1.0.1'),
+            Dependency.new('AFNetworking'),
+            Dependency.new('SDWebImage'),
+          ]
+        end
+
+        it 'returns the dependencies of a subspec' do
+          path = SpecHelper::Fixture.fixture('BananaLib.podspec').to_s
+          @parent.store_podspec(:path => path, :subspec => 'GreenBanana')
+          @parent.send(:podspec_dependencies).should == [
+            Dependency.new('monkey', '< 1.0.9', '~> 1.0.1'),
+            Dependency.new('AFNetworking'),
           ]
         end
 

--- a/spec/specification/json_spec.rb
+++ b/spec/specification/json_spec.rb
@@ -81,10 +81,18 @@ module Pod
 
       it 'handles subspecs when converted to a hash' do
         hash = @spec.to_hash
-        hash['subspecs'].should == [{
-          'name' => 'GreenBanana',
-          'source_files' => 'GreenBanana',
-        }]
+        hash['subspecs'].should == [
+          {
+            'name' => 'GreenBanana',
+            'source_files' => 'GreenBanana',
+            'dependencies' => { 'AFNetworking' => [] },
+          },
+          {
+            'name' => 'YellowBanana',
+            'source_files' => 'YellowBanana',
+            'dependencies' => { 'SDWebImage' => [] },
+          },
+        ]
       end
 
       it 'handles subspecs with different platforms' do
@@ -94,14 +102,22 @@ module Pod
           'tvos' => '9.0',
         }
         hash = @spec.to_hash
-        hash['subspecs'].should == [{
-          'name' => 'GreenBanana',
-          'source_files' => 'GreenBanana',
-          'platforms' => {
-            'ios' => '9.0',
-            'tvos' => '9.0',
+        hash['subspecs'].should == [
+          {
+            'name' => 'GreenBanana',
+            'source_files' => 'GreenBanana',
+            'dependencies' => { 'AFNetworking' => [] },
+            'platforms' => {
+              'ios' => '9.0',
+              'tvos' => '9.0',
+            },
           },
-        }]
+          {
+            'name' => 'YellowBanana',
+            'source_files' => 'YellowBanana',
+            'dependencies' => { 'SDWebImage' => [] },
+          },
+        ]
       end
 
       it 'handles subspecs when the parent spec specifies platforms and the subspec inherits' do
@@ -109,10 +125,18 @@ module Pod
           'tvos' => '9.0',
         }
         hash = @spec.to_hash
-        hash['subspecs'].should == [{
-          'name' => 'GreenBanana',
-          'source_files' => 'GreenBanana',
-        }]
+        hash['subspecs'].should == [
+          {
+            'name' => 'GreenBanana',
+            'source_files' => 'GreenBanana',
+            'dependencies' => { 'AFNetworking' => [] },
+          },
+          {
+            'name' => 'YellowBanana',
+            'source_files' => 'YellowBanana',
+            'dependencies' => { 'SDWebImage' => [] },
+          },
+        ]
       end
 
       it 'writes script phases' do
@@ -132,10 +156,18 @@ module Pod
       it 'writes test type for test subspec' do
         @spec.test_spec {}
         hash = @spec.to_hash
-        hash['subspecs'].should == [{
-          'name' => 'GreenBanana',
-          'source_files' => 'GreenBanana',
-        }]
+        hash['subspecs'].should == [
+          {
+            'name' => 'GreenBanana',
+            'source_files' => 'GreenBanana',
+            'dependencies' => { 'AFNetworking' => [] },
+          },
+          {
+            'name' => 'YellowBanana',
+            'source_files' => 'YellowBanana',
+            'dependencies' => { 'SDWebImage' => [] },
+          },
+        ]
         hash['testspecs'].should == [{
           'name' => 'Tests',
           'test_type' => :unit,

--- a/spec/specification_spec.rb
+++ b/spec/specification_spec.rb
@@ -632,7 +632,7 @@ module Pod
       end
 
       it 'returns the checksum of the file in which it is defined' do
-        @spec.checksum.should == '2060b3e89229b8b30e6bf1a7730ddefdd7669730'
+        @spec.checksum.should == '4fb39cb6f34f694ab489d39df699c5b7c7f9ac79'
       end
 
       it 'returns a nil checksum if the specification is not defined in a file' do


### PR DESCRIPTION
Sometimes, I use the `podspec` in a Podfile to load dependencies from a `.podspec` file. But I often just load one or some subspec(s) from the podspec file, not load all dependencies.
eg: this is a Podspec:
```
s.dependency 'SDWebImage'
s.subspec 'ASI' do |s1|
    s1.dependency 'ASIHTTPRequest'
end
s.subspec 'AF' do |s2|
    s2.dependency 'AFNetworking'
end
```
this is a Podfile:
```
target :SDKForASI do
    podspec :subspec=>'ASI'
end
target :SDKForAF do
    podspec :subspec=>'AF'
end
```

I need the target have different dependencies from different subspecs. This PR will add a option `subspec`(`subspecs`) to the `podspec` DSL.