### PR TITLE
Use private repositories with port in URL via SSH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@
 
 ##### Bug Fixes
 
-* None.  
-
+* Fix for repository name resolving in `name_for_url` when repository url uses SSH and contains a port number  
+  [Michał Nierebiński](https://github.com/CanIntoSpace)  
+  [#650](https://github.com/CocoaPods/Core/pull/650)
 
 ## 1.10.0.beta.2 (2020-08-12)
 

--- a/lib/cocoapods-core/source/manager.rb
+++ b/lib/cocoapods-core/source/manager.rb
@@ -433,7 +433,7 @@ module Pod
           base = Pod::TrunkSource::TRUNK_REPO_NAME
         when %r{github.com[:/]+(.+)/(.+)}
           base = Regexp.last_match[1]
-        when %r{^\S+@(\S+)[:/]+(.+)$}
+        when %r{^\S+@([^:/\s]+)(?::\d+)?[:/]+(.+)$}
           host, path = Regexp.last_match.captures
           base = base_from_host_and_path[host, path]
         when URI.regexp

--- a/spec/source/manager_spec.rb
+++ b/spec/source/manager_spec.rb
@@ -247,6 +247,11 @@ module Pod
               should == 'company-pods-specs'
           end
 
+          it 'supports ssh URLs with user and port' do
+            url = 'ssh://git@company.com:1234/pods/specs.git'
+            @sources_manager.send(:name_for_url, url).
+              should == 'company-pods-specs'
+          end
           it 'appends a number to the name if the base name dir exists' do
             url = 'https://github.com/segiddins/banana.git'
             Pathname.any_instance.stubs(:exist?).


### PR DESCRIPTION
I have two private spec repositories:
`ssh://myhost:8833/first/specs.git`
`ssh://myhost:8833/second/specs.git`

After `pod install --repo-update` I get normal beginning

```bash
Updating local specs repositories
Cloning spec repo `myhost:8833/first-specs` from `ssh://myhost:8833/first/specs.git`
```

I get an error: `RuntimeError - Unable to create a source with URL ssh://myhost:8833/first/specs.git`

And the directory structure in `~/.cocoapods/repos` has `myhost-8833` folder with `first-specs` and `second-specs` subfolders.

I fixed a regexp in `name_for_url(url)` in `Manager`
