### PR TITLE
Replace URI.encode (obsolete) with Addressable gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ PATH
   specs:
     cocoapods-core (1.9.0.beta.2)
       activesupport (>= 4.0.2, < 6)
+      addressable (~> 2.6)
       algoliasearch (~> 1.0)
       concurrent-ruby (~> 1.1)
       fuzzy_match (~> 2.0.4)

--- a/cocoapods-core.gemspec
+++ b/cocoapods-core.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'concurrent-ruby', '~> 1.1'
   s.add_runtime_dependency 'typhoeus', '~> 1.0'
   s.add_runtime_dependency 'netrc', '~> 0.11'
+  s.add_runtime_dependency "addressable", '~> 2.6'
 
   s.add_development_dependency 'bacon', '~> 1.1'
 

--- a/lib/cocoapods-core/cdn_source.rb
+++ b/lib/cocoapods-core/cdn_source.rb
@@ -333,7 +333,7 @@ module Pod
     end
 
     def download_file_async(partial_url)
-      file_remote_url = URI.encode(url + partial_url.to_s)
+      file_remote_url = Addressable::URI.encode(url + partial_url.to_s)
       path = repo + partial_url
 
       if File.exist?(path)


### PR DESCRIPTION
Replace URI.encode with Addressable gem to fix warning when running the latest stable release for CocoaPods on Ruby 2.7.0.
