### PR TITLE
Add namespace to example resource bundle for consistency with documentation

### DIFF
--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -1260,7 +1260,7 @@ module Pod
       #
       #     spec.resource_bundles = {
       #         'MapBox' => ['MapView/Map/Resources/*.png'],
-      #         'OtherResources' => ['MapView/Map/OtherResources/*.png']
+      #         'MapBoxOtherResources' => ['MapView/Map/OtherResources/*.png']
       #       }
       #
       #   @param  [Hash{String=>String}, Hash{String=>Array<String>}] resource_bundles


### PR DESCRIPTION
Closes https://github.com/CocoaPods/guides.cocoapods.org/issues/18

The documentation for this attribute seems pretty substantial, this adds the last item
mentioned on that issue.