### PR TITLE
Add headers option on Http download strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@
   [Samuel Giddins](https://github.com/segiddins)
   [#520](https://github.com/CocoaPods/Core/pull/520)
 
+* Add `:headers` option to allow passing in custom headers to `cURL` when downloading source via the `:http` download strategy.  
+  [Wilmar van Heerden](https://github.com/wilmarvh)
+  [cocoapods-downloader#89](https://github.com/CocoaPods/cocoapods-downloader/issues/89)
+  [#557](https://github.com/CocoaPods/Core/pull/557)
+
 ##### Bug Fixes
 
 * Emit an error when a Podspec has an incorrect type for the `source` attribute  

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -305,7 +305,7 @@ module Pod
         :git  => [:tag, :branch, :commit, :submodules].freeze,
         :svn  => [:folder, :tag, :revision].freeze,
         :hg   => [:revision].freeze,
-        :http => [:flatten, :type, :sha256, :sha1].freeze,
+        :http => [:flatten, :type, :sha256, :sha1, :headers].freeze,
       }.freeze
 
       # @!method source=(source)


### PR DESCRIPTION
This is a supporting PR for the functionality introduced in https://github.com/CocoaPods/cocoapods-downloader/pull/89.

- Add an option `:headers` key for the caller to provide custom headers