### PR TITLE
Add support for readme and changelog pod attributes

### DIFF
--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -299,6 +299,36 @@ module Pod
 
       #------------------#
 
+      # @!method readme=(readme)
+      #
+      #   The URL for the README markdown file for this pod version.
+      #
+      #   @example
+      #
+      #     spec.readme = 'https://www.example.com/Pod-1.5-README.md'
+      #
+      #   @param  [String] readme
+      #           the readme markdown URL.
+      #
+      root_attribute :readme
+
+      #------------------#
+
+      # @!method changelog=(changelog)
+      #
+      #   The URL for the CHANGELOG markdown file for this pod version.
+      #
+      #   @example
+      #
+      #     spec.changelog = 'https://www.example.com/Pod-1.5-CHANGELOG.md'
+      #
+      #   @param  [String] changelog
+      #           the changelog markdown URL.
+      #
+      root_attribute :changelog
+
+      #------------------#
+
       # The keys accepted by the hash of the source attribute.
       #
       SOURCE_KEYS = {

--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -520,6 +520,24 @@ module Pod
         end
       end
 
+      # Performs validations related to the `readme` attribute.
+      #
+      def _validate_readme(s)
+        if s =~ %r{https://www.example.com/README}
+          results.add_warning('readme', 'The readme has ' \
+            'not been updated from the default.')
+        end
+      end
+
+      # Performs validations related to the `changelog` attribute.
+      #
+      def _validate_changelog(s)
+        if s =~ %r{https://www.example.com/CHANGELOG}
+          results.add_warning('changelog', 'The changelog has ' \
+            'not been updated from the default.')
+        end
+      end
+
       # @param [Hash,Object] value
       #
       def _validate_info_plist(value)

--- a/lib/cocoapods-core/specification/root_attribute_accessors.rb
+++ b/lib/cocoapods-core/specification/root_attribute_accessors.rb
@@ -99,6 +99,18 @@ module Pod
           attributes_hash['social_media_url']
         end
 
+        # @return [String] The readme.
+        #
+        def readme
+          attributes_hash['readme']
+        end
+
+        # @return [String] The changelog.
+        #
+        def changelog
+          attributes_hash['changelog']
+        end
+
         # @return [Hash] A hash containing the license information of the Pod.
         #
         # @note   The indentation is stripped from the license text.

--- a/spec/specification/dsl_spec.rb
+++ b/spec/specification/dsl_spec.rb
@@ -71,6 +71,16 @@ module Pod
         @spec.attributes_hash['social_media_url'].should == 'https://twitter.com/cocoapods'
       end
 
+      it 'allows to specify the readme' do
+        @spec.readme = 'https://www.example.com/readme'
+        @spec.attributes_hash['readme'].should == 'https://www.example.com/readme'
+      end
+
+      it 'allows to specify the changelog' do
+        @spec.changelog = 'https://www.example.com/changelog'
+        @spec.attributes_hash['changelog'].should == 'https://www.example.com/changelog'
+      end
+
       it 'allows to specify the license' do
         @spec.license = { :type => 'MIT', :file => 'MIT-LICENSE' }
         @spec.attributes_hash['license'].should == { 'type' => 'MIT', 'file' => 'MIT-LICENSE' }

--- a/spec/specification/linter_spec.rb
+++ b/spec/specification/linter_spec.rb
@@ -525,6 +525,20 @@ module Pod
 
       #------------------#
 
+      it 'checks if the readme has been changed from default' do
+        @spec.stubs(:readme).returns('https://www.example.com/README')
+        result_should_include('readme', 'default')
+      end
+
+      #------------------#
+
+      it 'checks if the changelog has been changed from default' do
+        @spec.stubs(:changelog).returns('https://www.example.com/CHANGELOG')
+        result_should_include('changelog', 'default')
+      end
+
+      #------------------#
+
       it 'checks script phases include the required keys' do
         @spec.script_phases = { :name => 'Hello World' }
         result_should_include('script_phases', 'Missing required shell script phase options `script` in script phase `Hello World`.')

--- a/spec/specification/root_attribute_accessors_spec.rb
+++ b/spec/specification/root_attribute_accessors_spec.rb
@@ -90,6 +90,16 @@ module Pod
       @spec.social_media_url.should == 'www.example.com'
     end
 
+    it 'returns the readme' do
+      @spec.readme = 'www.example.com'
+      @spec.readme.should == 'www.example.com'
+    end
+
+    it 'returns the changelog' do
+      @spec.changelog = 'www.example.com'
+      @spec.changelog.should == 'www.example.com'
+    end
+
     it 'supports the license attribute specified as a string' do
       @spec.license = 'MIT'
       @spec.license.should == { :type => 'MIT' }


### PR DESCRIPTION
This change adds support and documentation for new optional `readme` and `changelog` attributes, which contain URLs pointing to Markdown files. The CocoaPods Metadata Service has already been modified to read these attributes and, if present, download the files and save them for rendering on the pod page (see https://github.com/CocoaPods/cocoapods-metadata-service/pull/6 and https://github.com/CocoaPods/cocoapods-metadata-service/pull/20).