### PR TITLE
Replace `test_only` attribute option with `spec_types`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 ##### Enhancements
 
-* None.  
+* Replace `test_only` attribute option with `spec_types`.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#470](https://github.com/CocoaPods/Core/pull/470)
+
 
 ##### Bug Fixes
 

--- a/lib/cocoapods-core/specification.rb
+++ b/lib/cocoapods-core/specification.rb
@@ -231,12 +231,9 @@ module Pod
 
     public
 
-    # Spec types currently supported in cocoapods.
-    SUPPORTED_SPEC_TYPES = [:library, :app, :test].freeze
-
     # @return [Symbol] Spec type of the current spec.
     #
-    # @note see #SUPPORTED_SPEC_TYPES for the list of available spec_types.
+    # @note see Attribute#SUPPORTED_SPEC_TYPES for the list of available spec_types.
     #
     def spec_type
       return :app if app_specification?

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -1463,7 +1463,7 @@ module Pod
       attribute :test_type,
                 :types => [Symbol, String],
                 :multi_platform => false,
-                :test_only => true
+                :spec_types => [:test]
 
       # @!method requires_app_host=(flag)
       #
@@ -1479,7 +1479,7 @@ module Pod
       attribute :requires_app_host,
                 :types => [TrueClass, FalseClass],
                 :default_value => false,
-                :test_only => true
+                :spec_types => [:test]
 
       # Represents a test specification for the library. Here you can place all
       # your tests for your podspec along with the test dependencies.

--- a/lib/cocoapods-core/specification/dsl/attribute.rb
+++ b/lib/cocoapods-core/specification/dsl/attribute.rb
@@ -7,6 +7,10 @@ module Pod
       class Attribute
         require 'active_support/inflector/inflections'
 
+        # Spec types currently supported.
+        #
+        SUPPORTED_SPEC_TYPES = [:library, :app, :test].freeze
+
         # @return [Symbol] the name of the attribute.
         #
         attr_reader :name
@@ -31,7 +35,7 @@ module Pod
 
           @multi_platform = options.delete(:multi_platform) { true       }
           @root_only      = options.delete(:root_only)      { false      }
-          @test_only      = options.delete(:test_only)      { false      }
+          @spec_types     = options.delete(:spec_types)     { SUPPORTED_SPEC_TYPES }
           @inherited      = options.delete(:inherited)      { @root_only }
           @required       = options.delete(:required)       { false      }
           @singularize    = options.delete(:singularize)    { false      }
@@ -45,6 +49,9 @@ module Pod
 
           unless options.empty?
             raise StandardError, "Unrecognized options: #{options} for #{self}"
+          end
+          unless (@spec_types - SUPPORTED_SPEC_TYPES).empty?
+            raise StandardError, "Unrecognized spec type option: #{@spec_types} for #{self}"
           end
         end
 
@@ -126,7 +133,7 @@ module Pod
         #         test specifications.
         #
         def test_only?
-          @test_only
+          @spec_types == [:test]
         end
 
         # @return [Bool] whether the attribute is multi-platform and should


### PR DESCRIPTION
In preparation of scheme support and now that we have app specs and test specs.