### PR TITLE
Don't `Dir.chdir` when loading `Pod::Specification` from JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ##### Enhancements
 
+* Don't `Dir.chdir` when loading `Pod::Specification` from JSON  
+  [Igor Makarov](https://github.com/igor-makarov)
+  [#565](https://github.com/CocoaPods/Core/pull/565)
+
 * Replace git-based `MasterSource` with CDN-based `TrunkSource`  
   [Igor Makarov](https://github.com/igor-makarov)
   [#552](https://github.com/CocoaPods/Core/pull/552)

--- a/lib/cocoapods-core/specification.rb
+++ b/lib/cocoapods-core/specification.rb
@@ -703,18 +703,18 @@ module Pod
     def self.from_string(spec_contents, path, subspec_name = nil)
       path = Pathname.new(path).expand_path
       spec = nil
-      Dir.chdir(path.parent.directory? ? path.parent : Dir.pwd) do
-        case path.extname
-        when '.podspec'
+      case path.extname
+      when '.podspec'
+        Dir.chdir(path.parent.directory? ? path.parent : Dir.pwd) do
           spec = ::Pod._eval_podspec(spec_contents, path)
           unless spec.is_a?(Specification)
             raise Informative, "Invalid podspec file at path `#{path}`."
           end
-        when '.json'
-          spec = Specification.from_json(spec_contents)
-        else
-          raise Informative, "Unsupported specification format `#{path.extname}` for spec at `#{path}`."
         end
+      when '.json'
+        spec = Specification.from_json(spec_contents)
+      else
+        raise Informative, "Unsupported specification format `#{path.extname}` for spec at `#{path}`."
       end
 
       spec.defined_in_file = path

--- a/spec/specification_spec.rb
+++ b/spec/specification_spec.rb
@@ -687,6 +687,7 @@ module Pod
       end
 
       it 'can be initialized from a JSON file' do
+        Dir.expects(:chdir).never
         spec = Spec.from_file(fixture('BananaLib.podspec.json'))
         spec.class.should == Spec
         spec.name.should == 'BananaLib'


### PR DESCRIPTION
Came across it when I was trying to multi-thread the Netlify builder. Did not end up needing it, but thought this made sense to PR anyway.