### PR TITLE
Use vendor/bundle in CI

### DIFF
--- a/.github/workflows/Specs.yml
+++ b/.github/workflows/Specs.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Run bundle install
         run: |
           gem install bundler -v "~> 1.17"
+          bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3 --without debugging documentation
 
       - name: Run Specs + Rubocop

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ coverage/
 .idea/
 documentation/
 .bundle/
+vendor/bundle
 
 # trunk source
 spec/fixtures/spec-repos/trunk/**/*.etag

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ inherit_from:
 AllCops:
   Exclude:
     - spec/fixtures/**/*
+    - vendor/bundle/**/*
     - lib/cocoapods-core/vendor/**/*
 
 FileName:


### PR DESCRIPTION
This PR aims to homogenize the way gems are installed in GH Actions and the M1 agent (#672).

The gems will now be installed in `vendor/bundle` and the various ignores have been updated to ignore it.