### PR TITLE
Use Ruby bundled json gem instead of forked

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,11 +2,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-# This is the version that ships with OS X 10.10, so be sure we test against it.
-# At the same time, the 1.7.7 version won't install cleanly on Ruby > 2.2,
-# so we use a fork that makes a trivial change to a macro invocation.
-gem 'json', :git => 'https://github.com/segiddins/json.git', :branch => 'seg-1.7.7-ruby-2.2'
-
 group :development do
   gem 'bacon'
   gem 'mocha', '< 1.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/segiddins/json.git
-  revision: a9588bc4334c2f5bf985f255b61c05eafdcd8907
-  branch: seg-1.7.7-ruby-2.2
-  specs:
-    json (1.7.7)
-
 PATH
   remote: .
   specs:
@@ -46,6 +39,7 @@ GEM
     httpclient (2.8.3)
     i18n (1.8.7)
       concurrent-ruby (~> 1.0)
+    json (2.5.1)
     kicker (3.0.0)
       listen (~> 1.3.0)
       notify (~> 0.5.2)
@@ -108,7 +102,6 @@ DEPENDENCIES
   awesome_print
   bacon
   cocoapods-core!
-  json!
   kicker
   mocha (< 1.5)
   mocha-on-bacon

--- a/lib/cocoapods-core/source/manager.rb
+++ b/lib/cocoapods-core/source/manager.rb
@@ -265,6 +265,11 @@ module Pod
             require 'json'
             begin
               index = JSON.parse(search_index_path.read)
+              unless index # JSON.parse("null") => nil
+                search_index_path.delete
+                return nil
+              end
+
               index if index.is_a?(Hash) # TODO: should we also check if hash has correct hierarchy?
             rescue JSON::ParserError
               search_index_path.delete


### PR DESCRIPTION
Same as https://github.com/CocoaPods/CocoaPods/pull/10347

It looks like we no longer need that fork, trying to remove it