### PR TITLE
Ignore path when checking vendored_libraries  format.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 ##### Bug Fixes
 
-* None.  
+* Ignore path when checking vendored_libraries `lib[name].a` format.
+  [Ivan Romanovski](https://github.com/IvanRomanovski)
+  [#626](https://github.com/CocoaPods/Core/pull/626)
 
 
 ## 1.10.0 (2020-10-20)

--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -340,9 +340,10 @@ module Pod
       #
       def _validate_vendored_libraries(vendored_libraries)
         vendored_libraries.each do |lib|
-          lib_name = lib.downcase
+          basename = File.basename(lib)
+          lib_name = basename.downcase
           unless lib_name.end_with?('.a') && lib_name.start_with?('lib')
-            results.add_warning('vendored_libraries', "`#{File.basename(lib)}` does not match the expected static library name format `lib[name].a`")
+            results.add_warning('vendored_libraries', "`#{basename}` does not match the expected static library name format `lib[name].a`")
           end
         end
       end

--- a/spec/specification/linter_spec.rb
+++ b/spec/specification/linter_spec.rb
@@ -645,7 +645,7 @@ module Pod
       #------------------#
 
       it 'accepts valid vendored_libraries' do
-        @spec.vendored_libraries = 'libCoconut.a'
+        @spec.vendored_libraries = ['libCoconut.a', 'path/libCoconut.a', '**/lib*.a']
         @linter.lint
         @linter.results.should.be.empty?
       end


### PR DESCRIPTION
Lint check for the name format of vendored static libraries (https://github.com/CocoaPods/Core/pull/626) introduced a breaking change, where relative paths and globs like `**/*.a` are not supported anymore.

This PR modifies linter to allow relative paths.  Globs like `**/*.a` still can't be supported because this would break the requirement that static libraries should begin with *lib*, however this limitation can be easily overcome by modifying `**/*.a` to `**/lib*.a` in a podspec.