### PR TITLE
CDNSource - Run a rudimentary local check to help with CDN client robustness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@
 
 ##### Bug Fixes
 
-* None.  
-
+* CDNSource - Run a rudimentary local check to help with CDN client robustness.  
+  [Igor Makarov](https://github.com/igor-makarov)
+  [#632](https://github.com/CocoaPods/Core/pull/632)
+  [CocoaPods#9814](https://github.com/CocoaPods/CocoaPods/issues/9814)
 
 ## 1.9.2 (2020-05-22)
 

--- a/lib/cocoapods-core/cdn_source.rb
+++ b/lib/cocoapods-core/cdn_source.rb
@@ -315,6 +315,11 @@ module Pod
       metadata.path_fragment(pod_name)[0..-2]
     end
 
+    def local_file_okay?(partial_url)
+      file_path = repo.join(partial_url)
+      File.exist?(file_path) && File.size(file_path) > 0
+    end
+
     def local_file(partial_url)
       file_path = repo.join(partial_url)
       File.open(file_path) do |file|
@@ -337,7 +342,8 @@ module Pod
       file_remote_url = URI.encode(url + partial_url.to_s)
       path = repo + partial_url
 
-      if File.exist?(path)
+      file_okay = local_file_okay?(partial_url)
+      if file_okay
         if @startup_time < File.mtime(path)
           debug "CDN: #{name} Relative path: #{partial_url} modified during this run! Returning local"
           return Promises.fulfilled_future(partial_url, HYDRA_EXECUTOR)
@@ -353,7 +359,7 @@ module Pod
 
       etag_path = path.sub_ext(path.extname + '.etag')
 
-      etag = File.read(etag_path) if File.exist?(etag_path)
+      etag = File.read(etag_path) if file_okay && File.exist?(etag_path)
       debug "CDN: #{name} Relative path: #{partial_url}, has ETag? #{etag}" unless etag.nil?
 
       download_and_save_with_retries_async(partial_url, file_remote_url, etag)

--- a/spec/cdn_source_spec.rb
+++ b/spec/cdn_source_spec.rb
@@ -355,6 +355,15 @@ module Pod
         spec.version.should.to_s == '1.0.5'
       end
 
+      it 'downloads specification again if file is not valid' do
+        # create empty podspec file
+        FileUtils.mkdir_p(@path + 'Specs/2/0/9/BeaconKit/1.0.5')
+        FileUtils.touch(@path + 'Specs/2/0/9/BeaconKit/1.0.5/BeaconKit.podspec.json')
+        spec = @source.specification('BeaconKit', Version.new('1.0.5'))
+        spec.name.should == 'BeaconKit'
+        spec.version.should.to_s == '1.0.5'
+      end
+
       it 'does not attempt to access a version not in the version index' do
         @source.versions('BeaconKit')
 


### PR DESCRIPTION
* Use a robust local check (file exists and is nonzero length) to ensure it's okay.
* Use same check to decide whether to use eTag (so that if file doesn't exist the eTag is disregarded).

Possibly closes https://github.com/CocoaPods/CocoaPods/issues/9814