### PR TITLE
Gracefully handle invalid version strings during linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@
   [Eric Amorde](https://github.com/amorde)
   [CocoaPods/CocoaPods#5420](https://github.com/CocoaPods/CocoaPods/issues/5420)
 
+* Gracefully handle invalid version values during linting.  
+  [Eric Amorde](https://github.com/amorde)
+  [CocoaPods/CocoaPods#8785](https://github.com/CocoaPods/CocoaPods/issues/8785)
+
 
 ## 1.7.3 (2019-06-28)
 

--- a/lib/cocoapods-core/specification.rb
+++ b/lib/cocoapods-core/specification.rb
@@ -125,8 +125,9 @@ module Pod
     #         clients.
     #
     def to_s
-      if name && !version.version.empty?
-        "#{name} (#{version})"
+      specified_version = attributes_hash['version'] || ''
+      if name && !specified_version.empty?
+        "#{name} (#{specified_version})"
       elsif name
         name
       else

--- a/spec/specification/linter_spec.rb
+++ b/spec/specification/linter_spec.rb
@@ -260,6 +260,12 @@ module Pod
         result_should_include('version', '0')
       end
 
+      it 'handles invalid version strings' do
+        @spec.stubs(:version).raises('Bad version')
+        result_ignore('attributes')
+        result_should_include('version', 'Unable to validate due to exception: Bad version')
+      end
+
       #------------------#
 
       it 'checks the summary length' do

--- a/spec/specification_spec.rb
+++ b/spec/specification_spec.rb
@@ -113,8 +113,15 @@ module Pod
         original_hash.should != new_hash
       end
 
-      it 'produces a string representation suitable for UI output.' do
-        @spec.to_s.should == 'Pod (1.0)'
+      describe '#to_s' do
+        it 'produces a string representation suitable for UI output.' do
+          @spec.to_s.should == 'Pod (1.0)'
+        end
+
+        it 'handles invalid version strings' do
+          @spec.version = '{SOME_VERSION}'
+          @spec.to_s.should == 'Pod ({SOME_VERSION})'
+        end
       end
 
       it 'handles the case where no version is available in the string representation' do


### PR DESCRIPTION
Closes CocoaPods/CocoaPods#8785

Output of lint for the example on the above issue will now look like this (a bit ugly, but nicer than a crash)

```
 -> SharkORM ({VER})
    - ERROR | attributes: Unable to parse attribute `version` due to error: Malformed version number string {VER}
    - ERROR | version: Unable to validate due to exception: Malformed version number string {VER}
    - ERROR | source: Unable to validate due to exception: Malformed version number string {VER}
    - ERROR | attributes: Unable to validate `version` (Malformed version number string {VER}).
    - ERROR | [iOS] unknown: Encountered an unknown error (The `SharkORM` pod failed to validate due to 4 errors:
    - ERROR | attributes: Unable to parse attribute `version` due to error: Malformed version number string {VER}
    - ERROR | version: Unable to validate due to exception: Malformed version number string {VER}
    - ERROR | source: Unable to validate due to exception: Malformed version number string {VER}
    - ERROR | attributes: Unable to validate `version` (Malformed version number string {VER}).

) during validation.
```