### PR TITLE
[Linter] Allow version `0` to be used.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ##### Enhancements
 
-* None.  
+* Allow version `0` to be used.  
+  [Eloy Durán](https://github.com/alloy)
+  [#657](https://github.com/CocoaPods/Core/pull/657)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -242,9 +242,6 @@ module Pod
       def _validate_version(v)
         if v.to_s.empty?
           results.add_error('version', 'A version is required.')
-        elsif v <= Version::ZERO
-          results.add_error('version', 'The version of the spec should be' \
-          ' higher than 0.')
         end
       end
 

--- a/spec/specification/linter_spec.rb
+++ b/spec/specification/linter_spec.rb
@@ -255,11 +255,6 @@ module Pod
         result_should_include('version', 'required')
       end
 
-      it 'checks the version is higher than 0' do
-        @spec.stubs(:version).returns(Pod::Version.new('0'))
-        result_should_include('version', '0')
-      end
-
       it 'handles invalid version strings' do
         @spec.stubs(:version).raises('Bad version')
         result_ignore('attributes')

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -18,6 +18,12 @@ module Pod
         version.to_s.should == '1.2.3'
       end
 
+      it 'does not accept negative versions' do
+        should.raise ArgumentError do
+          Version.new('-1')
+        end
+      end
+
       it 'identifies release versions' do
         version = Version.new('1.0.0')
         version.should.not.be.prerelease


### PR DESCRIPTION
In React and React Native, nightly builds are created using a version like `0.0.0-githash`. Trying to install such versions with CocoaPods currently fails due to this linter check.

I wasn't able to find a rationale for not allowing version `0` nor could I come up with a reason for not allowing it.

See:
* https://github.com/microsoft/react-native-macos/issues/620
* https://github.com/facebook/react-native/issues/30036