### PR TITLE
Normalize spec repo name generation

### DIFF
--- a/lib/cocoapods-core/source/manager.rb
+++ b/lib/cocoapods-core/source/manager.rb
@@ -434,7 +434,7 @@ module Pod
           end
 
           path = path.gsub(/.git$/, '').gsub(%r{^/}, '').split('/')
-          path.delete('specs')
+          path.pop if path.last == 'specs'
 
           (base + path).join('-')
         end

--- a/lib/cocoapods-core/source/manager.rb
+++ b/lib/cocoapods-core/source/manager.rb
@@ -471,8 +471,7 @@ module Pod
         end
 
         name = base
-        infinity = 1.0 / 0
-        (1..infinity).each do |i|
+        (1..).each do |i|
           break unless source_dir(name).exist?
           name = "#{base}-#{i}"
         end

--- a/spec/source/manager_spec.rb
+++ b/spec/source/manager_spec.rb
@@ -220,6 +220,11 @@ module Pod
               should == 'sourceforge-artsy'
           end
 
+          it 'does not remove /specs path component if it is not the last one' do
+            url = 'https://sourceforge.org.au/Specs/Path/Repo.git'
+            @sources_manager.send(:name_for_url, url).should == 'sourceforge-specs-path-repo'
+          end
+
           it 'can understand arbitrary URI schemes' do
             url = 'banana://website.org/Artsy/Specs.git'
             @sources_manager.send(:name_for_url, url).

--- a/spec/source/manager_spec.rb
+++ b/spec/source/manager_spec.rb
@@ -198,29 +198,56 @@ module Pod
             @sources_manager.send(:name_for_url, url).should == 'trunk'
           end
 
-          it 'uses the organization name for github.com URLs' do
+          it 'uses the organization and repo name for github.com URLs' do
             url = 'https://github.com/segiddins/banana.git'
+            @sources_manager.send(:name_for_url, url).should == 'segiddins-banana'
+          end
+
+          it 'uses the organization name only for github.com specs URLs' do
+            url = 'https://github.com/segiddins/Specs.git'
             @sources_manager.send(:name_for_url, url).should == 'segiddins'
           end
 
           it 'uses a combination of host and path for other URLs' do
             url = 'https://sourceforge.org/Artsy/Specs.git'
             @sources_manager.send(:name_for_url, url).
-              should == 'sourceforge-artsy-specs'
+              should == 'sourceforge-artsy'
+            url = 'https://sourceforge.org.au/Artsy/Specs.git'
+            @sources_manager.send(:name_for_url, url).
+              should == 'sourceforge-artsy'
+            url = 'https://pvt.sourceforge.org.au/Artsy/Specs.git'
+            @sources_manager.send(:name_for_url, url).
+              should == 'sourceforge-artsy'
+          end
+
+          it 'can understand arbitrary URI schemes' do
+            url = 'banana://website.org/Artsy/Specs.git'
+            @sources_manager.send(:name_for_url, url).
+              should == 'website-artsy'
+          end
+
+          it 'should raise on completely ridiculous non-URL input' do
+            url = '    '
+            should.raise Informative do
+              @sources_manager.send(:name_for_url, url)
+            end.message.should.== "Couldn't determine repo name for URL: #{url}"
           end
 
           it 'supports scp-style URLs' do
             url = 'git@git-host.com:specs.git'
             @sources_manager.send(:name_for_url, url).
-              should == 'git-host-specs'
+              should == 'git-host'
 
             url = 'git@git-host.com/specs.git'
             @sources_manager.send(:name_for_url, url).
-              should == 'git-host-specs'
+              should == 'git-host'
 
             url = 'git@git-host.com:/specs.git'
             @sources_manager.send(:name_for_url, url).
-              should == 'git-host-specs'
+              should == 'git-host'
+            url = 'git@github.com/segiddins/Specs'
+            @sources_manager.send(:name_for_url, url).
+              should == 'segiddins'
           end
 
           it 'supports ssh URLs with an aliased hostname' do
@@ -230,9 +257,12 @@ module Pod
           end
 
           it 'supports file URLs' do
-            url = 'file:///Users/kurrytran/pod-specs'
+            url = 'file:///Users/kurrytran/etc'
             @sources_manager.send(:name_for_url, url).
-              should == 'users-kurrytran-pod-specs'
+              should == 'users-kurrytran-etc'
+            url = 'file:///Users/kurrytran/specs'
+            @sources_manager.send(:name_for_url, url).
+              should == 'users-kurrytran'
           end
 
           it 'uses the repo name if no parent directory' do
@@ -244,20 +274,20 @@ module Pod
           it 'supports ssh URLs with no user component' do
             url = 'ssh://company.com/pods/specs.git'
             @sources_manager.send(:name_for_url, url).
-              should == 'company-pods-specs'
+              should == 'company-pods'
           end
 
           it 'appends a number to the name if the base name dir exists' do
             url = 'https://github.com/segiddins/banana.git'
             Pathname.any_instance.stubs(:exist?).
               returns(true).then.returns(false)
-            @sources_manager.send(:name_for_url, url).should == 'segiddins-1'
+            @sources_manager.send(:name_for_url, url).should == 'segiddins-banana-1'
 
             url = 'https://sourceforge.org/Artsy/Specs.git'
             Pathname.any_instance.stubs(:exist?).
               returns(true).then.returns(false)
             @sources_manager.send(:name_for_url, url).
-              should == 'sourceforge-artsy-specs-1'
+              should == 'sourceforge-artsy-1'
           end
         end
 

--- a/spec/source/manager_spec.rb
+++ b/spec/source/manager_spec.rb
@@ -291,8 +291,13 @@ module Pod
             url = 'https://sourceforge.org/Artsy/Specs.git'
             Pathname.any_instance.stubs(:exist?).
               returns(true).then.returns(false)
-            @sources_manager.send(:name_for_url, url).
-              should == 'sourceforge-artsy-1'
+            @sources_manager.send(:name_for_url, url).should == 'sourceforge-artsy-1'
+
+            url = 'https://sourceforge.org/Artsy/Specs.git'
+            Pathname.any_instance.stubs(:exist?).
+              returns(true).then.
+              returns(true).then.returns(false)
+            @sources_manager.send(:name_for_url, url).should == 'sourceforge-artsy-2'
           end
         end
 


### PR DESCRIPTION
This PR tries to simplify the way that a spec repo URL is converted to a repo name. 

The main cases covered:

* GitHub URL: `https://github.com/Orgname/Specs.git` => `orgname`
* Non-GH URL: `https://sourceforge.org/Orgname/Specs.git` => `sourceforge-orgname`
* SCP-style URL: `git@github.com/Orgname/Specs` => `orgname`
* File URL: `file:///Users/username/specs` => `users-username`
* Other odd URLs, such as `ssh://user@companyalias/pod-specs`
* If the repo isn't named `Specs`: `https://github.com/Username/banana.git` => `username-banana`