### PR TITLE
Fix warnings in `dependency.rb`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 
 ##### Bug Fixes
 
-* None.  
+* Fix warnings in `dependency.rb`.  
+  [Nick Cooke](https://github.com/ncooke3)
+  [#719](https://github.com/CocoaPods/Core/pull/719)
 
 
 ## 1.11.3 (2022-03-11)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 * Fix warnings in `dependency.rb`.  
   [Nick Cooke](https://github.com/ncooke3)
-  [#719](https://github.com/CocoaPods/Core/pull/719)
+  [#720](https://github.com/CocoaPods/Core/pull/720)
 
 
 ## 1.11.3 (2022-03-11)

--- a/lib/cocoapods-core/dependency.rb
+++ b/lib/cocoapods-core/dependency.rb
@@ -99,11 +99,13 @@ module Pod
       end
       @name = name
       @requirement = Requirement.create(requirements)
+      @specific_requirement ||= nil
+      @external_source ||= nil
     end
 
     # @return [Version] whether the dependency points to a specific version.
     #
-    attr_accessor :specific_version
+    attr_reader :specific_version
 
     # @return [Requirement] the requirement of this dependency (a set of
     #         one or more version restrictions).


### PR DESCRIPTION
`dependency.rb` has a few warnings that are showing up locally and in CI when `pod lib lint`ing. 

For example, see https://github.com/firebase/firebase-ios-sdk/runs/5619185788?check_suite_focus=true.

1. `warning: method redefined; discarding old ...`
```
/usr/local/lib/ruby/gems/2.7.0/gems/cocoapods-core-1.11.2/lib/cocoapods-core/dependency.rb:117: warning: method redefined; discarding old specific_version=
```
2. ` warning: instance variable ... not initialized`
```
/usr/local/lib/ruby/gems/2.7.0/gems/cocoapods-core-1.11.2/lib/cocoapods-core/dependency.rb:112: warning: instance variable @specific_requirement not initialized

/usr/local/lib/ruby/gems/2.7.0/gems/cocoapods-core-1.11.2/lib/cocoapods-core/dependency.rb:133: warning: instance variable @external_source not initialized
```

cc: @paulb777 