### PR TITLE
[DSL] Support for test_type :ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ##### Enhancements
 
+* Add support for UI test specs with `test_type` value `:ui`  
+  [Yavuz Nuzumlali](https://github.com/manuyavuz)
+  [#562](https://github.com/CocoaPods/Core/pull/562)
+
 * Don't `Dir.chdir` when loading `Pod::Specification` from JSON  
   [Igor Makarov](https://github.com/igor-makarov)
   [#565](https://github.com/CocoaPods/Core/pull/565)

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -1503,7 +1503,7 @@ module Pod
 
       # The list of the test types currently supported.
       #
-      SUPPORTED_TEST_TYPES = [:unit].freeze
+      SUPPORTED_TEST_TYPES = [:unit, :ui].freeze
 
       # The test type this specification supports. This only applies to test specifications.
       #

--- a/spec/specification/consumer_spec.rb
+++ b/spec/specification/consumer_spec.rb
@@ -304,6 +304,14 @@ module Pod
         test_consumer.test_type.should.be == :unit
       end
 
+      it 'allows to specify the ui test type for a test subspec' do
+        @spec.test_spec {}
+        test_spec = @spec.test_specs.first
+        test_spec.test_type = :ui
+        test_consumer = Specification::Consumer.new(test_spec, :ios)
+        test_consumer.test_type.should.be == :ui
+      end
+
       it 'returns the test type as a symbol when consuming JSON specs' do
         @spec.test_spec {}
         test_spec = @spec.test_specs.first

--- a/spec/specification/dsl_spec.rb
+++ b/spec/specification/dsl_spec.rb
@@ -454,7 +454,7 @@ module Pod
         end
       end
 
-      it 'allows you to specify a test spec' do
+      it 'allows you to specify a unit test spec' do
         test_spec = @spec.subspecs.first
         test_spec.class.should == Specification
         test_spec.name.should == 'Spec/Tests'
@@ -462,7 +462,7 @@ module Pod
         test_spec.test_type.should == :unit
       end
 
-      it 'allows you to specify a test type as string' do
+      it 'allows you to specify a unit test type as string' do
         a_spec = Spec.new do |spec|
           spec.name = 'Spec'
           spec.test_spec do |test_spec|
@@ -474,6 +474,34 @@ module Pod
         test_spec.name.should == 'Spec/Tests'
         test_spec.test_specification?.should == true
         test_spec.test_type.should == :unit
+      end
+
+      it 'allows you to specify a ui test spec' do
+        a_spec = Spec.new do |spec|
+          spec.name = 'Spec'
+          spec.test_spec do |test_spec|
+            test_spec.test_type = :ui
+          end
+        end
+        test_spec = a_spec.subspecs.first
+        test_spec.class.should == Specification
+        test_spec.name.should == 'Spec/Tests'
+        test_spec.test_specification?.should == true
+        test_spec.test_type.should == :ui
+      end
+
+      it 'allows you to specify a ui test type as string' do
+        a_spec = Spec.new do |spec|
+          spec.name = 'Spec'
+          spec.test_spec do |test_spec|
+            test_spec.test_type = 'ui'
+          end
+        end
+        test_spec = a_spec.subspecs.first
+        test_spec.class.should == Specification
+        test_spec.name.should == 'Spec/Tests'
+        test_spec.test_specification?.should == true
+        test_spec.test_type.should == :ui
       end
 
       it 'allows you to specify a scheme for a test spec' do

--- a/spec/specification/json_spec.rb
+++ b/spec/specification/json_spec.rb
@@ -198,6 +198,14 @@ module Pod
         hash.should.include '"name":"Tests","test_type":"unit"'
       end
 
+      it 'writes ui test type for test subspec in json' do
+        @spec.test_spec do |test|
+          test.test_type = :ui
+        }
+        hash = @spec.to_json
+        hash.should.include '"name":"Tests","test_type":"ui"'
+      end
+
       it 'can be loaded from an hash' do
         hash = {
           'name' => 'BananaLib',
@@ -299,6 +307,17 @@ module Pod
         result.test_specs.first.test_specification?.should.be.true
         result.test_specs.first.app_specification?.should.be.false
         result.test_specs.first.test_type.should.equal :unit
+      end
+
+      it 'can load ui test specification from json' do
+        json = '{"testspecs": [{"name": "Tests","test_type": "ui","source_files": "Tests/**/*.{h,m}"}]}'
+        result = Specification.from_json(json)
+        result.non_library_specs.count.should.equal 1
+        result.test_specs.count.should.equal 1
+        result.app_specs.count.should.equal 0
+        result.test_specs.first.test_specification?.should.be.true
+        result.test_specs.first.app_specification?.should.be.false
+        result.test_specs.first.test_type.should.equal :ui
       end
 
       it 'can load app specification from json' do

--- a/spec/specification/json_spec.rb
+++ b/spec/specification/json_spec.rb
@@ -201,7 +201,7 @@ module Pod
       it 'writes ui test type for test subspec in json' do
         @spec.test_spec do |test|
           test.test_type = :ui
-        }
+        end
         hash = @spec.to_json
         hash.should.include '"name":"Tests","test_type":"ui"'
       end

--- a/spec/specification/linter_spec.rb
+++ b/spec/specification/linter_spec.rb
@@ -293,7 +293,12 @@ module Pod
       end
 
       it 'checks the test type value is correct using a JSON podspec' do
-        podspec = '{"testspecs":[{"name": "Tests","test_type": "unit","source_files": "Tests/**/*.{h,m}"}]}'
+        podspec = '{
+          "testspecs":[
+            {"name": "Tests","test_type": "unit","source_files": "Tests/**/*.{h,m}"},
+            {"name": "Tests","test_type": "ui","source_files": "Tests/**/*.{h,m}"}
+          ]
+        }'
         path = SpecHelper.temporary_directory + 'BananaLib.podspec.json'
         File.open(path, 'w') { |f| f.write(podspec) }
         linter = Specification::Linter.new(path)


### PR DESCRIPTION
Add support for UI test type.

Required for CocoaPods/Cocoapods#9001.