### PR TITLE
Merge `1-10-stable` (1.10.0.beta.2) into `master`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@
 * None.  
 
 
+## 1.10.0.beta.2 (2020-08-12)
+
+##### Enhancements
+
+* None.  
+
+##### Bug Fixes
+
+* None.  
+
+
 ## 1.10.0.beta.1 (2020-07-17)
 
 ##### Breaking

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    cocoapods-core (1.10.0.beta.1)
+    cocoapods-core (1.10.0.beta.2)
       activesupport (> 5.0, < 6)
       addressable (~> 2.6)
       algoliasearch (~> 1.0)
@@ -36,7 +36,7 @@ GEM
     awesome_print (1.8.0)
     bacon (1.2.0)
     coderay (1.1.3)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.7)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     ethon (0.12.0)
@@ -45,7 +45,7 @@ GEM
     fuzzy_match (2.0.4)
     hashdiff (1.0.1)
     httpclient (2.8.3)
-    i18n (1.8.3)
+    i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     kicker (3.0.0)
       listen (~> 1.3.0)

--- a/lib/cocoapods-core/gem_version.rb
+++ b/lib/cocoapods-core/gem_version.rb
@@ -1,5 +1,5 @@
 module Pod
   # The version of the cocoapods-core.
   #
-  CORE_VERSION = '1.10.0.beta.1'.freeze unless defined? Pod::CORE_VERSION
+  CORE_VERSION = '1.10.0.beta.2'.freeze unless defined? Pod::CORE_VERSION
 end


### PR DESCRIPTION
There were no bug fixes or changes for 1.10.0.beta.2 of Core gem.