### PR TITLE
Added support for specifying build configurations for schemes

### DIFF
--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -1718,7 +1718,7 @@ module Pod
                 :types => [String],
                 :spec_types => [:test]
 
-      SCHEME_KEYS = [:launch_arguments, :environment_variables, :code_coverage, :parallelizable].freeze
+      SCHEME_KEYS = [:launch_arguments, :environment_variables, :code_coverage, :parallelizable, :build_configurations].freeze
 
       # @!method scheme=(flag)
       #

--- a/lib/cocoapods-core/specification/linter.rb
+++ b/lib/cocoapods-core/specification/linter.rb
@@ -465,6 +465,9 @@ module Pod
           if s.key?(:parallelizable) && ![true, false].include?(s[:parallelizable])
             results.add_error('scheme', 'Expected a boolean for key `parallelizable`.')
           end
+          if s.key?(:build_configurations) && !s[:build_configurations].is_a?(Hash)
+            results.add_error('scheme', 'Expected a hash for key `build_configurations`.')
+          end
         end
       end
 

--- a/spec/specification/linter_spec.rb
+++ b/spec/specification/linter_spec.rb
@@ -576,7 +576,8 @@ module Pod
 
       it 'accepts valid scheme values' do
         @spec.scheme = { :launch_arguments => ['Arg1'], :environment_variables => { 'Key1' => 'Val1' },
-                         :code_coverage => true }
+                         :code_coverage => true, :parallelizable => true, :build_configurations => { 'Debug' => 'Debug'}
+                       }
         @linter.lint
         @linter.results.should.be.empty
       end
@@ -599,6 +600,11 @@ module Pod
       it 'checks scheme parallelizable key type' do
         @spec.scheme = { :parallelizable => 1 }
         result_should_include('scheme', 'Expected a boolean for key `parallelizable`.')
+      end
+
+      it 'checks scheme build_configurations key type' do
+        @spec.scheme = { :build_configurations => [] }
+        result_should_include('scheme', 'Expected a hash for key `build_configurations`.')
       end
 
       #------------------#


### PR DESCRIPTION
Hi!

In our team we are using CocoaPods in a highly-modularized project and we recently came across a need to specify custom build configurations for autogenerated XCSchemes, especially we want to use custom debug config for some of the schemes and a custom test build config for our unit-tests.

We were surprised when found that this option is not supported, however [Xcodeproj](https://www.rubydoc.info/github/CocoaPods/Xcodeproj/Xcodeproj/XCScheme/AbstractSchemeAction) seems to support this.

Further investigation turns out, this is quite a simple feature, so here we are!

If you have any questions, feel free to ask!

This is the precondition for https://github.com/CocoaPods/CocoaPods/pull/11611