### PR TITLE
Fix --deployment flag incorrectly erroring on GoogleSignIn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@
 
 ##### Bug Fixes
 
+* Fix several array sorting inconsistencies when generating a Lockfile.  
+  When a Lockfile is being written to disk, `YAMLHelper` sorts arrays by `&:downcase`.  
+  When a new Lockfile is generated, the sort order is plain lexicographical.  
+  This causes pods like `GoogleSignIn` and `GTMSessionFetcher` being in a different order in each case, causing `--deployment` to report an error when in fact the Lockfile wouldn't be changed.  
+  [Igor Makarov](https://github.com/igor-makarov)
+
 * Fix a crash when using `inhibit_all_warnings!` in parent and child scopes  
   [Eric Amorde](https://github.com/amorde)
   [#472](https://github.com/CocoaPods/Core/issues/472)

--- a/lib/cocoapods-core/yaml_helper.rb
+++ b/lib/cocoapods-core/yaml_helper.rb
@@ -239,6 +239,8 @@ module Pod
         end
       end
 
+      public
+
       # Sorts an array according to the string representation of it values.
       # This method allows to sort arrays which contains strings or hashes.
       #
@@ -258,6 +260,8 @@ module Pod
           [sorting_string(element), index]
         end.map(&:first)
       end
+
+      private
 
       # Returns the string representation of a value useful for sorting.
       #


### PR DESCRIPTION
I've tried running `pod install --deployment` and it was erroring out on pod GoogleSignIn and its deps.  
Upon debugging this I've found a bug in the diff algorithm that I'm submitting a patch for.

I've made a demo project at [igor-makarov/Demo-CocoaPods-GoogleSignIn](https://github.com/igor-makarov/Demo-CocoaPods-GoogleSignIn/blob/20f7d1228a1f6277d5734ce67021d2aa6afde9e9/.travis.yml#L15).

I've also attached the [Travis build log](https://travis-ci.org/igor-makarov/Demo-CocoaPods-GoogleSignIn/builds/468356059) that shows the command run with/without the patch.

EDIT: The complementary PR in main CP repo wasn't necessary so I closed it.