### PR TITLE
Add ruby 2.7.0 support to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ rvm:
   - 2.3.4
   - 2.4.1
   - 2.6.2
+  - 2.7.0
 env:
   - LANG="en_US.UTF-8"
 script: bundle exec rake spec

--- a/spec/standard_error_spec.rb
+++ b/spec/standard_error_spec.rb
@@ -39,7 +39,23 @@ module Pod
       @err.stubs(:description).returns("Invalid `Three20.podspec` file: #{syntax_error.message}")
       @err.stubs(:underlying_exception).returns(syntax_error)
       File.stubs(:read).returns(code)
-      @err.message.should == <<-MSG.strip_heredoc
+      @err.message.should == if Pod::Version.new(RUBY_VERSION) >= Pod::Version.new('2.7.0')
+                               <<-MSG.strip_heredoc
+
+        [!] Invalid `Three20.podspec` file: syntax error, unexpected ')', expecting end-of-input
+        puts())
+              ^
+        .
+
+         #  from #{@dsl_path.expand_path}:2
+         #  -------------------------------------------
+         #  puts 'hi'
+         >  puts())
+         #  puts 'bye'
+         #  -------------------------------------------
+        MSG
+                             else
+                               <<-MSG.strip_heredoc
 
         [!] Invalid `Three20.podspec` file: syntax error, unexpected ')', expecting end-of-input.
 
@@ -49,7 +65,8 @@ module Pod
          >  puts())
          #  puts 'bye'
          #  -------------------------------------------
-      MSG
+        MSG
+                             end
     end
 
     it 'uses the passed-in contents' do


### PR DESCRIPTION
2.7.0 is stable now, and it included some deprecation that spawned other PRs
There was a suggestion to add support here: https://github.com/CocoaPods/Core/pull/613#issuecomment-580571457