### PR TITLE
Source::Manager - return all aggregate sources if the dependency's spec repo doesn't exist

### DIFF
--- a/lib/cocoapods-core/source/manager.rb
+++ b/lib/cocoapods-core/source/manager.rb
@@ -33,15 +33,12 @@ module Pod
       #         will be used.
       #
       def aggregate_for_dependency(dependency)
-        if dependency.podspec_repo
-          source = source_with_url(dependency.podspec_repo)
-          raise StandardError, '[Bug] Failed to find known source with the URL ' \
-            "#{dependency.podspec_repo.inspect}" if source.nil?
+        return aggregate if dependency.podspec_repo.nil?
 
-          aggregate_with_repos([source.repo])
-        else
-          aggregate
-        end
+        source = source_with_url(dependency.podspec_repo)
+        return aggregate if source.nil?
+
+        aggregate_with_repos([source.repo])
       end
 
       # @return [Array<Source>] The list of the sources with the given names.

--- a/spec/source/manager_spec.rb
+++ b/spec/source/manager_spec.rb
@@ -34,6 +34,12 @@ module Pod
         aggregate.sources.map(&:name).should == %w(master test_cdn_repo_local test_empty_dir_repo test_prefixed_repo test_repo)
       end
 
+      it 'includes all sources in an aggregate for a dependency if non-existent source is specified' do
+        dependency = Dependency.new('JSONKit', '1.4', :source => 'https://url/to/nonexistent/specs.git')
+        aggregate = @sources_manager.aggregate_for_dependency(dependency)
+        aggregate.sources.map(&:name).should == %w(master test_cdn_repo_local test_empty_dir_repo test_prefixed_repo test_repo)
+      end
+
       it 'includes only the one source in an aggregate for a dependency if a source is specified' do
         repo_url = 'https://url/to/specs.git'
         dependency = Dependency.new('JSONKit', '1.4', :source => repo_url)


### PR DESCRIPTION
This PR resolves a bug I was having because I've switched to the new [CDN-source](https://github.com/CocoaPods/Core/pull/469) and had an error.

The error happened because while the Podfile had the new source specified, the Podfile.lock still had the old source and I have deleted the old source.  
I've gotten around it by manually hacking the lockfile, but clearly this isn't the right way.

I've modified the `aggregate_for_dependency` method in a way that preserves current behavior but in the case of not being able to find the specified source for the dependency, it will default to all sources. 

I've added a test for the case.