### PR TITLE
Add `project_name` DSL to allow grouping pods into projects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ##### Enhancements
 
+* Add `project_name` DSL to allow grouping pods into projects.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#547](https://github.com/CocoaPods/Core/pull/547)
+
 * Allow test specs to specify an `app_host_name` to point to an app spec whose
   application is used as the test's app host.  
   [jkap](https://github.com/jkap)

--- a/spec/podfile/dsl_spec.rb
+++ b/spec/podfile/dsl_spec.rb
@@ -226,6 +226,17 @@ module Pod
         end
       end
 
+      describe 'project names' do
+        it 'sets the project name for a given pod' do
+          podfile = Podfile.new do
+            pod 'PonyDebugger', :project_name => 'PonyProject'
+          end
+
+          target = podfile.target_definitions['Pods']
+          target.project_name_for_pod('PonyDebugger').should == 'PonyProject'
+        end
+      end
+
       describe 'modular headers' do
         it 'does not have modular headers by default' do
           podfile = Podfile.new do

--- a/spec/podfile/target_definition_spec.rb
+++ b/spec/podfile/target_definition_spec.rb
@@ -390,6 +390,25 @@ module Pod
 
       #--------------------------------------#
 
+      it 'stores the project name for a given pod' do
+        @parent.store_pod('ASIHTTPRequest', :project_name => 'SomeProject')
+        @parent.project_name_for_pod('ASIHTTPRequest').should == 'SomeProject'
+        @parent.project_name_for_pod('UnknownPod').should.be.nil
+      end
+
+      it 'inherits the project name option to use for a pod' do
+        @parent.store_pod('ASIHTTPRequest', :project_name => 'SomeProject')
+        @child.project_name_for_pod('ASIHTTPRequest').should == 'SomeProject'
+      end
+
+      it 'honors the project name directly set from the target definition before delegating to parent' do
+        @parent.store_pod('ASIHTTPRequest', :project_name => 'SomeProject')
+        @child.store_pod('ASIHTTPRequest', :project_name => 'SomeOtherProject')
+        @child.project_name_for_pod('ASIHTTPRequest').should == 'SomeOtherProject'
+      end
+
+      #--------------------------------------#
+
       it 'returns if it should use frameworks' do
         @parent.use_frameworks!
         @parent.should.uses_frameworks?
@@ -508,7 +527,7 @@ module Pod
         @child.all_whitelisted_configurations.sort.should == %w(Debug Release)
       end
 
-      it 'whitelistes pod configurations with testspecs' do
+      it 'whitelists pod configurations with testspecs' do
         @parent.build_configurations = { 'Debug' => :debug, 'Release' => :release }
         @parent.store_pod('RestKit', :testspecs => %w(Tests), :configuration => 'Debug')
         @parent.should.pod_whitelisted_for_configuration?('RestKit', 'Debug')
@@ -517,7 +536,7 @@ module Pod
         @parent.should.not.pod_whitelisted_for_configuration?('RestKit/Tests', 'Release')
       end
 
-      it 'whitelistes pod configurations with appspecs' do
+      it 'whitelists pod configurations with appspecs' do
         @parent.build_configurations = { 'Debug' => :debug, 'Release' => :release }
         @parent.store_pod('RestKit', :appspecs => %w(App), :configuration => 'Debug')
         @parent.should.pod_whitelisted_for_configuration?('RestKit', 'Debug')
@@ -526,7 +545,7 @@ module Pod
         @parent.should.not.pod_whitelisted_for_configuration?('RestKit/App', 'Release')
       end
 
-      it 'whitelistes pod configurations with appspecs and testspecs' do
+      it 'whitelists pod configurations with appspecs and testspecs' do
         @parent.build_configurations = { 'Debug' => :debug, 'Release' => :release }
         @parent.store_pod('RestKit', :testspecs => %w(Tests), :configuration => 'Debug')
         @parent.store_pod('RestKit', :appspecs => %w(App), :configuration => 'Debug')


### PR DESCRIPTION
With multi-xcodeproj now users can have this option to group pods together. The actual CocoaPods change will follow but it's extremely easy in an internal test I did.

CocoaPods PR https://github.com/CocoaPods/CocoaPods/pull/8939