### PR TITLE
Remove the root spec's direct dependencies from subspecs lockfile entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@
 
 ##### Bug Fixes
 
-* None.  
+* The `PODS` entry in the Podfile.lock now excludes dependencies that are not explicitly declared
+  in entries for subspecs (including app & test specs)  
+  [Eric Amorde](https://github.com/amorde)
+  [#696](https://github.com/CocoaPods/Core/pull/696)
 
 
 ## 1.11.0.beta.1 (2021-08-09)

--- a/lib/cocoapods-core/lockfile.rb
+++ b/lib/cocoapods-core/lockfile.rb
@@ -457,7 +457,7 @@ module Pod
         pods_and_deps_merged = specs.reduce({}) do |result, spec|
           name = spec.to_s
           result[name] ||= []
-          result[name].concat(spec.all_dependencies.map(&:to_s))
+          result[name].concat(spec.dependencies.map(&:to_s))
           result
         end
 


### PR DESCRIPTION
The `PODS` key in the lockfile has a representation of the dependency graph. Each entry includes the name of the pod & its version as the key, and the value is an array of its direct dependencies.

For subspecs (including test specs and app specs) the array of dependencies includes those only declared by the root spec. This differs from the expectation that individual targets only have their direct dependencies declared here.

Side note, it appears we do not use this data at all inside CocoaPods. Here is the only place it is read: https://github.com/CocoaPods/Core/blob/a575cc388b2ad22289e1a21f329af60c31bd2d69/lib/cocoapods-core/lockfile.rb#L211-L217

Note how the above code calls `pod.keys.first`, and never reaches in to the value.