### PR TITLE
Update docs to mention that public header files should be included in source files

### DIFF
--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -1188,7 +1188,7 @@ module Pod
       #
       #   ---
       #
-      #   These patterns are matched against the source files to include headers 
+      #   These patterns are matched against the source files to include headers
       #   that will be exposed to the user’s project and
       #   from which documentation will be generated. When the library is built,
       #   these headers will appear in the build directory. If no public headers

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -1188,7 +1188,8 @@ module Pod
       #
       #   ---
       #
-      #   These are the headers that will be exposed to the user’s project and
+      #   These patterns are matched against the source files to include headers 
+      #   that will be exposed to the user’s project and
       #   from which documentation will be generated. When the library is built,
       #   these headers will appear in the build directory. If no public headers
       #   are specified then **all** the headers in source_files are considered


### PR DESCRIPTION
Please let me know if my understanding of this is correct! I was having issues because I had added a bunch of headers to `public_header_files` but not to `source_files`, and it wasn't working properly. Also, I wonder if this behavior should be changed somehow, even just adding a warning if it seems like the user is doing the wrong thing.