### PR TITLE
Remove vendored libraries name validation.

### DIFF
--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -334,19 +334,6 @@ module Pod
         end
       end
 
-      # Performs validations related to the `vendored_libraries` attribute.
-      #
-      # @param [Array<String>] vendored_libraries the values specified in the `vendored_libraries` attribute
-      #
-      def _validate_vendored_libraries(vendored_libraries)
-        vendored_libraries.each do |lib|
-          lib_name = lib.downcase
-          unless lib_name.end_with?('.a') && lib_name.start_with?('lib')
-            results.add_warning('vendored_libraries', "`#{File.basename(lib)}` does not match the expected static library name format `lib[name].a`")
-          end
-        end
-      end
-
       # Performs validations related to the `license` attribute.
       #
       def _validate_license(l)

--- a/spec/specification/linter_spec.rb
+++ b/spec/specification/linter_spec.rb
@@ -658,26 +658,6 @@ module Pod
 
       #------------------#
 
-      it 'accepts valid vendored_libraries' do
-        @spec.vendored_libraries = 'libCoconut.a'
-        @linter.lint
-        @linter.results.should.be.empty?
-      end
-
-      it 'checks the file name extension of vendored_libraries' do
-        @spec.vendored_libraries = 'libSomething'
-        result_should_include('`libSomething` does not match the expected static library name format `lib[name].a`', 'vendored_libraries')
-        @linter.results.map(&:type).should == [:warning]
-      end
-
-      it 'check the file name prefix of vendored_libraries' do
-        @spec.vendored_libraries = 'something.a'
-        result_should_include('`something.a` does not match the expected static library name format `lib[name].a`', 'vendored_libraries')
-        @linter.results.map(&:type).should == [:warning]
-      end
-
-      #------------------#
-
       it 'checks if the compiler flags disable warnings' do
         @spec.compiler_flags = '-some_flag', '-another -Wno_flags'
         result_should_include('warnings', 'disabled', 'compiler_flags')


### PR DESCRIPTION
This functionality is being removed from Core and instead is moving to CocoaPods under the `validator.rb` because the validator can actually use the expanded paths.

This will allow developers again to be able to use globs in the DSL for `vendored_libraries`.

see https://github.com/CocoaPods/CocoaPods/pull/10832