### PR TITLE
Add a lint check for the name format of vendored static libraries

### DIFF
--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -337,6 +337,19 @@ module Pod
         end
       end
 
+      # Performs validations related to the `vendored_libraries` attribute.
+      #
+      # @param [Array<String>] vendored_libraries the values specified in the `vendored_libraries` attribute
+      #
+      def _validate_vendored_libraries(vendored_libraries)
+        vendored_libraries.each do |lib|
+          lib_name = lib.downcase
+          unless lib_name.end_with?('.a') && lib_name.start_with?('lib')
+            results.add_warning('vendored_libraries', "`#{File.basename(lib)}` does not match the expected static library name format `lib[name].a`")
+          end
+        end
+      end
+
       # Performs validations related to the `license` attribute.
       #
       def _validate_license(l)

--- a/spec/specification/linter_spec.rb
+++ b/spec/specification/linter_spec.rb
@@ -649,6 +649,26 @@ module Pod
 
       #------------------#
 
+      it 'accepts valid vendored_libraries' do
+        @spec.vendored_libraries = 'libCoconut.a'
+        @linter.lint
+        @linter.results.should.be.empty?
+      end
+
+      it 'checks the file name extension of vendored_libraries' do
+        @spec.vendored_libraries = 'libSomething'
+        result_should_include('`libSomething` does not match the expected static library name format `lib[name].a`', 'vendored_libraries')
+        @linter.results.map(&:type).should == [:warning]
+      end
+
+      it 'check the file name prefix of vendored_libraries' do
+        @spec.vendored_libraries = 'something.a'
+        result_should_include('`something.a` does not match the expected static library name format `lib[name].a`', 'vendored_libraries')
+        @linter.results.map(&:type).should == [:warning]
+      end
+
+      #------------------#
+
       it 'checks if the compiler flags disable warnings' do
         @spec.compiler_flags = '-some_flag', '-another -Wno_flags'
         result_should_include('warnings', 'disabled', 'compiler_flags')


### PR DESCRIPTION
This checks that vendored libraries match the expected format `lib[name].a`.
This comes up occasionally in issues, such as https://github.com/CocoaPods/CocoaPods/issues/9596