### PR TITLE
Raise macOS default deployment target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,9 @@
 
 ##### Bug Fixes
 
-* None.  
-
+* Raise macOS default deployment target to avoid a warning in Xcode 12
+  [Marc Haisenko](https://github.com/DarkDust)
+  [CocoaPods#9884](https://github.com/CocoaPods/CocoaPods/issues/9884)
 
 ## 1.9.3 (2020-05-29)
 

--- a/lib/cocoapods-core/podfile/dsl.rb
+++ b/lib/cocoapods-core/podfile/dsl.rb
@@ -566,7 +566,7 @@ module Pod
       # Specifies the platform for which a static library should be built.
       #
       # CocoaPods provides a default deployment target if one is not specified.
-      # The current default values are `4.3` for iOS, `10.6` for OS X, `9.0` for tvOS
+      # The current default values are `4.3` for iOS, `10.9` for OS X, `9.0` for tvOS
       # and `2.0` for watchOS.
       #
       # If the deployment target requires it (iOS < `4.3`), `armv6`

--- a/lib/cocoapods-core/podfile/target_definition.rb
+++ b/lib/cocoapods-core/podfile/target_definition.rb
@@ -611,7 +611,7 @@ module Pod
 
       #--------------------------------------#
 
-      PLATFORM_DEFAULTS = { :ios => '4.3', :osx => '10.6', :tvos => '9.0', :watchos => '2.0' }.freeze
+      PLATFORM_DEFAULTS = { :ios => '4.3', :osx => '10.9', :tvos => '9.0', :watchos => '2.0' }.freeze
 
       # @return [Platform] the platform of the target definition.
       #

--- a/spec/podfile/target_definition_spec.rb
+++ b/spec/podfile/target_definition_spec.rb
@@ -616,7 +616,7 @@ module Pod
         @parent.platform.should == Pod::Platform.new(:ios, '4.3')
 
         @parent.set_platform(:osx)
-        @parent.platform.should == Pod::Platform.new(:osx, '10.6')
+        @parent.platform.should == Pod::Platform.new(:osx, '10.9')
       end
 
       it 'raises if the specified platform is unsupported' do

--- a/spec/podfile_spec.rb
+++ b/spec/podfile_spec.rb
@@ -565,7 +565,7 @@ module Pod
       it 'assigns a deployment target to the platforms if not specified' do
         @podfile.target_definitions['Pods'].platform.deployment_target.to_s.should == '4.3'
         @podfile.target_definitions[:test].platform.deployment_target.to_s.should == '4.3'
-        @podfile.target_definitions[:osx_target].platform.deployment_target.to_s.should == '10.6'
+        @podfile.target_definitions[:osx_target].platform.deployment_target.to_s.should == '10.9'
       end
 
       it "automatically marks a target as exclusive if the parent platform doesn't match" do


### PR DESCRIPTION
Raise the default deployment target for macOS from 10.6 to 10.9. This gets rid of a warning in Xcode 12 with pods that did not explicitly specify a deployment target.

Closes CocoaPods/CocoaPods#9884