### PR TITLE
Force UTF-8 encoding on JSON Podspecs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@
 
 ##### Bug Fixes
 
-* None.  
-
+* Fix a crash when JSON Podspec encoding is guessed incorrectly  
+  [Jason Schroeder](https://github.com/jasonschroeder-sfdc)
+  [#629](https://github.com/CocoaPods/Core/pull/629)
 
 ## 1.9.1 (2020-03-09)
 

--- a/lib/cocoapods-core/cdn_source.rb
+++ b/lib/cocoapods-core/cdn_source.rb
@@ -376,7 +376,7 @@ module Pod
           FileUtils.touch path
           partial_url
         when 200
-          File.open(path, 'w') { |f| f.write(response.response_body) }
+          File.open(path, 'w') { |f| f.write(response.response_body.force_encoding('UTF-8')) }
 
           etag_new = response.headers['etag'] unless response.headers.nil?
           debug "CDN: #{name} Relative path downloaded: #{partial_url}, save ETag: #{etag_new}"

--- a/spec/cdn_source_spec.rb
+++ b/spec/cdn_source_spec.rb
@@ -202,6 +202,20 @@ module Pod
         end
       end
 
+      it 'forces UTF-8 encoding for the body' do
+        mock_json_body = mock
+        mock_json_body.expects(:force_encoding).with('UTF-8').at_least_once
+        @source.expects(:download_typhoeus_impl_async).
+          with_url('http://localhost:4321/all_pods_versions_2_0_9.txt').
+          returns(typhoeus_http_response_future(200, nil, 'BeaconKit/1.0.0'))
+        @source.expects(:download_typhoeus_impl_async).
+          with_url('http://localhost:4321/Specs/2/0/9/BeaconKit/1.0.0/BeaconKit.podspec.json').
+          returns(typhoeus_http_response_future(200, {}, mock_json_body))
+        should.not.raise do
+          @source.versions('BeaconKit')
+        end
+      end
+
       it 'raises if unexpected HTTP error' do
         @source.expects(:download_typhoeus_impl_async).
           returns(typhoeus_http_response_future(500))


### PR DESCRIPTION
Write the file from CDN to disk without any conversions.
Some `response_body` are coming back with encoding=`ASCII-8BIT` but are not writable to
disk, with errors like this:

```
[!] CDN: trunk Repo update failed - 31 error(s):
"\xE2" from ASCII-8BIT to UTF-8
```
(second line repeated 31 times)

### Environment: 
- Cocoapods 1.9.1
- Ruby 2.5.3, and Ruby 2.7.1 both via `rvm`
- MacOS 10.14.6
Env vars: 
- `LANG=en_US.UTF-8`

Here is the stacktrace from `pod install --verbose`
```
$HOME/.rvm/gems/ruby-2.5.3/gems/cocoapods-core-1.9.1/lib/cocoapods-core/cdn_source.rb:479:in `rescue in concurrent_requests_catching_errors'
$HOME/.rvm/gems/ruby-2.5.3/gems/cocoapods-core-1.9.1/lib/cocoapods-core/cdn_source.rb:474:in `concurrent_requests_catching_errors'
$HOME/.rvm/gems/ruby-2.5.3/gems/cocoapods-core-1.9.1/lib/cocoapods-core/cdn_source.rb:121:in `versions'
$HOME/.rvm/gems/ruby-2.5.3/gems/cocoapods-core-1.9.1/lib/cocoapods-core/specification/set.rb:99:in `block in versions_by_source'
$HOME/.rvm/gems/ruby-2.5.3/gems/cocoapods-core-1.9.1/lib/cocoapods-core/specification/set.rb:98:in `each'
$HOME/.rvm/gems/ruby-2.5.3/gems/cocoapods-core-1.9.1/lib/cocoapods-core/specification/set.rb:98:in `each_with_object'
$HOME/.rvm/gems/ruby-2.5.3/gems/cocoapods-core-1.9.1/lib/cocoapods-core/specification/set.rb:98:in `versions_by_source'
$HOME/.rvm/gems/ruby-2.5.3/gems/cocoapods-core-1.9.1/lib/cocoapods-core/specification/set.rb:56:in `specification_name'
$HOME/.rvm/gems/ruby-2.5.3/gems/cocoapods-core-1.9.1/lib/cocoapods-core/cdn_source.rb:216:in `search'
$HOME/.rvm/gems/ruby-2.5.3/gems/cocoapods-core-1.9.1/lib/cocoapods-core/source/aggregate.rb:83:in `block in search'
$HOME/.rvm/gems/ruby-2.5.3/gems/cocoapods-core-1.9.1/lib/cocoapods-core/source/aggregate.rb:83:in `select'
$HOME/.rvm/gems/ruby-2.5.3/gems/cocoapods-core-1.9.1/lib/cocoapods-core/source/aggregate.rb:83:in `search'
$HOME/.rvm/gems/ruby-2.5.3/gems/cocoapods-1.9.1/lib/cocoapods/resolver.rb:416:in `create_set_from_sources'
$HOME/.rvm/gems/ruby-2.5.3/gems/cocoapods-1.9.1/lib/cocoapods/resolver.rb:385:in `find_cached_set'
$HOME/.rvm/gems/ruby-2.5.3/gems/cocoapods-1.9.1/lib/cocoapods/resolver.rb:360:in `specifications_for_dependency'
$HOME/.rvm/gems/ruby-2.5.3/gems/cocoapods-1.9.1/lib/cocoapods/resolver.rb:165:in `search_for'
$HOME/.rvm/gems/ruby-2.5.3/gems/cocoapods-1.9.1/lib/cocoapods/resolver.rb:274:in `block in sort_dependencies'
$HOME/.rvm/gems/ruby-2.5.3/gems/cocoapods-1.9.1/lib/cocoapods/resolver.rb:267:in `each'
$HOME/.rvm/gems/ruby-2.5.3/gems/cocoapods-1.9.1/lib/cocoapods/resolver.rb:267:in `sort_by'
$HOME/.rvm/gems/ruby-2.5.3/gems/cocoapods-1.9.1/lib/cocoapods/resolver.rb:267:in `sort_dependencies'
$HOME/.rvm/gems/ruby-2.5.3/gems/molinillo-0.6.6/lib/molinillo/delegates/specification_provider.rb:53:in `block in sort_dependencies'
$HOME/.rvm/gems/ruby-2.5.3/gems/molinillo-0.6.6/lib/molinillo/delegates/specification_provider.rb:70:in `with_no_such_dependency_error_handling'
$HOME/.rvm/gems/ruby-2.5.3/gems/molinillo-0.6.6/lib/molinillo/delegates/specification_provider.rb:52:in `sort_dependencies'
$HOME/.rvm/gems/ruby-2.5.3/gems/molinillo-0.6.6/lib/molinillo/resolution.rb:288:in `initial_state'
$HOME/.rvm/gems/ruby-2.5.3/gems/molinillo-0.6.6/lib/molinillo/resolution.rb:210:in `start_resolution'
$HOME/.rvm/gems/ruby-2.5.3/gems/molinillo-0.6.6/lib/molinillo/resolution.rb:168:in `resolve'
$HOME/.rvm/gems/ruby-2.5.3/gems/molinillo-0.6.6/lib/molinillo/resolver.rb:43:in `resolve'
$HOME/.rvm/gems/ruby-2.5.3/gems/cocoapods-1.9.1/lib/cocoapods/resolver.rb:94:in `resolve'
$HOME/.rvm/gems/ruby-2.5.3/gems/cocoapods-1.9.1/lib/cocoapods/installer/analyzer.rb:1065:in `block in resolve_dependencies'
$HOME/.rvm/gems/ruby-2.5.3/gems/cocoapods-1.9.1/lib/cocoapods/user_interface.rb:64:in `section'
$HOME/.rvm/gems/ruby-2.5.3/gems/cocoapods-1.9.1/lib/cocoapods/installer/analyzer.rb:1063:in `resolve_dependencies'
$HOME/.rvm/gems/ruby-2.5.3/gems/cocoapods-1.9.1/lib/cocoapods/installer/analyzer.rb:124:in `analyze'
$HOME/.rvm/gems/ruby-2.5.3/gems/cocoapods-1.9.1/lib/cocoapods/installer.rb:410:in `analyze'
$HOME/.rvm/gems/ruby-2.5.3/gems/cocoapods-1.9.1/lib/cocoapods/installer.rb:235:in `block in resolve_dependencies'
$HOME/.rvm/gems/ruby-2.5.3/gems/cocoapods-1.9.1/lib/cocoapods/user_interface.rb:64:in `section'
$HOME/.rvm/gems/ruby-2.5.3/gems/cocoapods-1.9.1/lib/cocoapods/installer.rb:234:in `resolve_dependencies'
$HOME/.rvm/gems/ruby-2.5.3/gems/cocoapods-1.9.1/lib/cocoapods/installer.rb:156:in `install!'
$HOME/.rvm/gems/ruby-2.5.3/gems/cocoapods-1.9.1/lib/cocoapods/command/install.rb:52:in `run'
$HOME/.rvm/gems/ruby-2.5.3/gems/claide-1.0.3/lib/claide/command.rb:334:in `run'
$HOME/.rvm/gems/ruby-2.5.3/gems/cocoapods-1.9.1/lib/cocoapods/command.rb:52:in `run'
$HOME/.rvm/gems/ruby-2.5.3/gems/cocoapods-1.9.1/bin/pod:55:in `<top (required)>'
$HOME/.rvm/gems/ruby-2.5.3/bin/pod:23:in `load'
$HOME/.rvm/gems/ruby-2.5.3/bin/pod:23:in `<main>'
$HOME/.rvm/gems/ruby-2.5.3/bin/ruby_executable_hooks:24:in `eval'
$HOME/.rvm/gems/ruby-2.5.3/bin/ruby_executable_hooks:24:in `<main>'
```

Some sample "bad" JSON Podspecs:
- https://raw.githubusercontent.com/CocoaPods/Specs/master/Specs/b/e/c/EarlGrey/1.16.0/EarlGrey.podspec.json (there are two `\x00E2` in the Description ): `’`