### PR TITLE
Set `fail-fast` to false

### DIFF
--- a/.github/workflows/Specs.yml
+++ b/.github/workflows/Specs.yml
@@ -3,6 +3,7 @@ name: Specs
 jobs:
   specs:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-20.04]
         ruby: [2.6, 2.7, 3.0]


### PR DESCRIPTION
Set `fail-fast` to false so that all specs run and output errors.