### PR TITLE
Fix crash when retrieve subspec from a unavailable podspec file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
   [fnxpt](https://github.com/fnxpt)
   [#748](https://github.com/CocoaPods/Core/issues/748)
 
+* Fix a crash when calling Specification#subspec_by_name on a deprecated specification with no name  
+  [sagiwei](https://github.com/sagiwei)
+  [#742](https://github.com/CocoaPods/Core/pull/742)
+
 
 ## 1.14.3 (2023-11-19)
 

--- a/lib/cocoapods-core/specification.rb
+++ b/lib/cocoapods-core/specification.rb
@@ -331,6 +331,13 @@ module Pod
     def subspec_by_name(relative_name, raise_if_missing = true, include_non_library_specifications = false)
       if relative_name.nil? || relative_name == base_name
         self
+      elsif base_name.nil?
+        if raise_if_missing
+          raise Informative, "Trying to access a `#{relative_name}` " \
+          "specification from `#{defined_in_file}`, which has no contents."
+        else
+          return nil
+        end
       elsif relative_name.downcase == base_name.downcase
         raise Informative, "Trying to access a `#{relative_name}` " \
           "specification from `#{base_name}`, which has a different case."

--- a/spec/specification_spec.rb
+++ b/spec/specification_spec.rb
@@ -418,6 +418,15 @@ module Pod
         @spec.subspec_by_name('Pod/Subspec/Subsubspec/Missing', false).should.be.nil?
       end
 
+      describe 'deprecated podspec' do
+        it 'returns nil for an empty deprecated spec' do
+          @spec = Spec.new do |s|
+            s.deprecated_in_favor_of = 'SomeOtherSpec'
+          end
+          @spec.subspec_by_name('subspec', false).should.be.nil?
+        end
+      end
+
       it 'returns the default subspecs' do
         spec = @spec.dup
         spec.default_subspecs = 'Subspec1', 'Subspec2'


### PR DESCRIPTION
When install a subspec such as `AFNetworking/Reachability` with no version range is specified:

```ruby
pod 'AFNetworking/Reachability'
```

Cocoapods will crashed:

```
NoMethodError - undefined method `downcase' for nil:NilClass
```

Same issue mentioned here: https://github.com/CocoaPods/CocoaPods/issues/11733

---
After some research, I found it caused by [AFNetworking (= 1.1.1)](https://github.com/CocoaPods/Specs/blob/master/Specs/a/7/5/AFNetworking/1.1.1/AFNetworking.podspec.json), this `podspec.json` has empty contents:
```json
{
  "deprecated_in_favor_of": "Alamofire",
  "platforms": {
    "osx": null,
    "ios": null,
    "tvos": null,
    "watchos": null
  }
}
```
so I add some check code in `subspec_by_name` method, and now no more crash occurs.