### PR TITLE
Remove legacy code around HEAD dependencies

### DIFF
--- a/lib/cocoapods-core/dependency.rb
+++ b/lib/cocoapods-core/dependency.rb
@@ -69,20 +69,6 @@ module Pod
     #
     #             Dependency.new('Artsy+UILabels', '~> 1.0', :source => 'https://github.com/Artsy/Specs.git')
     #
-    # @overload   initialize(name, is_head)
-    #
-    #   @param    [String] name
-    #             the name of the Pod.
-    #
-    #   @param    [Symbol] is_head
-    #             a symbol that can be `:head` or nil.
-    #
-    #   @todo     Remove `:head` code once everyone has migrated past CocoaPods 1.0.
-    #
-    #   @example  Initialization with the head option
-    #
-    #             Dependency.new('RestKit', :head)
-    #
     def initialize(name = nil, *requirements)
       if requirements.last.is_a?(Hash)
         additional_params = requirements.pop.select { |_, v| !v.nil? }
@@ -121,10 +107,6 @@ module Pod
 
     # @return [Requirement] the requirement of this dependency (a set of
     #         one or more version restrictions).
-    #
-    # @todo   The specific version is stripped from head information because
-    #         because its string representation would not parse. It would
-    #         be better to add something like Version#display_string.
     #
     def requirement
       if specific_version
@@ -357,8 +339,6 @@ module Pod
     #           part by clients that need to create a dependency equal to the
     #           original one.
     #
-    # @todo     Remove the `HEAD` code once everyone has migrated past 1.0.
-    #
     # @return   [Dependency] the dependency described by the string.
     #
     def self.from_string(string)
@@ -367,9 +347,6 @@ module Pod
       version = match_data[2]
       version = version.gsub(/[()]/, '') if version
       case version
-      when / HEAD( \(based on #{Pod::Version::VERSION_PATTERN}\))?/
-        CoreUI.warn "Ignoring obsolete `HEAD` specifier in `#{string}`"
-        Dependency.new(name)
       when nil, /from `(.*)(`|')/
         Dependency.new(name)
       else

--- a/lib/cocoapods-core/specification/root_attribute_accessors.rb
+++ b/lib/cocoapods-core/specification/root_attribute_accessors.rb
@@ -27,11 +27,6 @@ module Pod
 
         # @return [Version] The version of the Pod.
         #
-        # @todo   The version is memoized because the Resolvers sets the head
-        #         state on it. This information should be stored in the
-        #         specification instance and the lockfile should have a more
-        #         robust handling of head versions (like a dedicated section).
-        #
         def version
           if root?
             @version ||= Version.new(attributes_hash['version'])


### PR DESCRIPTION
The code path was already defunct* and untested. The todos around this were misleading as not in sync with actual behavior anymore.

*defunct as in dead: the first regex here removes all parentheses, the next tries to match on them.

https://github.com/CocoaPods/Core/blob/065bb3e0576e3bd92d97809018b376572f3d00d2/lib/cocoapods-core/dependency.rb#L368-L370
