### PR TITLE
Support GitHub org-style URLs in source manager

### DIFF
--- a/lib/cocoapods-core/source/manager.rb
+++ b/lib/cocoapods-core/source/manager.rb
@@ -461,7 +461,7 @@ module Pod
           # SCP-style URLs for private git repos
           url = valid_scp_url[url]
           base = base_from_host_and_path[url.host, url.path]
-        when %r{(?:git|ssh|https?|git@([-\w.]+)):(\/\/)?(.*?)(\.git)(\/?|\#[-\d\w._]+?)$}i
+        when %r{(?:git|ssh|https?|[a-z0-9_-]+@([-\w.]+)):(\/\/)?(.*?)(\.git)(\/?|\#[-\d\w._]+?)$}i
           # Additional SCP-style URLs for private git repos
           host, _, path = Regexp.last_match.captures
           base = base_from_host_and_path[host, path]

--- a/spec/source/manager_spec.rb
+++ b/spec/source/manager_spec.rb
@@ -243,6 +243,10 @@ module Pod
             @sources_manager.send(:name_for_url, url).
               should == 'git-host'
 
+            url = 'org-123456789@github.com:mycompany/ios-companypods.git'
+            @sources_manager.send(:name_for_url, url).
+              should == 'mycompany-ios-companypods'
+
             url = 'git@git-host.com/specs.git'
             @sources_manager.send(:name_for_url, url).
               should == 'git-host'

--- a/spec/source/manager_spec.rb
+++ b/spec/source/manager_spec.rb
@@ -286,6 +286,12 @@ module Pod
               should == 'company-pods'
           end
 
+          it 'supports ssh URLs with user and port' do
+            url = 'ssh://git@company.com:1234/pods/specs.git'
+            @sources_manager.send(:name_for_url, url).
+              should == 'company-pods'
+          end
+
           it 'appends a number to the name if the base name dir exists' do
             url = 'https://github.com/segiddins/banana.git'
             Pathname.any_instance.stubs(:exist?).


### PR DESCRIPTION
The "username" doesn't always have to be `git`