### PR TITLE
[Consumer] Don't merge non-library spec build settings

### DIFF
--- a/lib/cocoapods-core/specification/consumer.rb
+++ b/lib/cocoapods-core/specification/consumer.rb
@@ -369,6 +369,8 @@ module Pod
         case attr.name
         when :info_plist
           new
+        when ->(name) { spec.non_library_specification? && [:pod_target_xcconfig, :user_target_xcconfig, :xcconfig].include?(name) }
+          new
         else
           if new.is_a?(Array) || old.is_a?(Array)
             r = Array(old) + Array(new)


### PR DESCRIPTION
That will now be handled by the xcconfig generator in CocoaPods

For https://github.com/CocoaPods/CocoaPods/pull/9030