### PR TITLE
Add documentation for `:testspecs` option on Podfile `pod` DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ##### Enhancements
 
+* Add documentation for the `:testspecs` option on the `pod` Podfile DSL  
+  [Eric Amorde](https://github.com/amorde)
+  [#506](https://github.com/CocoaPods/Core/issues/506)
+
 * Better error messages, if unallowed version requirement is specified in Podspec.  
   [Wolfgang Lutz][https://github.com/lutzifer]  
   [#466](https://github.com/CocoaPods/Core/pull/474)

--- a/lib/cocoapods-core/podfile/dsl.rb
+++ b/lib/cocoapods-core/podfile/dsl.rb
@@ -185,6 +185,18 @@ module Pod
       #
       #     pod 'QueryKit', :subspecs => ['Attribute', 'QuerySet']
       #
+      # ### Test Specs
+      #
+      # Test specs can be optionally included via the `:testspecs` option. By default,
+      # none of a Pod's test specs are included.
+      #
+      # You may specify a list of test spec names to install using the following:
+      #
+      #     pod 'AFNetworking', :testspecs => ['UnitTests', 'SomeOtherTests']
+      #
+      # The values provided to `:testspecs` correspond to the name provided to the
+      # `test_spec` DSL attribute in a Podspec.
+      #
       # ------
       #
       # Dependencies can be obtained also from external sources.


### PR DESCRIPTION
Closes #506 

