### PR TITLE
Remove activesupport < 6 requirement

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
   remote: .
   specs:
     cocoapods-core (1.10.0.beta.1)
-      activesupport (> 5.0, < 6)
+      activesupport (> 5)
       addressable (~> 2.6)
       algoliasearch (~> 1.0)
       concurrent-ruby (~> 1.1)
@@ -22,11 +22,12 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.4.3)
+    activesupport (6.0.3.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+      zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     algoliasearch (1.27.3)
@@ -45,7 +46,7 @@ GEM
     fuzzy_match (2.0.4)
     hashdiff (1.0.1)
     httpclient (2.8.3)
-    i18n (1.8.3)
+    i18n (1.8.4)
       concurrent-ruby (~> 1.0)
     kicker (3.0.0)
       listen (~> 1.3.0)
@@ -100,6 +101,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
+    zeitwerk (2.4.0)
 
 PLATFORMS
   ruby

--- a/cocoapods-core.gemspec
+++ b/cocoapods-core.gemspec
@@ -19,8 +19,7 @@ Gem::Specification.new do |s|
   s.files         =  Dir["lib/**/*.rb"] + %w{ README.md LICENSE }
   s.require_paths =  %w{ lib }
 
-  # 6.0 requires Ruby 2.5.0
-  s.add_runtime_dependency 'activesupport', '> 5.0', '< 6'
+  s.add_runtime_dependency 'activesupport', '> 5'
   s.add_runtime_dependency 'nap', '~> 1.0'
   s.add_runtime_dependency 'fuzzy_match', '~> 2.0.4'
   s.add_runtime_dependency 'algoliasearch', '~> 1.0'


### PR DESCRIPTION
This matches cocoapods gem https://github.com/CocoaPods/CocoaPods/blob/master/cocoapods.gemspec#L42

Both Core and CocoaPods go in lockstep so there is no need for their requirements to be different.