### PR TITLE
Improve error messages  for podspec dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ##### Enhancements
 
+* Better error messages, if unallowed version requirement is specified in Podspec.
+  [Wolfgang Lutz][https://github.com/lutzifer]  
+  [#466](https://github.com/CocoaPods/Core/pull/474)
+
 * DSL for `scheme` support.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#7577](https://github.com/CocoaPods/CocoaPods/issues/7577)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ##### Enhancements
 
-* Better error messages, if unallowed version requirement is specified in Podspec.
+* Better error messages, if unallowed version requirement is specified in Podspec.  
   [Wolfgang Lutz][https://github.com/lutzifer]  
   [#466](https://github.com/CocoaPods/Core/pull/474)
 

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -680,11 +680,11 @@ module Pod
           version_requirements.each do |requirement|
             if requirement.is_a?(Hash)
               if !requirement[:path].nil?
-                raise Informative, 'Podspecs cannot specify the source of dependencies. The :path option is not supported.'\
-                                   ' :path can be used in the Podfile instead to override global dependencies.'
+                raise Informative, 'Podspecs cannot specify the source of dependencies. The `:path` option is not supported.'\
+                                   ' `:path` can be used in the Podfile instead to override global dependencies.'
               elsif !requirement[:git].nil?
-                raise Informative, 'Podspecs cannot specify the source of dependencies. The :git option is not supported.'\
-                                   ' :git can be used in the Podfile instead to override global dependencies.'
+                raise Informative, 'Podspecs cannot specify the source of dependencies. The `:git` option is not supported.'\
+                                   ' `:git` can be used in the Podfile instead to override global dependencies.'
               end
             end
           end

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -679,15 +679,15 @@ module Pod
         unless version_requirements.all? { |req| req.is_a?(String) }
           version_requirements.each do |requirement|
             if requirement.is_a?(Hash)
-              if requirement[:path] != nil
-                raise Informative, "Podspecs can only use remote pods as dependencies. :path is not supported"
-              elsif requirement[:git] != nil
-                raise Informative, "Podspecs can only use remote pods as dependencies. :git is not supported"
+              if !requirement[:path].nil?
+                raise Informative, 'Podspecs can only use remote pods as dependencies. :path is not supported'
+              elsif !requirement[:git].nil?
+                raise Informative, 'Podspecs can only use remote pods as dependencies. :git is not supported'
               end
             end
           end
 
-         raise Informative, "Unsupported version requirements. #{version_requirements.inspect()} is not valid."
+          raise Informative, "Unsupported version requirements. #{version_requirements.inspect} is not valid."
         end
 
         attributes_hash['dependencies'] ||= {}

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -677,7 +677,13 @@ module Pod
           end
         end
         unless version_requirements.all? { |req| req.is_a?(String) }
-          raise Informative, 'Unsupported version requirements'
+          unless version_requirements.is_a?(Hash)
+            version_requirements.each do |requirement|
+              raise Informative, "Podspecs can only use remote pods as dependencies. :path is not supported" if requirement[:path] != nil
+              raise Informative, "Podspecs can only use remote pods as dependencies. :git is not supported" if requirement[:git] != nil
+            end
+          end
+          raise Informative, "Unsupported version requirements. #{version_requirements} is not valid."
         end
         attributes_hash['dependencies'] ||= {}
         attributes_hash['dependencies'][name] = version_requirements

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -677,14 +677,19 @@ module Pod
           end
         end
         unless version_requirements.all? { |req| req.is_a?(String) }
-          unless version_requirements.is_a?(Hash)
-            version_requirements.each do |requirement|
-              raise Informative, "Podspecs can only use remote pods as dependencies. :path is not supported" if requirement[:path] != nil
-              raise Informative, "Podspecs can only use remote pods as dependencies. :git is not supported" if requirement[:git] != nil
+          version_requirements.each do |requirement|
+            if requirement.is_a?(Hash)
+              if requirement[:path] != nil
+                raise Informative, "Podspecs can only use remote pods as dependencies. :path is not supported"
+              elsif requirement[:git] != nil
+                raise Informative, "Podspecs can only use remote pods as dependencies. :git is not supported"
+              end
             end
           end
-          raise Informative, "Unsupported version requirements. #{version_requirements} is not valid."
+
+         raise Informative, "Unsupported version requirements. #{version_requirements.inspect()} is not valid."
         end
+
         attributes_hash['dependencies'] ||= {}
         attributes_hash['dependencies'][name] = version_requirements
       end

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -680,9 +680,9 @@ module Pod
           version_requirements.each do |requirement|
             if requirement.is_a?(Hash)
               if !requirement[:path].nil?
-                raise Informative, 'Podspecs can only use remote pods as dependencies. :path is not supported'
+                raise Informative, 'Podspecs cannot specify the source of dependencies. The :path option is not supported. :path can be used in the Podfile instead to override global dependencies.'
               elsif !requirement[:git].nil?
-                raise Informative, 'Podspecs can only use remote pods as dependencies. :git is not supported'
+                raise Informative, 'Podspecs cannot specify the source of dependencies. The :git option is not supported. :git can be used in the Podfile instead to override global dependencies.'
               end
             end
           end

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -680,9 +680,11 @@ module Pod
           version_requirements.each do |requirement|
             if requirement.is_a?(Hash)
               if !requirement[:path].nil?
-                raise Informative, 'Podspecs cannot specify the source of dependencies. The :path option is not supported. :path can be used in the Podfile instead to override global dependencies.'
+                raise Informative, 'Podspecs cannot specify the source of dependencies. The :path option is not supported.'\
+                                   ' :path can be used in the Podfile instead to override global dependencies.'
               elsif !requirement[:git].nil?
-                raise Informative, 'Podspecs cannot specify the source of dependencies. The :git option is not supported. :git can be used in the Podfile instead to override global dependencies.'
+                raise Informative, 'Podspecs cannot specify the source of dependencies. The :git option is not supported.'\
+                                   ' :git can be used in the Podfile instead to override global dependencies.'
               end
             end
           end

--- a/spec/specification/dsl_spec.rb
+++ b/spec/specification/dsl_spec.rb
@@ -240,7 +240,19 @@ module Pod
         it 'raises if the requirements are not supported' do
           should.raise Informative do
             @spec.dependency('SVProgressHUD', :head)
-          end.message.should.match /Unsupported version requirements/
+          end.message.should.match /Unsupported version requirements. \[\:head\] is not valid/
+        end
+
+        it 'raises if the requirements specify :git' do
+          should.raise Informative do
+            @spec.dependency('SVProgressHUD', :git => "AnyPath")
+          end.message.should.match /Podspecs can only use remote pods as dependencies. :git is not supported/
+        end
+
+        it 'raises if the requirements specify :path' do
+          should.raise Informative do
+            @spec.dependency('SVProgressHUD', :path => "AnyPath")
+          end.message.should.match /Podspecs can only use remote pods as dependencies. :path is not supported/
         end
 
         it 'raises when attempting to assign a value to dependency' do

--- a/spec/specification/dsl_spec.rb
+++ b/spec/specification/dsl_spec.rb
@@ -246,13 +246,13 @@ module Pod
         it 'raises if the requirements specify :git' do
           should.raise Informative do
             @spec.dependency('SVProgressHUD', :git => 'AnyPath')
-          end.message.should.match /Podspecs can only use remote pods as dependencies. :git is not supported/
+          end.message.should.match /Podspecs cannot specify the source of dependencies. The :git option is not supported. :git can be used in the Podfile instead to override global dependencies./
         end
 
         it 'raises if the requirements specify :path' do
           should.raise Informative do
             @spec.dependency('SVProgressHUD', :path => 'AnyPath')
-          end.message.should.match /Podspecs can only use remote pods as dependencies. :path is not supported/
+          end.message.should.match /Podspecs cannot specify the source of dependencies. The :path option is not supported. :path can be used in the Podfile instead to override global dependencies./
         end
 
         it 'raises when attempting to assign a value to dependency' do

--- a/spec/specification/dsl_spec.rb
+++ b/spec/specification/dsl_spec.rb
@@ -246,13 +246,13 @@ module Pod
         it 'raises if the requirements specify :git' do
           should.raise Informative do
             @spec.dependency('SVProgressHUD', :git => 'AnyPath')
-          end.message.should.match /Podspecs cannot specify the source of dependencies. The :git option is not supported.\.*/
+          end.message.should.match /Podspecs cannot specify the source of dependencies. The `:git` option is not supported.\.*/
         end
 
         it 'raises if the requirements specify :path' do
           should.raise Informative do
             @spec.dependency('SVProgressHUD', :path => 'AnyPath')
-          end.message.should.match /Podspecs cannot specify the source of dependencies. The :path option is not supported.\.*/
+          end.message.should.match /Podspecs cannot specify the source of dependencies. The `:path` option is not supported.\.*/
         end
 
         it 'raises when attempting to assign a value to dependency' do

--- a/spec/specification/dsl_spec.rb
+++ b/spec/specification/dsl_spec.rb
@@ -246,13 +246,13 @@ module Pod
         it 'raises if the requirements specify :git' do
           should.raise Informative do
             @spec.dependency('SVProgressHUD', :git => 'AnyPath')
-          end.message.should.match /Podspecs cannot specify the source of dependencies. The :git option is not supported. :git can be used in the Podfile instead to override global dependencies./
+          end.message.should.match /Podspecs cannot specify the source of dependencies. The :git option is not supported.\.*/
         end
 
         it 'raises if the requirements specify :path' do
           should.raise Informative do
             @spec.dependency('SVProgressHUD', :path => 'AnyPath')
-          end.message.should.match /Podspecs cannot specify the source of dependencies. The :path option is not supported. :path can be used in the Podfile instead to override global dependencies./
+          end.message.should.match /Podspecs cannot specify the source of dependencies. The :path option is not supported.\.*/
         end
 
         it 'raises when attempting to assign a value to dependency' do

--- a/spec/specification/dsl_spec.rb
+++ b/spec/specification/dsl_spec.rb
@@ -245,13 +245,13 @@ module Pod
 
         it 'raises if the requirements specify :git' do
           should.raise Informative do
-            @spec.dependency('SVProgressHUD', :git => "AnyPath")
+            @spec.dependency('SVProgressHUD', :git => 'AnyPath')
           end.message.should.match /Podspecs can only use remote pods as dependencies. :git is not supported/
         end
 
         it 'raises if the requirements specify :path' do
           should.raise Informative do
-            @spec.dependency('SVProgressHUD', :path => "AnyPath")
+            @spec.dependency('SVProgressHUD', :path => 'AnyPath')
           end.message.should.match /Podspecs can only use remote pods as dependencies. :path is not supported/
         end
 


### PR DESCRIPTION
Improves the error message ’Unsupported version requirements' if it is caused by specifying :git or :path in the podspec file.