### PR TITLE
update concurrent-ruby dep to be ~> 1.1, as that's the one with the new Promises API

### DIFF
--- a/cocoapods-core.gemspec
+++ b/cocoapods-core.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'nap', '~> 1.0'
   s.add_runtime_dependency 'fuzzy_match', '~> 2.0.4'
   s.add_runtime_dependency 'algoliasearch', '~> 1.0'
-  s.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
+  s.add_runtime_dependency 'concurrent-ruby', '~> 1.1'
 
   s.add_development_dependency 'bacon', '~> 1.1'
 


### PR DESCRIPTION
Closes https://github.com/CocoaPods/CocoaPods/issues/9177