### PR TITLE
CDNSource: Raise error on unexpected HTTP errors + add/improve tests

### DIFF
--- a/lib/cocoapods-core/cdn_source.rb
+++ b/lib/cocoapods-core/cdn_source.rb
@@ -273,6 +273,11 @@ module Pod
         debug "CDN: #{name} Relative path downloaded: #{partial_url}, save ETag: #{etag_new}"
         File.open(etag_path, 'w') { |f| f.write(etag_new) } unless etag_new.nil?
         partial_url
+      when 404
+        debug "CDN: #{name} Relative path couldn't be downloaded: #{partial_url} Response: #{response.status_code}"
+        nil
+      else 
+        raise Informative, "CDN: #{name} Relative path couldn't be downloaded: #{partial_url} Response: #{response.status_code}"
       end
     end
 

--- a/lib/cocoapods-core/cdn_source.rb
+++ b/lib/cocoapods-core/cdn_source.rb
@@ -276,7 +276,7 @@ module Pod
       when 404
         debug "CDN: #{name} Relative path couldn't be downloaded: #{partial_url} Response: #{response.status_code}"
         nil
-      else 
+      else
         raise Informative, "CDN: #{name} Relative path couldn't be downloaded: #{partial_url} Response: #{response.status_code}"
       end
     end

--- a/spec/cdn_source_spec.rb
+++ b/spec/cdn_source_spec.rb
@@ -48,7 +48,15 @@ module Pod
       end
 
       it 'returns nil if the Pod could not be found' do
+        @source.expects(:debug).with { |cmd| cmd =~ /CDN: #{@source.name} Relative path couldn't be downloaded: Specs\/.*\/Unknown_Pod\/index\.txt Response: 404/ }
         @source.versions('Unknown_Pod').should.be.nil
+      end
+
+      it 'raises if unexpected HTTP error' do
+        REST.expects(:get).returns(REST::Response.new(500))
+        should.raise Informative do
+          @source.versions('Unknown_Pod')
+        end.message.should.match /CDN: .* Relative path couldn\'t be downloaded: .* Response: 500/
       end
 
       it 'returns cached versions for a Pod' do
@@ -118,6 +126,7 @@ module Pod
       end
 
       it 'matches case' do
+        @source.expects(:debug).with { |cmd| cmd =~ /CDN: #{@source.name} Relative path couldn't be downloaded: Specs\/.*\/bEacoNKIT\/index\.txt Response: 404/ }
         @source.search('bEacoNKIT').should.be.nil?
       end
 

--- a/spec/cdn_source_spec.rb
+++ b/spec/cdn_source_spec.rb
@@ -48,7 +48,7 @@ module Pod
       end
 
       it 'returns nil if the Pod could not be found' do
-        @source.expects(:debug).with { |cmd| cmd =~ /CDN: #{@source.name} Relative path couldn't be downloaded: Specs\/.*\/Unknown_Pod\/index\.txt Response: 404/ }
+        @source.expects(:debug).with { |cmd| cmd =~ %r{CDN: #{@source.name} Relative path couldn't be downloaded: Specs\/.*\/Unknown_Pod\/index\.txt Response: 404} }
         @source.versions('Unknown_Pod').should.be.nil
       end
 
@@ -126,7 +126,7 @@ module Pod
       end
 
       it 'matches case' do
-        @source.expects(:debug).with { |cmd| cmd =~ /CDN: #{@source.name} Relative path couldn't be downloaded: Specs\/.*\/bEacoNKIT\/index\.txt Response: 404/ }
+        @source.expects(:debug).with { |cmd| cmd =~ %r{CDN: #{@source.name} Relative path couldn't be downloaded: Specs\/.*\/bEacoNKIT\/index\.txt Response: 404} }
         @source.search('bEacoNKIT').should.be.nil?
       end
 


### PR DESCRIPTION
Today, an outage has started happening on jsDelivr's network and CDNSource didn't provide any constructive feedback.

Furthermore, I noticed that there's no distinction between expected errors (404) and unexpected errors (5XX).

This PR adds proper error handling to CDNSource.  
I've added a test for the error 500 case and also refined the 404 tests to check for the error.