### PR TITLE
Update public_suffix requirement to ~>5.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)
       netrc (~> 0.11)
-      public_suffix (~> 4.0)
+      public_suffix (~> 5.0)
       typhoeus (~> 1.0)
 
 GEM
@@ -67,7 +67,7 @@ GEM
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    public_suffix (4.0.7)
+    public_suffix (5.0.1)
     rainbow (3.0.0)
     rake (12.3.3)
     rb-fsevent (0.10.4)

--- a/cocoapods-core.gemspec
+++ b/cocoapods-core.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'typhoeus', '~> 1.0'
   s.add_runtime_dependency 'netrc', '~> 0.11'
   s.add_runtime_dependency 'addressable', '~> 2.8'
-  s.add_runtime_dependency 'public_suffix', '~> 4.0'
+  s.add_runtime_dependency 'public_suffix', '~> 5.0'
 
   s.add_development_dependency 'bacon', '~> 1.1'
 


### PR DESCRIPTION
The [public_suffix 5.0.0 release](https://github.com/weppos/publicsuffix-ruby/blob/main/CHANGELOG.md#500) is a major version bump due to updating the ruby requirement from >= 2.3 to >=2.6.  This gem already has a requirement for a base version >= 2.6 so the dependency update shouldn't introduce any breaking changes here.

I don't know the ecosystem of tooling and users around this gem, would `>= 4.0, < 6` be more appropriate in case there are other gems relying on `cocoapods-core`'s current requirement on public_suffix 4.x.x?