### PR TITLE
[Pod::Version prerelease?] Not correct when version with metadata.

### DIFF
--- a/lib/cocoapods-core/version.rb
+++ b/lib/cocoapods-core/version.rb
@@ -69,7 +69,8 @@ module Pod
     #
     def prerelease?
       return @prerelease if defined?(@prerelease)
-      @prerelease = @version =~ /[a-zA-Z\-]/
+      comparable_version = @version.sub(/#{METADATA_PATTERN}$/, '')
+      @prerelease = comparable_version =~ /[a-zA-Z\-]/
     end
 
     # @return [Bool] Whether a string representation is correct.

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -21,6 +21,8 @@ module Pod
       it 'identifies release versions' do
         version = Version.new('1.0.0')
         version.should.not.be.prerelease
+        version = Version.new('1.0.0+exp.sha1.77cb5a')
+        version.should.not.be.prerelease
       end
 
       it 'matches Semantic Version pre-release versions' do


### PR DESCRIPTION
According to the [semver](https://semver.org/), metadata could contain ASCII alphanumerics. That make `Pod::Version` method `prerelease?` regard version like '1.1.0+exp.1' as a prerelease version.