### PR TITLE
Add pre-integrate hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,9 @@
 
 ##### Enhancements
 
-* None.  
+* Add a pre_integrate_hook API  
+  [dcvz](https://github.com/dcvz)
+  [#643](https://github.com/CocoaPods/Core/pull/643)
 
 ##### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ##### Enhancements
 
+* Add a pre_integrate_hook API  
+  [David Chavez](https://github.com/dcvz)
+  [#643](https://github.com/CocoaPods/Core/pull/643)
+
 * Allow version `0` to be used.  
   [Eloy Durán](https://github.com/alloy)
   [#657](https://github.com/CocoaPods/Core/pull/657)
@@ -21,9 +25,7 @@
 
 ##### Enhancements
 
-* Add a pre_integrate_hook API  
-  [dcvz](https://github.com/dcvz)
-  [#643](https://github.com/CocoaPods/Core/pull/643)
+* None.
 
 ##### Bug Fixes
 

--- a/lib/cocoapods-core/podfile.rb
+++ b/lib/cocoapods-core/podfile.rb
@@ -166,6 +166,23 @@ module Pod
       end
     end
 
+    # Calls the pre integrate callback if defined.
+    #
+    # @param  [Pod::Installer] installer
+    #         the installer that is performing the installation.
+    #
+    # @return [Bool] whether a pre install callback was specified and it was
+    #         called.
+    #
+    def pre_integrate!(installer)
+      if @pre_integrate_callback
+        @pre_integrate_callback.call(installer)
+        true
+      else
+        false
+      end
+    end
+
     # Calls the post install callback if defined.
     #
     # @param  [Pod::Installer] installer

--- a/lib/cocoapods-core/podfile.rb
+++ b/lib/cocoapods-core/podfile.rb
@@ -171,7 +171,7 @@ module Pod
     # @param  [Pod::Installer] installer
     #         the installer that is performing the installation.
     #
-    # @return [Bool] whether a pre install callback was specified and it was
+    # @return [Bool] whether a pre integrate callback was specified and it was
     #         called.
     #
     def pre_integrate!(installer)

--- a/lib/cocoapods-core/podfile/dsl.rb
+++ b/lib/cocoapods-core/podfile/dsl.rb
@@ -921,9 +921,7 @@ module Pod
       # This hook allows you to make any changes to the Pods after they have
       # been downloaded but before they are installed.
       #
-      # It receives the
-      # [`Pod::Installer`](http://rubydoc.info/gems/cocoapods/Pod/Installer/)
-      # as its only argument.
+      # It receives the [Pod::Installer] as its only argument.
       #
       # @example  Defining a pre-install hook in a Podfile.
       #
@@ -939,9 +937,7 @@ module Pod
       # This hook allows you to make changes before the project is written
       # to disk.
       #
-      # It receives the
-      # [`Pod::Installer`](http://rubydoc.info/gems/cocoapods/Pod/Installer/)
-      # as its only argument.
+      # It receives the [Pod::Installer] as its only argument.
       #
       # @example  Customizing the dependencies before integration
       #
@@ -960,9 +956,7 @@ module Pod
       # project before it is written to disk, or any other tasks you might want
       # to perform.
       #
-      # It receives the
-      # [`Pod::Installer`](http://rubydoc.info/gems/cocoapods/Pod/Installer/)
-      # as its only argument.
+      # It receives the [Pod::Installer] as its only argument.
       #
       # @example  Customizing the build settings of all targets
       #
@@ -984,9 +978,7 @@ module Pod
       # This hook allows you to make changes after the project is written
       # to disk.
       #
-      # It receives the
-      # [`Pod::Installer`](http://rubydoc.info/gems/cocoapods/Pod/Installer/)
-      # as its only argument.
+      # It receives the [Pod::Installer] as its only argument.
       #
       # @example  Customizing the build settings of all targets
       #

--- a/lib/cocoapods-core/podfile/dsl.rb
+++ b/lib/cocoapods-core/podfile/dsl.rb
@@ -936,6 +936,26 @@ module Pod
         @pre_install_callback = block
       end
 
+      # This hook allows you to make changes before the project is written
+      # to disk.
+      #
+      # It receives the
+      # [`Pod::Installer`](http://rubydoc.info/gems/cocoapods/Pod/Installer/)
+      # as its only argument.
+      #
+      # @example  Customising the dependencies before integration
+      #
+      #   pre_integrate do |installer|
+      #     # perform some changes on dependencies
+      #   end
+      #
+      # @return   [void]
+      #
+      def pre_integrate(&block)
+        raise Informative, 'Specifying multiple `pre_integrate` hooks is unsupported.' if @pre_integrate_callback
+        @pre_integrate_callback = block
+      end
+
       # This hook allows you to make any last changes to the generated Xcode
       # project before it is written to disk, or any other tasks you might want
       # to perform.

--- a/lib/cocoapods-core/podfile/dsl.rb
+++ b/lib/cocoapods-core/podfile/dsl.rb
@@ -943,7 +943,7 @@ module Pod
       # [`Pod::Installer`](http://rubydoc.info/gems/cocoapods/Pod/Installer/)
       # as its only argument.
       #
-      # @example  Customising the dependencies before integration
+      # @example  Customizing the dependencies before integration
       #
       #   pre_integrate do |installer|
       #     # perform some changes on dependencies
@@ -964,7 +964,7 @@ module Pod
       # [`Pod::Installer`](http://rubydoc.info/gems/cocoapods/Pod/Installer/)
       # as its only argument.
       #
-      # @example  Customising the build settings of all targets
+      # @example  Customizing the build settings of all targets
       #
       #   post_install do |installer|
       #     installer.pods_project.targets.each do |target|
@@ -988,7 +988,7 @@ module Pod
       # [`Pod::Installer`](http://rubydoc.info/gems/cocoapods/Pod/Installer/)
       # as its only argument.
       #
-      # @example  Customising the build settings of all targets
+      # @example  Customizing the build settings of all targets
       #
       #   post_integrate do |installer|
       #     # some change after project write to disk

--- a/spec/podfile_spec.rb
+++ b/spec/podfile_spec.rb
@@ -84,6 +84,12 @@ module Pod
         result.should.be == true
       end
 
+      it 'indicates if the pre integrate hook was executed' do
+        Podfile.new {}.pre_integrate!(:an_installer).should.be == false
+        result = Podfile.new { pre_integrate { |_installer| } }.pre_integrate!(:an_installer)
+        result.should.be == true
+      end
+
       it 'returns all dependencies of all targets combined' do
         @podfile.dependencies.map(&:name).sort.should == %w(ASIHTTPRequest JSONKit Reachability SSZipArchive)
       end


### PR DESCRIPTION
Add support for a `pre-integrate` hook that will allow plugins to make changes to downloaded pods before the integration into projects.

This is useful for a plugin such as a `cocoapods-patch` that allows users to create patch files for pod dependencies.. whose changes might include a file deletion (which needs to happen before the integration to not cause problems).

CocoaPods PR: https://github.com/CocoaPods/CocoaPods/pull/9935