### PR TITLE
CDNSource: Add retries for 502, 503, 504 errors

### DIFF
--- a/lib/cocoapods-core/cdn_source.rb
+++ b/lib/cocoapods-core/cdn_source.rb
@@ -6,8 +6,8 @@ module Pod
   # Subclass of Pod::Source to provide support for CDN-based Specs repositories
   #
   class CDNSource < Source
-    MAX_CDN_NETWORK_THREADS = 50
-    MAX_NUMBER_OF_RETRIES = 5
+    MAX_CDN_NETWORK_THREADS = (ENV['MAX_CDN_NETWORK_THREADS'] || 50).to_i
+    MAX_NUMBER_OF_RETRIES = (ENV['COCOAPODS_MAX_NUMBER_OF_RETRIES'] || 5).to_i
 
     # @param [String] repo The name of the repository
     #
@@ -20,7 +20,7 @@ module Pod
 
       @executor = Concurrent::ThreadPoolExecutor.new(
         :min_threads => 5,
-        :max_threads => (ENV['MAX_CDN_NETWORK_THREADS'] || MAX_CDN_NETWORK_THREADS).to_i,
+        :max_threads => MAX_CDN_NETWORK_THREADS,
         :max_queue => 0 # unbounded work queue
       )
 

--- a/lib/cocoapods-core/cdn_source.rb
+++ b/lib/cocoapods-core/cdn_source.rb
@@ -7,7 +7,7 @@ module Pod
   #
   class CDNSource < Source
     MAX_CDN_NETWORK_THREADS = (ENV['MAX_CDN_NETWORK_THREADS'] || 50).to_i
-    MAX_NUMBER_OF_RETRIES = (ENV['COCOAPODS_MAX_NUMBER_OF_RETRIES'] || 5).to_i
+    MAX_NUMBER_OF_RETRIES = (ENV['COCOAPODS_CDN_MAX_NUMBER_OF_RETRIES'] || 5).to_i
 
     # @param [String] repo The name of the repository
     #


### PR DESCRIPTION
This PR addresses some reports of encountering reliability problems with CDN servers.  
Generally speaking, ['retry culture'](https://twitter.com/jessfraz/status/1141414897743466496) is not a positive phenomenon and it affects all aspects of modern computing.  

However, in the case of CocoaPods, this was inevitable, since we are free users of the CDNs and can't expect GitHub or Netlify to improve their infrastructure for our benefit.

This PR adds exponential backoff retries for HTTP errors `502`, `503`, `504`. Adding it for other `5xx` errors seemed too heavy-handed.

The total number of retries is configured by the constant `MAX_NUMBER_OF_RETRIES`, or by setting ENV variable `COCOAPODS_CDN_MAX_NUMBER_OF_RETRIES`.

The backoff function is `4 * 2 ^ i`, meaning `4, 8, 16, 32` seconds.

Additionally, this PR fixed an off-by-one error in the previously implemented non-HTTP retry counter. Tests were added for that as well.