### PR TITLE
Add `type` attribute to `Specification` and use that to determine if it's a test_spec

### DIFF
--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -1341,7 +1341,7 @@ module Pod
       #           the path to the module map file that should be used.
       #
       attribute :module_map,
-                :root_only     => true
+                :spec_types => [:root]
 
       #-----------------------------------------------------------------------#
 
@@ -1420,7 +1420,7 @@ module Pod
       #   end
       #
       def subspec(name, &block)
-        subspec = Specification.new(self, name, &block)
+        subspec = Specification.new(self, name, :sub, &block)
         @subspecs << subspec
         subspec
       end
@@ -1443,10 +1443,11 @@ module Pod
       #
       # @param  [Symbol, String] type
       #         The test type to use.
+      #
       attribute :test_type,
                 :types => [Symbol, String],
                 :multi_platform => false,
-                :test_only => true
+                :spec_types => [:test]
 
       # @!method requires_app_host=(flag)
       #
@@ -1462,7 +1463,7 @@ module Pod
       attribute :requires_app_host,
                 :types => [TrueClass, FalseClass],
                 :default_value => false,
-                :test_only => true
+                :spec_types => [:test]
 
       # Represents a test specification for the library. Here you can place all
       # your tests for your podspec along with the test dependencies.
@@ -1481,7 +1482,7 @@ module Pod
       #   end
       #
       def test_spec(name = 'Tests', &block)
-        subspec = Specification.new(self, name, true, &block)
+        subspec = Specification.new(self, name, :test, &block)
         @subspecs << subspec
         subspec
       end
@@ -1519,7 +1520,7 @@ module Pod
                 :container => Array,
                 :singularize => true,
                 :multi_platform => false,
-                :root_only => true
+                :spec_types => [:root]
 
       #-----------------------------------------------------------------------#
 

--- a/lib/cocoapods-core/specification/dsl/attribute.rb
+++ b/lib/cocoapods-core/specification/dsl/attribute.rb
@@ -29,19 +29,18 @@ module Pod
         def initialize(name, options)
           @name = name
 
-          @multi_platform = options.delete(:multi_platform) { true       }
-          @root_only      = options.delete(:root_only)      { false      }
-          @test_only      = options.delete(:test_only)      { false      }
-          @inherited      = options.delete(:inherited)      { @root_only }
-          @required       = options.delete(:required)       { false      }
-          @singularize    = options.delete(:singularize)    { false      }
-          @file_patterns  = options.delete(:file_patterns)  { false      }
-          @container      = options.delete(:container)      { nil        }
-          @keys           = options.delete(:keys)           { nil        }
-          @default_value  = options.delete(:default_value)  { nil        }
-          @ios_default    = options.delete(:ios_default)    { nil        }
-          @osx_default    = options.delete(:osx_default)    { nil        }
-          @types          = options.delete(:types)          { [String]   }
+          @multi_platform = options.delete(:multi_platform) { true }
+          @spec_types     = options.delete(:spec_types)     { [:root, :sub, :test] }
+          @inherited      = options.delete(:inherited)      { root_only? }
+          @required       = options.delete(:required)       { false }
+          @singularize    = options.delete(:singularize)    { false }
+          @file_patterns  = options.delete(:file_patterns)  { false }
+          @container      = options.delete(:container)      { nil }
+          @keys           = options.delete(:keys)           { nil }
+          @default_value  = options.delete(:default_value)  { nil }
+          @ios_default    = options.delete(:ios_default)    { nil }
+          @osx_default    = options.delete(:osx_default)    { nil }
+          @types          = options.delete(:types)          { [String] }
 
           unless options.empty?
             raise StandardError, "Unrecognized options: #{options} for #{self}"
@@ -108,6 +107,10 @@ module Pod
         #
         attr_reader :osx_default
 
+        # @return [Symbol] array of spec types that this attribute belongs to.
+        #
+        attr_reader :spec_types
+
         # @return [Bool] whether the specification should be considered invalid
         #         if a value for the attribute is not specified.
         #
@@ -119,7 +122,7 @@ module Pod
         #         root specification.
         #
         def root_only?
-          @root_only
+          @spec_types.include?(:root) && @spec_types.count == 1
         end
 
         # @return [Bool] whether the attribute should be specified only on

--- a/lib/cocoapods-core/specification/dsl/attribute_support.rb
+++ b/lib/cocoapods-core/specification/dsl/attribute_support.rb
@@ -26,7 +26,7 @@ module Pod
         # @return [void]
         #
         def root_attribute(name, options = {})
-          options[:root_only] = true
+          options[:spec_types] = [:root]
           options[:multi_platform] = false
           store_attribute(name, options)
         end

--- a/lib/cocoapods-core/specification/linter/analyzer.rb
+++ b/lib/cocoapods-core/specification/linter/analyzer.rb
@@ -42,7 +42,9 @@ module Pod
         def check_attributes
           attributes_keys = Pod::Specification::DSL.attributes.keys.map(&:to_s)
           platform_keys = Specification::DSL::PLATFORMS.map(&:to_s)
-          valid_keys = attributes_keys + platform_keys
+          specification_internal_keys = Specification::INTERNAL_KEYS.map(&:to_s)
+
+          valid_keys = attributes_keys + platform_keys + specification_internal_keys
           attributes_hash = consumer.spec.attributes_hash
           keys = attributes_hash.keys
           Specification::DSL::PLATFORMS.each do |platform|
@@ -136,13 +138,9 @@ module Pod
         #         The value of the attribute.
         #
         def validate_attribute_occurrence(attribute, value)
-          if attribute.root_only? && !value.nil? && !consumer.spec.root?
-            results.add_error('attributes', "Can't set `#{attribute.name}` attribute for " \
-              "subspecs (in `#{consumer.spec.name}`).")
-          end
-          if attribute.test_only? && !value.nil? && !consumer.spec.test_specification?
-            results.add_error('attributes', "Attribute `#{attribute.name}` can only be set " \
-              "within test specs (in `#{consumer.spec.name}`).")
+          if !attribute.spec_types.include?(consumer.spec.type) && !value.nil?
+            results.add_error('attributes', "Can't set `#{attribute.name}` attribute for #{consumer.spec.type} "\
+              "specs (in `#{consumer.spec.name}`).")
           end
         end
 

--- a/spec/specification/dsl/attribute_spec.rb
+++ b/spec/specification/dsl/attribute_spec.rb
@@ -77,7 +77,7 @@ module Pod
       end
 
       it 'is inherited by default if it is root only' do
-        attr = Attribute.new('name', :root_only => true)
+        attr = Attribute.new('name', :spec_types => [:root])
         attr.should.be.inherited
       end
     end

--- a/spec/specification/dsl/attribute_support_spec.rb
+++ b/spec/specification/dsl/attribute_support_spec.rb
@@ -5,7 +5,7 @@ module Pod
     class TestClass
       extend Pod::Specification::DSL::AttributeSupport
       root_attribute :test_root_attribute,  :types => [String]
-      attribute :test_attribute,  :types => [String], :root_only => false
+      attribute :test_attribute,  :types => [String], :spec_types => Specification::SUPPORTED_TYPES.map(&:to_s)
 
       class << self
         attr_reader :attributes

--- a/spec/specification/dsl_spec.rb
+++ b/spec/specification/dsl_spec.rb
@@ -14,6 +14,10 @@ module Pod
         @spec.attributes_hash['name'].should == 'Name'
       end
 
+      it 'should be a root spec' do
+        @spec.type.should == :root
+      end
+
       it 'allows to specify the version' do
         @spec.version = '1.0'
         @spec.attributes_hash['version'].should == '1.0'
@@ -389,6 +393,7 @@ module Pod
         subspec.parent.should == @spec
         subspec.class.should == Specification
         subspec.name.should == 'Spec/Subspec'
+        subspec.type.should == :sub
       end
 
       it 'should allow you to specify a preferred set of dependencies' do
@@ -413,6 +418,7 @@ module Pod
         test_spec = @spec.subspecs.first
         test_spec.class.should == Specification
         test_spec.name.should == 'Spec/Tests'
+        test_spec.type.should == :test
         test_spec.test_specification?.should == true
         test_spec.test_type.should == :unit
       end
@@ -427,6 +433,7 @@ module Pod
         test_spec = a_spec.subspecs.first
         test_spec.class.should == Specification
         test_spec.name.should == 'Spec/Tests'
+        test_spec.type.should == :test
         test_spec.test_specification?.should == true
         test_spec.test_type.should == :unit
       end

--- a/spec/specification/linter/analyzer_spec.rb
+++ b/spec/specification/linter/analyzer_spec.rb
@@ -37,7 +37,24 @@ module Pod
           @analyzer = Specification::Linter::Analyzer.new(subspec.consumer(:ios), results)
           results = @analyzer.analyze
           results.count.should.be.equal(1)
-          expected = 'Can\'t set `homepage` attribute for subspecs (in `BananaLib/subspec`).'
+          expected = 'Can\'t set `homepage` attribute for sub specs (in `BananaLib/subspec`).'
+          results.first.message.should.include?(expected)
+          results.first.attribute_name.should.include?('attribute')
+        end
+      end
+
+      #----------------------------------------#
+
+      describe 'Test attributes' do
+        it 'fails a subspec with a test only attribute' do
+          subspec = @spec.subspec 'subspec' do |sp|
+            sp.requires_app_host = true
+          end
+          results = Specification::Linter::Results.new
+          @analyzer = Specification::Linter::Analyzer.new(subspec.consumer(:ios), results)
+          results = @analyzer.analyze
+          results.count.should.be.equal(1)
+          expected = 'Can\'t set `requires_app_host` attribute for sub specs (in `BananaLib/subspec`).'
           results.first.message.should.include?(expected)
           results.first.attribute_name.should.include?('attribute')
         end

--- a/spec/specification/linter_spec.rb
+++ b/spec/specification/linter_spec.rb
@@ -594,14 +594,14 @@ module Pod
 
       it 'fails a specification with a subspec with a module map' do
         @subspec.module_map = 'subspec.modulemap'
-        result_should_include('module_map', 'can\'t set', 'for subspecs')
+        result_should_include('module_map', 'Can\'t set', 'for sub specs')
       end
 
       #------------------#
 
       it 'fails a specification with a subspec with default subspecs' do
         @subspec.default_subspecs = 'Spec'
-        result_should_include('default_subspecs', 'can\'t set', 'for subspecs')
+        result_should_include('default_subspecs', 'Can\'t set', 'for sub specs')
       end
     end
   end

--- a/spec/specification_spec.rb
+++ b/spec/specification_spec.rb
@@ -18,8 +18,8 @@ module Pod
       end
 
       it 'returns the attributes hash' do
-        @spec.attributes_hash.should == { 'name' => 'Pod', 'version' => '1.0' }
-        @subspec.attributes_hash.should == { 'name' => 'Subspec' }
+        @spec.attributes_hash.should == { 'name' => 'Pod', 'version' => '1.0', 'type' => :root }
+        @subspec.attributes_hash.should == { 'name' => 'Subspec', 'type' => :sub }
       end
 
       it 'returns the subspecs' do
@@ -316,7 +316,7 @@ module Pod
           s.test_spec {}
         end
         test_spec = @spec.test_specs.first
-        @spec.subspec_by_name('Pod/Tests', false, true).should == test_spec
+        @spec.subspec_by_name('Pod/Tests', false, [:test]).should == test_spec
       end
 
       it 'returns a subspec given the relative name' do
@@ -516,6 +516,7 @@ module Pod
         @spec.store_attribute(:attribute, 'value')
         @spec.attributes_hash.should == {
           'name' => nil,
+          'type' => :root,
           'attribute' => 'value',
         }
       end
@@ -524,6 +525,7 @@ module Pod
         @spec.store_attribute(:attribute, 'value', :ios)
         @spec.attributes_hash.should == {
           'name' => nil,
+          'type' => :root,
           'ios' => { 'attribute' => 'value' },
         }
       end
@@ -532,6 +534,7 @@ module Pod
         @spec.store_attribute(:attribute, :key => 'value')
         @spec.attributes_hash.should == {
           'name' => nil,
+          'type' => :root,
           'attribute' => { 'key' => 'value' },
         }
       end
@@ -544,6 +547,7 @@ module Pod
         @spec.store_attribute(:attribute, value)
         @spec.attributes_hash.should == {
           'name' => nil,
+          'type' => :root,
           'attribute' => "foo\n  bar",
         }
       end
@@ -553,6 +557,7 @@ module Pod
         @spec.store_attribute(:attribute, value)
         @spec.attributes_hash.should == {
           'name' => nil,
+          'type' => :root,
           'attribute' => 'foo',
         }
       end


### PR DESCRIPTION
 🌈 🌈 🌈 🌈 🌈 🌈
Doesn't change any public API however internals of the `Specification` now uses a `.type` attribute to determine if it's a `test_specification`. 

This aims to keep the API the same while still allowing for extensibility of top level specs. A 

@dnkoutso @segiddins 
 🌈 🌈 🌈 🌈 🌈 🌈 