### PR TITLE
Ensure `test_type` value is converted to a symbol from consumer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ script: bundle exec rake spec
 git:
   submodules: false
 before_install:
-  - gem install bundler
+  - gem install bundler -v "~> 1.17"
   - |
       master_sha="$(ruby -e "puts '`git submodule status spec/fixtures/spec-repos/master`'.strip.sub(/^-/, '').split(/\s/, 2).first")"
       curl -ssL "https://github.com/CocoaPods/Specs/archive/$master_sha.tar.gz" | tar xz -C spec/fixtures/spec-repos

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
 
 ##### Bug Fixes
 
+* Ensure `test_type` value is converted to a symbol from consumers of JSON podspecs.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#504](https://github.com/CocoaPods/Core/pull/504)
+
 * Fix several array sorting inconsistencies when generating a Lockfile.  
   When a Lockfile is being written to disk, `YAMLHelper` sorts arrays by `&:downcase`.  
   When a new Lockfile is generated, the sort order is plain lexicographical.  

--- a/lib/cocoapods-core/specification/consumer.rb
+++ b/lib/cocoapods-core/specification/consumer.rb
@@ -376,6 +376,19 @@ module Pod
         end
       end
 
+      # Converts the test type value from a string to a symbol.
+      #
+      # @param  [String, Symbol] value.
+      #         The value of the test type attributed as specified by the user.
+      #
+      # @return [Symbol] the test type as a symbol.
+      #
+      def _prepare_test_type(value)
+        if value
+          value.to_sym
+        end
+      end
+
       # Converts the array of hashes (script phases) where keys are strings into symbols.
       #
       # @param  [Array<Hash{String=>String}>] value.

--- a/spec/specification/consumer_spec.rb
+++ b/spec/specification/consumer_spec.rb
@@ -272,6 +272,15 @@ module Pod
         test_consumer.test_type.should.be == :unit
       end
 
+      it 'returns the test type as a symbol when consuming JSON specs' do
+        @spec.test_spec {}
+        test_spec = @spec.test_specs.first
+        test_spec.test_type = :unit
+        json_spec = @spec.to_json
+        test_consumer = Specification::Consumer.new(Specification.from_json(json_spec).test_specs.first, :ios)
+        test_consumer.test_type.should.be == :unit
+      end
+
       it 'allows to specify whether the specification requires an app host' do
         @spec.test_spec {}
         test_spec = @spec.test_specs.first


### PR DESCRIPTION
In https://github.com/CocoaPods/CocoaPods/blob/master/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb#L289...

...we now use the consumer of the spec to read the value. Unfortunately the value that comes back from the consumer for JSON podspecs can be a string which cascades into other failures.

This fixes this and all subsequent callsites.