### PR TITLE
Ruby 2.7.x clear remaining warnings during tests.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :development do
   gem 'mocha'
   gem 'mocha-on-bacon'
   gem 'prettybacon'
-  gem 'rake'
+  gem 'rake', '~> 12.0'
   gem 'vcr'
   gem 'webmock'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
     public_suffix (2.0.5)
     rainbow (2.2.2)
       rake
-    rake (12.0.0)
+    rake (12.3.3)
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
@@ -128,7 +128,7 @@ DEPENDENCIES
   prettybacon
   pry
   public_suffix (>= 2.0.5, < 3)
-  rake
+  rake (~> 12.0)
   rb-fsevent
   rubocop (~> 0.38.0)
   vcr

--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -288,6 +288,7 @@ module Pod
       # Performs validations related to the `homepage` attribute.
       #
       def _validate_homepage(h)
+        return unless h.is_a?(String)
         if h =~ %r{http://EXAMPLE}
           results.add_warning('homepage', 'The homepage has not been updated' \
            ' from default')


### PR DESCRIPTION
Fixes some warnings by upgrading `rake` gem and also a warning during running a single test.