### PR TITLE
Fix Source::Manager#aggregate_for_dependency

### DIFF
--- a/lib/cocoapods-core/lockfile.rb
+++ b/lib/cocoapods-core/lockfile.rb
@@ -489,7 +489,10 @@ module Pod
           next unless source
           next if specs.empty?
           key = source.url || source.name
+
+          # save `trunk` as 'trunk' so that the URL itself can be changed without lockfile churn
           key = Pod::TrunkSource::TRUNK_REPO_NAME if source.name == Pod::TrunkSource::TRUNK_REPO_NAME
+
           value = specs.map { |s| s.root.name }.uniq
           [key, YAMLHelper.sorted_array(value)]
         end.compact]

--- a/lib/cocoapods-core/source/manager.rb
+++ b/lib/cocoapods-core/source/manager.rb
@@ -35,7 +35,7 @@ module Pod
       def aggregate_for_dependency(dependency)
         return aggregate if dependency.podspec_repo.nil?
 
-        source = source_with_url(dependency.podspec_repo)
+        source = source_with_url(dependency.podspec_repo) || source_with_name(dependency.podspec_repo)
         return aggregate if source.nil?
 
         aggregate_with_repos([source.repo])
@@ -326,6 +326,17 @@ module Pod
         @aggregates_by_repos[repos] ||= Source::Aggregate.new(sources)
       end
 
+      # @return [Source] The source with the given name.
+      #
+      # @param  [String] name
+      #         The name of the source.
+      #
+      def source_with_name(name)
+        source = sources([name]).first
+        return nil unless source.repo.exist?
+        source
+      end
+
       # @return [Source] The updateable source with the given name. If no updateable source
       #         with given name is found it raises.
       #
@@ -333,7 +344,7 @@ module Pod
       #         The name of the source.
       #
       def updateable_source_named(name)
-        specified_source = sources([name]).first
+        specified_source = source_with_name(name)
         unless specified_source
           raise Informative, "Unable to find the `#{name}` repo."
         end

--- a/spec/source/manager_spec.rb
+++ b/spec/source/manager_spec.rb
@@ -61,7 +61,6 @@ module Pod
       end
 
       it 'includes only the one source in an aggregate for a dependency if a source is specified by name' do
-        repo_url = 'https://url/to/specs.git'
         dependency = Dependency.new('JSONKit', '1.4', :source => 'repo_name')
 
         source = mock

--- a/spec/source/manager_spec.rb
+++ b/spec/source/manager_spec.rb
@@ -45,7 +45,7 @@ module Pod
         aggregate.sources.map(&:name).should == %w(artsy test_cdn_repo_local test_empty_dir_repo test_prefixed_repo test_repo test_repo_without_specs_dir trunk)
       end
 
-      it 'includes only the one source in an aggregate for a dependency if a source is specified' do
+      it 'includes only the one source in an aggregate for a dependency if a source is specified by URL' do
         repo_url = 'https://url/to/specs.git'
         dependency = Dependency.new('JSONKit', '1.4', :source => repo_url)
 
@@ -54,6 +54,22 @@ module Pod
         source.stubs(:repo).returns('path')
 
         @sources_manager.expects(:source_with_url).with(repo_url).returns(source)
+        @sources_manager.expects(:source_from_path).with('path').returns(source)
+
+        aggregate = @sources_manager.aggregate_for_dependency(dependency)
+        aggregate.sources.map(&:name).should == [source.name]
+      end
+
+      it 'includes only the one source in an aggregate for a dependency if a source is specified by name' do
+        repo_url = 'https://url/to/specs.git'
+        dependency = Dependency.new('JSONKit', '1.4', :source => 'repo_name')
+
+        source = mock
+        source.stubs(:name).returns('repo_name')
+        source.stubs(:repo).returns('path')
+
+        @sources_manager.expects(:source_with_url).with('repo_name').returns(nil)
+        @sources_manager.expects(:source_with_name).with('repo_name').returns(source)
         @sources_manager.expects(:source_from_path).with('path').returns(source)
 
         aggregate = @sources_manager.aggregate_for_dependency(dependency)


### PR DESCRIPTION
Today I looked into what seems like a resolver issue.  
A user that had the old `master` repo still intact reported the fact that some pods were being unlocked in the `Podfile.lock` and reassigned to `master` repo.   
The 'multiple sources' warning was being raised.

Upon researching, it came to light that `Source::Manager` wasn't correctly finding sources by their names, including the `trunk` source.

This PR fixes the behavior and also adds some code comments as to why `TrunkSource` is locked by name.
