### PR TITLE
delete search index json file when parsing failed

### DIFF
--- a/lib/cocoapods-core/source/manager.rb
+++ b/lib/cocoapods-core/source/manager.rb
@@ -249,8 +249,12 @@ module Pod
         @updated_search_index ||= begin
           if search_index_path.exist?
             require 'json'
-            index = JSON.parse(search_index_path.read)
-            index if index.is_a?(Hash) # TODO: should we also check if hash has correct hierarchy?
+            begin
+              index = JSON.parse(search_index_path.read)
+              index if index.is_a?(Hash) # TODO: should we also check if hash has correct hierarchy?
+            rescue JSON::ParserError
+              search_index_path.delete
+              nil
           end
         end
       end


### PR DESCRIPTION
for issue https://github.com/CocoaPods/CocoaPods/issues/5172

I think it is more friendly to delete `search_index.json` file  automatically when we fail to parse the file.

for now,  I have to delete `search_index.json` file manually every time when I encounter the problem.

It's inconvenient especially when I forget where is the `search_index.json` file located.