### PR TITLE
Use Typhoeus for more performant CDN requests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,7 @@ PATH
       concurrent-ruby (~> 1.1)
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)
+      typhoeus (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -38,6 +39,8 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     docile (1.1.5)
+    ethon (0.12.0)
+      ffi (>= 1.3.0)
     ffi (1.9.18)
     fuzzy_match (2.0.4)
     hashdiff (0.3.8)
@@ -94,6 +97,8 @@ GEM
     simplecov-html (0.9.0)
     slop (3.6.0)
     thread_safe (0.3.6)
+    typhoeus (1.3.1)
+      ethon (>= 0.9.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,7 @@ PATH
       concurrent-ruby (~> 1.1)
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)
+      netrc (~> 0.11)
       typhoeus (~> 1.0)
 
 GEM
@@ -63,6 +64,7 @@ GEM
       mocha (>= 0.13.0)
     multi_json (1.12.1)
     nap (1.1.0)
+    netrc (0.11.0)
     notify (0.5.2)
     parser (2.4.0.0)
       ast (~> 2.2)

--- a/cocoapods-core.gemspec
+++ b/cocoapods-core.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'fuzzy_match', '~> 2.0.4'
   s.add_runtime_dependency 'algoliasearch', '~> 1.0'
   s.add_runtime_dependency 'concurrent-ruby', '~> 1.1'
+  s.add_runtime_dependency 'typhoeus', '~> 1.0'
 
   s.add_development_dependency 'bacon', '~> 1.1'
 

--- a/cocoapods-core.gemspec
+++ b/cocoapods-core.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'algoliasearch', '~> 1.0'
   s.add_runtime_dependency 'concurrent-ruby', '~> 1.1'
   s.add_runtime_dependency 'typhoeus', '~> 1.0'
+  s.add_runtime_dependency 'netrc', '~> 0.11'
 
   s.add_development_dependency 'bacon', '~> 1.1'
 

--- a/lib/cocoapods-core/cdn_source.rb
+++ b/lib/cocoapods-core/cdn_source.rb
@@ -2,6 +2,7 @@ require 'cocoapods-core/source'
 require 'rest'
 require 'concurrent'
 require 'typhoeus'
+require 'netrc'
 
 module Pod
   # Subclass of Pod::Source to provide support for CDN-based Specs repositories
@@ -443,6 +444,8 @@ module Pod
         :timeout => 10,
         :connecttimeout => 10,
         :accept_encoding => 'gzip',
+        :netrc => :optional,
+        :netrc_file => Netrc.default_path,
         :headers => etag.nil? ? {} : { 'If-None-Match' => etag },
       )
 

--- a/lib/cocoapods-core/cdn_source.rb
+++ b/lib/cocoapods-core/cdn_source.rb
@@ -432,12 +432,17 @@ module Pod
     def download_typhoeus_impl_async(file_remote_url, etag)
       # Create a prefereably HTTP/2 request - the protocol is ultimately responsible for picking
       # the maximum supported protocol
+      # When debugging with proxy, use the following extra options:
+      # :proxy => 'http://localhost:8888',
+      # :ssl_verifypeer => false,
+      # :ssl_verifyhost => 0,
       request = Typhoeus::Request.new(
         file_remote_url,
         :method => :get,
         :http_version => :httpv2_0,
         :timeout => 10,
         :connecttimeout => 10,
+        :accept_encoding => 'gzip',
         :headers => etag.nil? ? {} : { 'If-None-Match' => etag },
       )
 


### PR DESCRIPTION
This PR comes to address 3 issues regarding `CDNSource` and its HTTP handling by moving to `Typhoeus`, a `libcurl` wrapper:

### 50 Threads
The previous implementation utilized 50 threads to make HTTP requests, which was too much/too little for different use cases.  
The new implementation moves all the async code to a single-threaded reactor provided by the [libcurl Multi interface](https://curl.haxx.se/libcurl/c/libcurl-multi.html). This achieves same performance as the multithreaded way.

### No HTTP/2
The built-in `Net::HTTP` module doesn't support HTTP/2, and by extension, `nap` also doesn't.  There are many benefits to HTTP/2, but the relevant to us are reducing the number of connections and reducing bandwidth by compressing headers.

I believe that the time to move to this better-performing implementation is now, before 1.8.0 ships to the general public and we start seeing much more traffic from default-repo users.

### Gzip
`nap` doesn't have built-in support for Gzip decoding the requests. Typhoeus does and now so does `CDNSource`.