### PR TITLE
Add M1 pipeline on Buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,14 @@
+steps:
+  - label: ":hammer: Specs"
+    agents:
+      m1: true
+    commands:
+      - echo "--- Initialize git"
+      - git submodule update --init
+      - ./.github/scripts/setup_test_repo.sh
+      - echo "--- Bundler"
+      - gem install bundler:1.17.3
+      - bundle config path vendor/bundle
+      - bundle install --jobs 4 --retry 3 --without debugging documentation
+      - echo "+++ Run Specs"
+      - bundle exec rake spec

--- a/.github/scripts/setup_test_repo.sh
+++ b/.github/scripts/setup_test_repo.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 cd spec/fixtures/spec-repos/test_repo
+rm -rf .git || true
 git init
 git remote add origin https://bitbucket.com/test/test_repo.git

--- a/Rakefile
+++ b/Rakefile
@@ -50,11 +50,11 @@ begin
     end
 
     task :all do
-      title 'Running Unit Tests'
-      sh "bundle exec bacon #{specs('**')}"
-
       title 'Checking code style...'
       Rake::Task['rubocop'].invoke if RUBY_VERSION >= '1.9.3'
+
+      title 'Running Unit Tests'
+      sh "bundle exec bacon #{specs('**')}"
     end
   end
 


### PR DESCRIPTION
Following discussions in #669, @dcvz has volunteered a Buildkite agent running on an M1 Mac. 

This PR adds the pipeline that runs tests on it (currently failing because of Typhoeus).

Things to figure out before merge: 
* @dcvz - as the owner of the machine, make sure the pipeline is configured in a clean way that doesn't interfere with the other uses for the machine. The gems are installed into `vendor/bundle` to minimize interference.
* @dnkoutso are we fine with merging a PR that has failing builds, assuming there's another PR that's going to address it?
* I've emailed Buildkite support to enable the open source plan that their pricing page touts. Should we wait for that before merging?