### PR TITLE
fix hash array merge

### DIFF
--- a/lib/cocoapods-core/podfile/target_definition.rb
+++ b/lib/cocoapods-core/podfile/target_definition.rb
@@ -963,7 +963,7 @@ module Pod
         if exclusive?
           whitelist_hash
         else
-          parent.send(:configuration_pod_whitelist).merge(whitelist_hash) { |l, r| (l + r).uniq }
+          parent.send(:configuration_pod_whitelist).merge(whitelist_hash) { |_, l, r| Array(l).concat(r).uniq }
         end
       end
 

--- a/spec/podfile/target_definition_spec.rb
+++ b/spec/podfile/target_definition_spec.rb
@@ -548,6 +548,17 @@ module Pod
         @child.should.not.pod_whitelisted_for_configuration?('AFNetworking', 'Release')
       end
 
+      it 'child pods for configurations can merge from parent' do
+        @parent.store_pod('ObjectiveSugar', :configuration => 'Release')
+        @child.store_pod('AFNetworking', :configuration => 'Release')
+        @parent.should.pod_whitelisted_for_configuration?('ObjectiveSugar', 'Release')
+        @parent.should.not.pod_whitelisted_for_configuration?('ObjectiveSugar', 'Debug')
+        @child.should.pod_whitelisted_for_configuration?('ObjectiveSugar', 'Release')
+        @child.should.not.pod_whitelisted_for_configuration?('ObjectiveSugar', 'Debug')
+        @child.should.pod_whitelisted_for_configuration?('AFNetworking', 'Release')
+        @child.should.not.pod_whitelisted_for_configuration?('AFNetworking', 'Debug')
+      end
+
       it 'coerces configuration names to strings' do
         @parent.store_pod('ObjectiveSugar', :configuration => :Release)
         @parent.should.pod_whitelisted_for_configuration?('ObjectiveSugar', 'Release')


### PR DESCRIPTION
## TypeError - no implicit conversion of Array into String

### Error

```
TypeError - no implicit conversion of Array into String
/Users/JaminZhou/.rvm/gems/ruby-2.6.3/gems/cocoapods-core-1.7.5/lib/cocoapods-core/podfile/target_definition.rb:920:in `+'
/Users/JaminZhou/.rvm/gems/ruby-2.6.3/gems/cocoapods-core-1.7.5/lib/cocoapods-core/podfile/target_definition.rb:920:in `block in configuration_pod_whitelist'
/Users/JaminZhou/.rvm/gems/ruby-2.6.3/gems/cocoapods-core-1.7.5/lib/cocoapods-core/podfile/target_definition.rb:920:in `merge'
/Users/JaminZhou/.rvm/gems/ruby-2.6.3/gems/cocoapods-core-1.7.5/lib/cocoapods-core/podfile/target_definition.rb:920:in `configuration_pod_whitelist'
/Users/JaminZhou/.rvm/gems/ruby-2.6.3/gems/cocoapods-core-1.7.5/lib/cocoapods-core/podfile/target_definition.rb:476:in `all_whitelisted_configurations'
/Users/JaminZhou/.rvm/gems/ruby-2.6.3/gems/cocoapods-1.7.5/lib/cocoapods/installer/analyzer.rb:479:in `generate_aggregate_target'
/Users/JaminZhou/.rvm/gems/ruby-2.6.3/gems/cocoapods-1.7.5/lib/cocoapods/installer/analyzer.rb:413:in `block in generate_aggregate_targets'
/Users/JaminZhou/.rvm/gems/ruby-2.6.3/gems/cocoapods-1.7.5/lib/cocoapods/installer/analyzer.rb:412:in `map'
/Users/JaminZhou/.rvm/gems/ruby-2.6.3/gems/cocoapods-1.7.5/lib/cocoapods/installer/analyzer.rb:412:in `generate_aggregate_targets'
/Users/JaminZhou/.rvm/gems/ruby-2.6.3/gems/cocoapods-1.7.5/lib/cocoapods/installer/analyzer.rb:121:in `analyze'
/Users/JaminZhou/.rvm/gems/ruby-2.6.3/gems/cocoapods-1.7.5/lib/cocoapods/installer.rb:398:in `analyze'
/Users/JaminZhou/.rvm/gems/ruby-2.6.3/gems/cocoapods-1.7.5/lib/cocoapods/installer.rb:221:in `block in resolve_dependencies'
/Users/JaminZhou/.rvm/gems/ruby-2.6.3/gems/cocoapods-1.7.5/lib/cocoapods/user_interface.rb:64:in `section'
/Users/JaminZhou/.rvm/gems/ruby-2.6.3/gems/cocoapods-1.7.5/lib/cocoapods/installer.rb:220:in `resolve_dependencies'
/Users/JaminZhou/.rvm/gems/ruby-2.6.3/gems/cocoapods-1.7.5/lib/cocoapods/installer.rb:156:in `install!'
/Users/JaminZhou/.rvm/gems/ruby-2.6.3/gems/cocoapods-1.7.5/lib/cocoapods/command/install.rb:51:in `run'
/Users/JaminZhou/.rvm/gems/ruby-2.6.3/gems/claide-1.0.3/lib/claide/command.rb:334:in `run'
/Users/JaminZhou/.rvm/gems/ruby-2.6.3/gems/cocoapods-1.7.5/lib/cocoapods/command.rb:52:in `run'
/Users/JaminZhou/.rvm/gems/ruby-2.6.3/gems/cocoapods-1.7.5/bin/pod:55:in `<top (required)>'
/Users/JaminZhou/.rvm/gems/ruby-2.6.3/bin/pod:23:in `load'
/Users/JaminZhou/.rvm/gems/ruby-2.6.3/bin/pod:23:in `<main>'
/Users/JaminZhou/.rvm/gems/ruby-2.6.3/bin/ruby_executable_hooks:24:in `eval'
/Users/JaminZhou/.rvm/gems/ruby-2.6.3/bin/ruby_executable_hooks:24:in `<main>'
```
