### PR TITLE
Bump activesupport requirement to < 8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     cocoapods-core (1.11.3)
-      activesupport (>= 5.0, < 7)
+      activesupport (>= 5.0, < 8)
       addressable (~> 2.8)
       algoliasearch (~> 1.0)
       concurrent-ruby (~> 1.1)
@@ -127,4 +127,4 @@ DEPENDENCIES
   webrick (~> 1.7.0)
 
 BUNDLED WITH
-   2.2.3
+   2.3.9

--- a/cocoapods-core.gemspec
+++ b/cocoapods-core.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files         =  Dir["lib/**/*.rb"] + %w{ README.md LICENSE }
   s.require_paths =  %w{ lib }
 
-  s.add_runtime_dependency 'activesupport', '>= 5.0', '< 7'
+  s.add_runtime_dependency 'activesupport', '>= 5.0', '< 8'
   s.add_runtime_dependency 'nap', '~> 1.0'
   s.add_runtime_dependency 'fuzzy_match', '~> 2.0.4'
   s.add_runtime_dependency 'algoliasearch', '~> 1.0'


### PR DESCRIPTION
:wave: I maintain a tool called [licensed](https://github.com/github/licensed) that enumerates OSS license and other metadata for dependencies used by a project.  We recently added cocoapods and received a [report](https://github.com/github/licensed/issues/609) that the `activesupport < 7` requirement from this gem was causing a user to be unable to upgrade to the latest version of licensed.

Would you consider updating the activesupport requirement to `<8` to support users that want to use this gem in conjunction with rails 7?  I _think_ this change should be ok?  It looks like the gem was only used to add indifferent access support for hashes so the impact would be minimal, and I ran the test suite with `bundle exec rake spec` and everything passed.