### PR TITLE
Give the pathname for failed json podspecs in the error

### DIFF
--- a/lib/cocoapods-core/specification.rb
+++ b/lib/cocoapods-core/specification.rb
@@ -749,7 +749,7 @@ module Pod
           end
         end
       when '.json'
-        spec = Specification.from_json(spec_contents)
+        spec = Specification.from_json(spec_contents, path)
       else
         raise Informative, "Unsupported specification format `#{path.extname}` for spec at `#{path}`."
       end

--- a/lib/cocoapods-core/specification/json.rb
+++ b/lib/cocoapods-core/specification/json.rb
@@ -56,10 +56,17 @@ module Pod
     #
     # @return [Specification] the specification
     #
-    def self.from_json(json)
+    def self.from_json(json, path="")
       require 'json'
-      hash = JSON.parse(json)
-      from_hash(hash)
+      begin
+        hash = JSON.parse(json)
+        from_hash(hash)
+      rescue JSON::ParserError => e
+        if path != ""
+          raise e.class, "Failed to parse JSON at file: '#{path}'.\n\n#{e.message}"
+        else raise
+        end
+      end      
     end
 
     # Configures a new specification from the given hash.

--- a/spec/specification/json_spec.rb
+++ b/spec/specification/json_spec.rb
@@ -412,6 +412,13 @@ module Pod
         result.test_specs.first.test_type.should.equal :unit
       end
 
+      it 'can throws with the path for malformed json' do
+        json = '{"script_phases": [{name": "Hello World", "script": "echo \"Hello World\""}]}'
+        should.raise JSON::ParserError do
+          result = Specification.from_json(json, "path/to/spec.json")
+        end.message.should.include 'path/to/spec.json'
+      end
+
       it 'can load test specification from 1.3.0 JSON format' do
         json = '{"subspecs": [{"name": "Tests","test_type": "unit","source_files": "Tests/**/*.{h,m}"}]}'
         result = Specification.from_json(json)


### PR DESCRIPTION
Definitely in the top 5 of issues we get which are pretty much unactionable are ones where JSON isn't parsed, so now we give the path to the file in the error message so its more likely people will try and solve themselves instead of making an issue