### PR TITLE
Update comments/docs to indicate `module_map=false` will skip `modulemap` file generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Allow version `0` to be used.  
   [Eloy Durán](https://github.com/alloy)
   [#657](https://github.com/CocoaPods/Core/pull/657)
+
 * Update comments/docs to indicate `module_map=false` will skip `modulemap` file generation.  
   [Sergey Erokhin](https://github.com/till0xff)
   [#664](https://github.com/CocoaPods/Core/pull/664)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Allow version `0` to be used.  
   [Eloy Durán](https://github.com/alloy)
   [#657](https://github.com/CocoaPods/Core/pull/657)
+* Update comments/docs to indicate `module_map=false` will skip `modulemap` file generation.  
+  [Sergey Erokhin](https://github.com/till0xff)
+  [#664](https://github.com/CocoaPods/Core/pull/664)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -1427,7 +1427,7 @@ module Pod
       #
       #   The module map file that should be used when this pod is integrated as
       #   a framework.
-      #  `false` indicates that the default CocoaPods `modulemap` file should not
+      #   `false` indicates that the default CocoaPods `modulemap` file should not
       #   be generated.
       #   `true` is the default and indicates that the default CocoaPods
       #   `modulemap` file should be generated.

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -1427,6 +1427,10 @@ module Pod
       #
       #   The module map file that should be used when this pod is integrated as
       #   a framework.
+      #  `false` indicates that the default CocoaPods `modulemap` file should not
+      #   be generated.
+      #   `true` is the default and indicates that the default CocoaPods
+      #   `modulemap` file should be generated.
       #
       #   ---
       #
@@ -1437,11 +1441,17 @@ module Pod
       #
       #     spec.module_map = 'source/module.modulemap'
       #
-      #   @param  [String] module_map
-      #           the path to the module map file that should be used.
+      #   @example
+      #
+      #     spec.module_map = false
+      #
+      #   @param  [String, Bool] module_map
+      #           the path to the module map file that should be used
+      #           or whether to disable module_map generation.
       #
       attribute :module_map,
-                :root_only     => true
+                :types => [TrueClass, FalseClass, String],
+                :root_only => true
 
       #-----------------------------------------------------------------------#
 

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -1427,8 +1427,10 @@ module Pod
       #
       #   The module map file that should be used when this pod is integrated as
       #   a framework.
+      #
       #   `false` indicates that the default CocoaPods `modulemap` file should not
       #   be generated.
+      #
       #   `true` is the default and indicates that the default CocoaPods
       #   `modulemap` file should be generated.
       #

--- a/spec/specification/dsl_spec.rb
+++ b/spec/specification/dsl_spec.rb
@@ -370,6 +370,11 @@ module Pod
         @spec.attributes_hash['module_map'].should == 'module.modulemap'
       end
 
+      it 'allows to skip modulemap file generation' do
+        @spec.module_map = false
+        @spec.attributes_hash['module_map'].should == false
+      end
+
       it 'allows to specify the script phases shipped with the Pod' do
         @spec.script_phases = { :name => 'Hello World', :script => 'echo "Hello World"' }
         @spec.attributes_hash['script_phases'].should == { 'name' => 'Hello World', 'script' => 'echo "Hello World"' }


### PR DESCRIPTION
See also https://github.com/CocoaPods/CocoaPods/pull/10207