### PR TITLE
Improve threading in CDNSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@
 
 ##### Enhancements
 
-* None.  
+* CDNSource: Lower the thread pool limit to 50 and add an environment variable to override it.  
+  [Igor Makarov](https://github.com/igor-makarov)
+  [#551](https://github.com/CocoaPods/Core/pull/551)
+
+* CDNSource: Improve the error messaging from multi-threaded code.  
+  [Igor Makarov](https://github.com/igor-makarov)
+  [#551](https://github.com/CocoaPods/Core/pull/551)
 
 ##### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
   [Igor Makarov](https://github.com/igor-makarov)
   [#551](https://github.com/CocoaPods/Core/pull/551)
 
+* CDNSource: Retry connection errors.  
+  [Igor Makarov](https://github.com/igor-makarov)
+  [#551](https://github.com/CocoaPods/Core/pull/551)
+
 ##### Bug Fixes
 
 * None.  

--- a/lib/cocoapods-core/cdn_source.rb
+++ b/lib/cocoapods-core/cdn_source.rb
@@ -6,6 +6,7 @@ module Pod
   # Subclass of Pod::Source to provide support for CDN-based Specs repositories
   #
   class CDNSource < Source
+    MAX_CDN_NETWORK_THREADS = 50
     MAX_NUMBER_OF_RETRIES = 5
 
     # @param [String] repo The name of the repository
@@ -19,7 +20,7 @@ module Pod
 
       @executor = Concurrent::ThreadPoolExecutor.new(
         :min_threads => 5,
-        :max_threads => (ENV['MAX_CDN_NETWORK_THREADS'] || 50).to_i,
+        :max_threads => (ENV['MAX_CDN_NETWORK_THREADS'] || MAX_CDN_NETWORK_THREADS).to_i,
         :max_queue => 0 # unbounded work queue
       )
 

--- a/spec/cdn_source_spec.rb
+++ b/spec/cdn_source_spec.rb
@@ -94,7 +94,7 @@ module Pod
           returns(REST::Response.new(200, {}, real_podspec))
 
         spec = @source.specification('BeaconKit', '1.0.0')
-        spec.name.should.== 'BeaconKit'
+        spec.name.should == 'BeaconKit'
       end
 
       it 'raises cumulative error when more than one Future rejects' do

--- a/spec/cdn_source_spec.rb
+++ b/spec/cdn_source_spec.rb
@@ -93,7 +93,7 @@ module Pod
 
         should.raise Informative do
           @source.versions('BeaconKit')
-        end.message.should.== "CDN: test_cdn_repo_local Repo update failed - 6 error(s):\n" + messages.join("\n")
+        end.message.should.== "CDN: #{@source.name} Repo update failed - 6 error(s):\n" + messages.join("\n")
       end
 
       it 'returns cached versions for a Pod' do

--- a/spec/cdn_source_spec.rb
+++ b/spec/cdn_source_spec.rb
@@ -71,24 +71,43 @@ module Pod
       it 'raises if unexpected HTTP error' do
         REST.expects(:get).returns(REST::Response.new(500))
         should.raise Informative do
-          @source.versions('Unknown_Pod')
-        end.message.should.match /CDN: .* Relative path couldn\'t be downloaded: .* Response: 500/
+          @source.specification('BeaconKit', '1.0.0')
+        end.message.
+          should.== "CDN: #{@source.name} Relative path couldn\'t be downloaded: Specs/2/0/9/BeaconKit/1.0.0/BeaconKit.podspec.json Response: 500"
       end
 
       it 'raises if unexpected non-HTTP error' do
-        REST.expects(:get).raises(Exception, 'test message')
-        should.raise Exception do
-          @source.versions('Unknown_Pod')
-        end.message.should.== 'test message'
+        REST.expects(:get).at_least_once.raises(Errno::ECONNREFUSED)
+        should.raise Informative do
+          @source.specification('BeaconKit', '1.0.0')
+        end.message.
+          should.== "CDN: #{@source.name} Relative path couldn\'t be downloaded: Specs/2/0/9/BeaconKit/1.0.0/BeaconKit.podspec.json, error: #{Errno::ECONNREFUSED.new}"
+      end
+
+      it 'retries after unexpected non-HTTP error' do
+        real_podspec = File.read(@remote_dir.join(*%w(Specs 2 0 9 BeaconKit 1.0.0 BeaconKit.podspec.json)))
+        REST.expects(:get).
+          with('http://localhost:4321/Specs/2/0/9/BeaconKit/1.0.0/BeaconKit.podspec.json').
+          at_most(2).
+          raises(Errno::ECONNREFUSED).
+          then.
+          returns(REST::Response.new(200, {}, real_podspec))
+
+        spec = @source.specification('BeaconKit', '1.0.0')
+        spec.name.should.== 'BeaconKit'
       end
 
       it 'raises cumulative error when more than one Future rejects' do
-        REST.expects(:get).with('http://localhost:4321/all_pods_versions_2_0_9.txt').returns(REST::Response.new(200, {}, 'BeaconKit/1.0.0/1.0.1/1.0.2/1.0.3/1.0.4/1.0.5'))
+        REST.expects(:get).
+          with('http://localhost:4321/all_pods_versions_2_0_9.txt').
+          returns(REST::Response.new(200, {}, 'BeaconKit/1.0.0/1.0.1/1.0.2/1.0.3/1.0.4/1.0.5'))
         versions = %w(0 1 2 3 4 5)
         messages = versions.map do |index|
-          message = "test message #{index}"
-          REST.expects(:get).with("http://localhost:4321/Specs/2/0/9/BeaconKit/1.0.#{index}/BeaconKit.podspec.json").raises(Exception, message)
-          message
+          REST.expects(:get).
+            at_least_once.
+            with("http://localhost:4321/Specs/2/0/9/BeaconKit/1.0.#{index}/BeaconKit.podspec.json").
+            raises(Errno::ECONNREFUSED)
+          "CDN: #{@source.name} Relative path couldn't be downloaded: Specs/2/0/9/BeaconKit/1.0.#{index}/BeaconKit.podspec.json, error: #{Errno::ECONNREFUSED.new}"
         end
 
         should.raise Informative do


### PR DESCRIPTION
This PR addresses several issues in `CDNSource`:
1. Thread exhaustion on low-performance machines (such as CI VMs). The default number of threads is now set to 50 with an environment variable allowing to set it differently (`MAX_CDN_NETWORK_THREADS`).
2. Mangled output when concurrent code was failing. Now it will provide a more structured and readable output. Also using `Future`s as apparently this is what the `ruby-concurrent` docs suggest.
3. Non-HTTP errors were raised as exceptions. Now these will be wrapped with data about the specific download.
4. Added retry for network-related errors (`MAX_NUMBER_OF_RETRIES = 5`).
