### PR TITLE
fixed bug for the target definition of podfile 

### DIFF
--- a/lib/cocoapods-core/podfile/target_definition.rb
+++ b/lib/cocoapods-core/podfile/target_definition.rb
@@ -545,7 +545,7 @@ module Pod
           end
           if parent_hash['for_pods']
             # Remove pods that are set to use modular headers inside parent if they are set to not use modular headers inside current target.
-            parent_hash['for_pods'] -= Array(raw_hash['for_pods'])
+            parent_hash['for_pods'] -= Array(raw_hash['not_for_pods'])
           end
           if raw_hash['all']
             # Clean pods that are set to not use modular headers inside parent if use_modular_headers! was set.
@@ -934,7 +934,7 @@ module Pod
           end
           if parent_hash['for_pods']
             # Remove pods that are set to inhibit inside parent if they are set to not inhibit inside current target.
-            parent_hash['for_pods'] -= Array(inhibit_hash['for_pods'])
+            parent_hash['for_pods'] -= Array(inhibit_hash['not_for_pods'])
           end
           if inhibit_hash['all']
             # Clean pods that are set to not inhibit inside parent if inhibit_all_warnings! was set.


### PR DESCRIPTION
When the class Pod::Podfile::TargetDefinition merges use_modular_headers_hash and inhibit_warnings_hash, if the inherited class overrides the settings of the parent class, it will cause the final stored data to exist in both types collections, so the data of the parent class needs to be deleted.

For example the following Podfile file

```
target 'CocoapodsDemo' do
  pod 'YYCategories', :inhibit_warnings => true

  target 'CocoapodsDemo_dp1' do
    pod 'YYCategories', :inhibit_warnings => false
  end
end
```
Set a breakpoint in the function inhibit_warnings_hash, and you will find that the dependency of the final merged result exists in the two sets: for_pods and: not_for_pods

Although cocoapods warning does not support two different settings at the same time, this may be a hidden danger in the future
Interestingly, it can be seen from the comments that the purpose is to de-duplicate, but this is not done.

Thanks for your review
