### PR TITLE
Produce an error when a Podspec contains an invalid type for the `source` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@
 
 ##### Bug Fixes
 
-* None.  
+* Emit an error when a Podspec has an incorrect type for the `source` attribute  
+  [Eric Amorde](https://github.com/amorde)
+  [CocoaPods/CocoaPods#5420](https://github.com/CocoaPods/CocoaPods/issues/5420)
 
 
 ## 1.7.0.rc.1 (2019-05-02)

--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -350,6 +350,7 @@ module Pod
       # Performs validations related to the `source` attribute.
       #
       def _validate_source(s)
+        return unless s.is_a?(Hash)
         if git = s[:git]
           tag, commit = s.values_at(:tag, :commit)
           version = spec.version.to_s

--- a/lib/cocoapods-core/specification/linter/analyzer.rb
+++ b/lib/cocoapods-core/specification/linter/analyzer.rb
@@ -180,6 +180,10 @@ module Pod
         end
 
         def validate_attribute_hash_keys(attribute, value)
+          unless value.is_a?(Hash)
+            results.add_error(attribute.name, "Unsupported type `#{value.class}`, expected `Hash`")
+            return
+          end
           major_keys = value.keys & attribute.keys.keys
           if major_keys.count.zero?
             results.add_warning('keys', "Missing primary key for `#{attribute.name}` " \

--- a/lib/cocoapods-core/specification/root_attribute_accessors.rb
+++ b/lib/cocoapods-core/specification/root_attribute_accessors.rb
@@ -131,7 +131,12 @@ module Pod
         #         should be retrieved.
         #
         def source
-          Specification.convert_keys_to_symbol(attributes_hash['source'])
+          value = attributes_hash['source']
+          if value && value.is_a?(Hash)
+            Specification.convert_keys_to_symbol(value)
+          else
+            value
+          end
         end
 
         # @return [String] A short description of the Pod.

--- a/spec/specification/linter_spec.rb
+++ b/spec/specification/linter_spec.rb
@@ -176,9 +176,14 @@ module Pod
         result_should_include('license', 'unrecognized `name` key')
       end
 
-      xit 'checks the source for unknown keys' do
-        call = lambda { @spec.source = { :tig => 'www.example.com/repo.tig' } }
-        call.should.raise StandardError
+      it 'checks that source is a hash' do
+        @spec.source = '.'
+        result_should_include('source', 'Unsupported type `String`, expected `Hash`')
+      end
+
+      it 'checks the source for unknown keys' do
+        @spec.source = { :tig => 'www.example.com/repo.tig' }
+        result_should_include('[keys]', 'Missing primary key for `source` attribute. The acceptable ones are: `git, hg, http, svn`.')
       end
 
       it 'checks the required attributes' do


### PR DESCRIPTION
Closes CocoaPods/CocoaPods#5420