### PR TITLE
Add `test_spec. app_host_name` to DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 ##### Enhancements
 
-* Add `test_spec.app_spec_name` to DSL  
+* Allow test specs to specify an `app_host_name` to point to an app spec whose
+  application is used as the test's app host.  
   [jkap](https://github.com/jkap)
+  [Samuel Giddins](https://github.com/segiddins)
   [#520](https://github.com/CocoaPods/Core/pull/520)
 
 ##### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ##### Enhancements
 
-* None.  
+* Add `test_spec.app_spec_name` to DSL  
+  [jkap](https://github.com/jkap)
+  [#520](https://github.com/CocoaPods/Core/pull/520)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods-core/specification/consumer.rb
+++ b/lib/cocoapods-core/specification/consumer.rb
@@ -144,6 +144,10 @@ module Pod
       spec_attr_accessor :requires_app_host
       alias_method :requires_app_host?, :requires_app_host
 
+      # @return [String?] Name of the app host this spec requires
+      #
+      spec_attr_accessor :app_host_name
+
       # @return [Symbol] the test type supported by this specification.
       #
       spec_attr_accessor :test_type

--- a/lib/cocoapods-core/specification/consumer.rb
+++ b/lib/cocoapods-core/specification/consumer.rb
@@ -144,7 +144,7 @@ module Pod
       spec_attr_accessor :requires_app_host
       alias_method :requires_app_host?, :requires_app_host
 
-      # @return [String?] Name of the app host this spec requires
+      # @return [String] Name of the app host this spec requires
       #
       spec_attr_accessor :app_host_name
 

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -1511,10 +1511,24 @@ module Pod
       # @!method app_host_name=(name)
       #
       #   The app specification to use as an app host, if necessary.
+      #   Requires `test_spec.requires_app_host` to be `true`.
       #
-      #   @example
+      # @example
       #
-      #     test_spec.app_host_name = 'Foo'
+      #   Pod::Spec.new do |spec|
+      #     spec.name = 'NSAttributedString+CCLFormat'
+      #
+      #     spec.test_spec do |test_spec|
+      #       test_spec.source_files = 'NSAttributedString+CCLFormatTests.m'
+      #       test_spec.requires_app_host = true
+      #       test_spec.app_host_name = 'NSAttributedString+CCLFormat/App'
+      #     end
+      #
+      #     spec.app_spec 'App' do |app_spec|
+      #       app_spec.source_files = 'NSAttributedString+CCLFormat.m'
+      #       app_spec.dependency 'AFNetworking'
+      #     end
+      #   end
       #
       #   @param [String] name
       #          The app specification to use as an app host, if necessary.

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -1508,6 +1508,21 @@ module Pod
                 :default_value => false,
                 :spec_types => [:test]
 
+      # @!method app_host_name=(name)
+      #
+      #   The app specification to use as an app host, if necessary.
+      #
+      #   @example
+      #
+      #     test_spec.app_host_name = 'Foo'
+      #
+      #   @param [String] name
+      #          The app specification to use as an app host, if necessary.
+      #
+      attribute :app_host_name,
+                :types => [String],
+                :spec_types => [:test]
+
       SCHEME_KEYS = [:launch_arguments, :environment_variables].freeze
 
       # @!method scheme=(flag)

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -1512,7 +1512,9 @@ module Pod
       #
       #   The app specification to use as an app host, if necessary.
       #
-      #   **Note** If the app host is in another pod, you must depend on that pod using `test_spec.dependency 'PodName'`
+      # @note
+      #
+      #    You must depend on that app spec using `test_spec.dependency 'PodName'`.
       #
       # @example
       #

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -1511,8 +1511,8 @@ module Pod
       # @!method app_host_name=(name)
       #
       #   The app specification to use as an app host, if necessary.
-      #   
-      #   **Note** Requires `test_spec.requires_app_host` to be `true`.
+      #
+      #   **Note** If the app host is in another pod, you must depend on that pod using `test_spec.dependency 'PodName'`
       #
       # @example
       #

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -1511,7 +1511,8 @@ module Pod
       # @!method app_host_name=(name)
       #
       #   The app specification to use as an app host, if necessary.
-      #   Requires `test_spec.requires_app_host` to be `true`.
+      #   
+      #   **Note** Requires `test_spec.requires_app_host` to be `true`.
       #
       # @example
       #

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -1525,6 +1525,7 @@ module Pod
       #       test_spec.source_files = 'NSAttributedString+CCLFormatTests.m'
       #       test_spec.requires_app_host = true
       #       test_spec.app_host_name = 'NSAttributedString+CCLFormat/App'
+      #       test_spec.dependency 'NSAttributedString+CCLFormat/App'
       #     end
       #
       #     spec.app_spec 'App' do |app_spec|

--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -400,13 +400,9 @@ module Pod
             '`true` when `app_host_name` is specified.')
         end
 
-        parent_spec_name = (consumer.spec.parent && consumer.spec.parent.name) || consumer.name
-        podspec_name, appspec_name = n.split('/')
-
-        unless podspec_name == parent_spec_name || consumer.dependencies.map(&:name).include?(appspec_name)
-          results.add_error('app_host_name', "The app host name specified by #{consumer.spec.name} could " \
-            "not be found. Either explicitly declare it within #{podspec_name} or add a dependency to the " \
-            'podspec that specifies it.')
+        unless consumer.dependencies.map(&:name).include?(n)
+          results.add_error('app_host_name', "The app host name (#{n}) specified by #{consumer.spec.name} could " \
+            'not be found. You must explicitly declare a dependency on that app spec.')
         end
       end
 

--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -404,8 +404,9 @@ module Pod
         podspec_name, appspec_name = n.split('/')
 
         unless podspec_name == parent_spec_name || consumer.dependencies.map(&:name).include?(appspec_name)
-          results.add_error('app_host_name', "Test spec must depend on `#{podspec_name}` " \
-            'to use it as an app host.')
+          results.add_error('app_host_name', "The app host name specified by #{consumer.spec.name} could " \
+            "not be found. Either explicitly declare it within #{podspec_name} or add a dependency to the " \
+            'podspec that specifies it.')
         end
       end
 

--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -401,7 +401,7 @@ module Pod
         end
 
         unless consumer.dependencies.map(&:name).include?(n)
-          results.add_error('app_host_name', "The app host name (#{n}) specified by #{consumer.spec.name} could " \
+          results.add_error('app_host_name', "The app host name (#{n}) specified by `#{consumer.spec.name}` could " \
             'not be found. You must explicitly declare a dependency on that app spec.')
         end
       end

--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -394,10 +394,18 @@ module Pod
         end
       end
 
-      def _validate_app_host_name(_n)
+      def _validate_app_host_name(n)
         unless consumer.requires_app_host?
           results.add_error('app_host_name', '`requires_app_host` must be set to ' \
             '`true` when `app_host_name` is specified.')
+        end
+
+        parent_spec_name = (consumer.spec.parent && consumer.spec.parent.name) || consumer.name
+        podspec_name, appspec_name = n.split('/')
+
+        unless podspec_name == parent_spec_name || consumer.dependencies.map(&:name).include?(appspec_name)
+          results.add_error('app_host_name', "Test spec must depend on `#{podspec_name}` " \
+            'to use it as an app host.')
         end
       end
 

--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -394,8 +394,8 @@ module Pod
         end
       end
 
-      def _validate_app_host_name(n)
-        unless @consumer.requires_app_host?
+      def _validate_app_host_name(_n)
+        unless consumer.requires_app_host?
           results.add_error('app_host_name', '`requires_app_host` must be set to ' \
             '`true` when `app_host_name` is specified.')
         end

--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -394,6 +394,13 @@ module Pod
         end
       end
 
+      def _validate_app_host_name(n)
+        unless @consumer.requires_app_host?
+          results.add_error('app_host_name', '`requires_app_host` must be set to ' \
+            '`true` when `app_host_name` is specified.')
+        end
+      end
+
       # Performs validations related to the `script_phases` attribute.
       #
       def _validate_script_phases(s)

--- a/spec/specification/consumer_spec.rb
+++ b/spec/specification/consumer_spec.rb
@@ -289,6 +289,14 @@ module Pod
         test_consumer.requires_app_host?.should.be.true
       end
 
+      it 'allows to specify a specific app host to use' do
+        @spec.test_spec {}
+        test_spec = @spec.test_specs.first
+        test_spec.app_host_name = 'Foo/App'
+        test_consumer = Specification::Consumer.new(test_spec, :ios)
+        test_consumer.app_host_name.should == 'Foo/App'
+      end
+
       it 'returns the scheme configuration of a test spec' do
         @spec.test_spec {}
         test_spec = @spec.test_specs.first

--- a/spec/specification/linter_spec.rb
+++ b/spec/specification/linter_spec.rb
@@ -305,6 +305,15 @@ module Pod
 
       #------------------#
 
+      it 'fails a test spec with `requires_app_host = false` and `app_host_name` set' do
+        @spec.test_specification = true
+        @spec.requires_app_host = false
+        @spec.app_host_name = 'Foo/App'
+        result_should_include('app_host_name', 'requires_app_host')
+      end
+
+      #------------------#
+
       it 'checks if the description is not an empty string' do
         @spec.stubs(:description).returns('')
         result_should_include('description', 'empty')

--- a/spec/specification/linter_spec.rb
+++ b/spec/specification/linter_spec.rb
@@ -312,6 +312,14 @@ module Pod
         result_should_include('app_host_name', 'requires_app_host')
       end
 
+      it 'passes a test spec with `requires_app_host = true` and `app_host_name` set' do
+        @spec.test_specification = true
+        @spec.requires_app_host = true
+        @spec.app_host_name = 'Foo/App'
+        @linter.lint
+        @linter.results.should.be.empty?
+      end
+
       #------------------#
 
       it 'checks if the description is not an empty string' do

--- a/spec/specification/linter_spec.rb
+++ b/spec/specification/linter_spec.rb
@@ -308,16 +308,31 @@ module Pod
       it 'fails a test spec with `requires_app_host = false` and `app_host_name` set' do
         @spec.test_specification = true
         @spec.requires_app_host = false
-        @spec.app_host_name = 'Foo/App'
+        @spec.app_host_name = 'BananaLib/App'
         result_should_include('app_host_name', 'requires_app_host')
       end
 
       it 'passes a test spec with `requires_app_host = true` and `app_host_name` set' do
         @spec.test_specification = true
         @spec.requires_app_host = true
-        @spec.app_host_name = 'Foo/App'
+        @spec.app_host_name = 'BananaLib/App'
         @linter.lint
         @linter.results.should.be.empty?
+      end
+
+      it 'fails a test spec requiring an app host from a pod that isn\'t required' do
+        @spec.test_specification = true
+        @spec.requires_app_host = true
+        @spec.app_host_name = 'Foo/App'
+        result_should_include('app_host_name', 'Foo')
+      end
+
+      it 'passes a test spec requiring an app host from a pod that is listed as a dependency' do
+        @spec.dependency 'Foo'
+        @spec.test_specification = true
+        @spec.requires_app_host = true
+        @spec.app_host_name = 'Foo/App'
+        result_should_include('app_host_name', 'Foo')
       end
 
       #------------------#

--- a/spec/specification/linter_spec.rb
+++ b/spec/specification/linter_spec.rb
@@ -309,6 +309,7 @@ module Pod
         @spec.test_specification = true
         @spec.requires_app_host = false
         @spec.app_host_name = 'BananaLib/App'
+        result_ignore('must explicitly declare a dependency')
         result_should_include('app_host_name', 'requires_app_host')
       end
 
@@ -316,6 +317,7 @@ module Pod
         @spec.test_specification = true
         @spec.requires_app_host = true
         @spec.app_host_name = 'BananaLib/App'
+        @spec.dependency 'BananaLib/App'
         @linter.lint
         @linter.results.should.be.empty?
       end
@@ -328,11 +330,12 @@ module Pod
       end
 
       it 'passes a test spec requiring an app host from a pod that is listed as a dependency' do
-        @spec.dependency 'Foo'
+        @spec.dependency 'Foo/App'
         @spec.test_specification = true
         @spec.requires_app_host = true
         @spec.app_host_name = 'Foo/App'
-        result_should_include('app_host_name', 'Foo')
+        @linter.lint
+        @linter.results.should.be.empty?
       end
 
       #------------------#


### PR DESCRIPTION
This supports a forthcoming PR in cocoapods/cocoapods to specify an
existing app spec to use as a test spec app host instead of generating
one on the fly.