### PR TITLE
Make initializing `Platform` with a string 'macos' behave the same as `Platform.macos`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 * Extend `script_phase` DSL to support dependency file.  
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#579](https://github.com/CocoaPods/Core/pull/579)
+  
+* Make initializing `Platform` with the string 'macos' equivalent to calling `Platform.macos`  
+  [Eric Amorde](https://github.com/amorde)
+  [#602](https://github.com/CocoaPods/Core/pull/602) 
 
 ##### Bug Fixes
 

--- a/lib/cocoapods-core/platform.rb
+++ b/lib/cocoapods-core/platform.rb
@@ -45,6 +45,10 @@ module Pod
         @symbolic_name = input.name
         @deployment_target = input.deployment_target
       else
+        # Allow `Platform.new('macos')` to be equivalent to `Platform.macos`
+        if input == 'macos'
+          input = 'osx'
+        end
         @symbolic_name = input.to_sym
         target = target[:deployment_target] if target.is_a?(Hash)
         @deployment_target = Version.create(target)

--- a/spec/platform_spec.rb
+++ b/spec/platform_spec.rb
@@ -29,8 +29,14 @@ module Pod
       end
 
       it 'can be initialized with a string symbolic name' do
-        Platform.new('ios')
-        @platform.name.should == :ios
+        platform = Platform.new('ios')
+        platform.name.should == :ios
+      end
+
+      it 'can be initialized with a string representing macOS' do
+        platform = Platform.new('macos')
+        platform.name.should == :osx
+        platform.string_name.should == 'macOS'
       end
 
       it 'exposes its name as string' do


### PR DESCRIPTION
This makes it easier for `Platform` consumers to use `Platform.new` to parse values from JSON, Info.plist files,  etc. without having to manually map `macos` => `osx` in order for it to successfully match other platforms defined within CocoaPods.