### PR TITLE
Add a post integrate hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ##### Enhancements
 
-* None.  
+* Add a post_integrate_hook API  
+  [lucasmpaim](https://github.com/lucasmpaim)
+  [#7432](https://github.com/CocoaPods/CocoaPods/issues/7432)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods-core/podfile.rb
+++ b/lib/cocoapods-core/podfile.rb
@@ -183,6 +183,23 @@ module Pod
       end
     end
 
+    # Calls the post integrate callback if defined.
+    #
+    # @param  [Pod::Installer] installer
+    #         the installer that is performing the installation.
+    #
+    # @return [Bool] whether a post install callback was specified and it was
+    #         called.
+    #
+    def post_integrate!(installer)
+      if @post_integrate_callback
+        @post_integrate_callback.call(installer)
+        true
+      else
+        false
+      end
+    end
+
     #-------------------------------------------------------------------------#
 
     public

--- a/lib/cocoapods-core/podfile/dsl.rb
+++ b/lib/cocoapods-core/podfile/dsl.rb
@@ -930,6 +930,26 @@ module Pod
         raise Informative, 'Specifying multiple `post_install` hooks is unsupported.' if @post_install_callback
         @post_install_callback = block
       end
+
+      # This hook allows you to make changes after the project is written
+      # to disk.
+      #
+      # It receives the
+      # [`Pod::Installer`](http://rubydoc.info/gems/cocoapods/Pod/Installer/)
+      # as its only argument.
+      #
+      # @example  Customising the build settings of all targets
+      #
+      #   post_integrate do |installer|
+      #     # some change after project write to disk
+      #   end
+      #
+      # @return   [void]
+      #
+      def post_integrate(&block)
+        raise Informative, 'Specifying multiple `post_integrate` hooks is unsupported.' if @post_integrate_callback
+        @post_integrate_callback = block
+      end
     end
   end
 end

--- a/spec/podfile_spec.rb
+++ b/spec/podfile_spec.rb
@@ -93,6 +93,12 @@ module Pod
         result = Podfile.new { post_install { |_installer| } }.post_install!(:an_installer)
         result.should.be == true
       end
+
+      it 'indicates if the post integrate hook was executed' do
+        Podfile.new {}.post_integrate!(:an_installer).should.be == false
+        result = Podfile.new { post_integrate { |_installer| } }.post_integrate!(:an_installer)
+        result.should.be == true
+      end
     end
 
     #-------------------------------------------------------------------------#


### PR DESCRIPTION
Create a post_integrate API, with this we are able to add a scripts to execute after the project are generated, like:

```ruby
post_integrate do |installer|
    puts "Called"
    bricklayer.configure_project
end
```

obs: `bricklayer` is my own package to link and compile project subproject's, for execute this I need the `.xcworkspace` file already created

Ref. [#7432](https://github.com/CocoaPods/CocoaPods/issues/7432#issuecomment-561745032)
Impl. [#9391](https://github.com/CocoaPods/CocoaPods/pull/9391)