### PR TITLE
Add `visionos` as a new platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ##### Enhancements
 
-* None.  
+* Add `visionOS` as a new platform.
+  [Gabriel Donadel](https://github.com/gabrieldonadel)
+  [Core#745](https://github.com/CocoaPods/Core/pull/745)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods-core/platform.rb
+++ b/lib/cocoapods-core/platform.rb
@@ -87,6 +87,14 @@ module Pod
       new :tvos
     end
 
+    # Convenience method to initialize a visionOS platform.
+    #
+    # @return [Platform] a visionOS platform.
+    #
+    def self.visionos
+      new :visionos
+    end
+
     # Convenience method to initialize a watchOS platform.
     #
     # @return [Platform] a watchOS platform.
@@ -100,7 +108,7 @@ module Pod
     # @return [Array<Platform>] list of platforms.
     #
     def self.all
-      [ios, osx, watchos, tvos]
+      [ios, osx, watchos, visionos, tvos]
     end
 
     # Checks if a platform is equivalent to another one or to a symbol
@@ -239,6 +247,7 @@ module Pod
       when :osx then 'macOS'
       when :watchos then 'watchOS'
       when :tvos then 'tvOS'
+      when :visionos then 'visionOS'
       else symbolic_name.to_s
       end
     end

--- a/lib/cocoapods-core/podfile/dsl.rb
+++ b/lib/cocoapods-core/podfile/dsl.rb
@@ -566,15 +566,15 @@ module Pod
       # Specifies the platform for which a static library should be built.
       #
       # CocoaPods provides a default deployment target if one is not specified.
-      # The current default values are `4.3` for iOS, `10.6` for OS X, `9.0` for tvOS
-      # and `2.0` for watchOS.
+      # The current default values are `4.3` for iOS, `10.6` for OS X, `9.0` for tvOS,
+      # `1.0` for visionOS and `2.0` for watchOS.
       #
       # If the deployment target requires it (iOS < `4.3`), `armv6`
       # architecture will be added to `ARCHS`.
       #
       # @param    [Symbol] name
       #           the name of platform, can be either `:osx` for OS X, `:ios`
-      #           for iOS, `:tvos` for tvOS, or `:watchos` for watchOS.
+      #           for iOS, `:tvos` for tvOS, `:visionos` for visionOS, or `:watchos` for watchOS.
       #
       # @param    [String, Version] target
       #           The optional deployment.  If not provided a default value

--- a/lib/cocoapods-core/podfile/target_definition.rb
+++ b/lib/cocoapods-core/podfile/target_definition.rb
@@ -611,7 +611,7 @@ module Pod
 
       #--------------------------------------#
 
-      PLATFORM_DEFAULTS = { :ios => '4.3', :osx => '10.6', :tvos => '9.0', :watchos => '2.0' }.freeze
+      PLATFORM_DEFAULTS = { :ios => '4.3', :osx => '10.6', :tvos => '9.0', :visionos => '1.0', :watchos => '2.0' }.freeze
 
       # @return [Platform] the platform of the target definition.
       #
@@ -648,9 +648,9 @@ module Pod
       #
       def set_platform(name, target = nil)
         name = :osx if name == :macos
-        unless [:ios, :osx, :tvos, :watchos].include?(name)
+        unless [:ios, :osx, :tvos, :visionos, :watchos].include?(name)
           raise StandardError, "Unsupported platform `#{name}`. Platform " \
-            'must be `:ios`, `:osx`, `:macos`, `:tvos`, or `:watchos`.'
+            'must be `:ios`, `:osx`, `:macos`, `:tvos`, :visionos, or `:watchos`.'
         end
 
         if target

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -583,7 +583,7 @@ module Pod
 
       # The names of the platforms supported by the specification class.
       #
-      PLATFORMS = [:osx, :ios, :tvos, :watchos].freeze
+      PLATFORMS = [:osx, :ios, :tvos, :visionos, :watchos].freeze
 
       # @todo This currently is not used in the Ruby DSL.
       #
@@ -1878,6 +1878,17 @@ module Pod
       #
       def tvos
         PlatformProxy.new(self, :tvos)
+      end
+
+      # Provides support for specifying visionOS attributes.
+      #
+      # @example
+      #   spec.visionos.source_files = 'Classes/visionos/**/*.{h,m}'
+      #
+      # @return [PlatformProxy] the proxy that will set the attributes.
+      #
+      def visionos
+        PlatformProxy.new(self, :visionos)
       end
 
       # Provides support for specifying watchOS attributes.

--- a/spec/platform_spec.rb
+++ b/spec/platform_spec.rb
@@ -7,10 +7,12 @@ module Pod
         Platform.ios.should == Platform.new(:ios)
         Platform.osx.should == Platform.new(:osx)
         Platform.tvos.should == Platform.new(:tvos)
+        Platform.visionos.should == Platform.new(:visionos)
         Platform.watchos.should == Platform.new(:watchos)
         Platform.all.should.include? Platform.new(:ios)
         Platform.all.should.include? Platform.new(:osx)
         Platform.all.should.include? Platform.new(:tvos)
+        Platform.all.should.include? Platform.new(:visionos)
         Platform.all.should.include? Platform.new(:watchos)
       end
 
@@ -43,6 +45,7 @@ module Pod
         Platform.ios.string_name.should == 'iOS'
         Platform.osx.string_name.should == 'macOS'
         Platform.tvos.string_name.should == 'tvOS'
+        Platform.visionos.string_name.should == 'visionOS'
         Platform.watchos.string_name.should == 'watchOS'
       end
 
@@ -50,6 +53,7 @@ module Pod
         Platform.ios.safe_string_name.should == 'iOS'
         Platform.osx.safe_string_name.should == 'macOS'
         Platform.tvos.safe_string_name.should == 'tvOS'
+        Platform.visionos.safe_string_name.should == 'visionOS'
         Platform.watchos.safe_string_name.should == 'watchOS'
       end
 
@@ -69,10 +73,12 @@ module Pod
       it 'presents an accurate string representation' do
         @platform.to_s.should == 'iOS'
         Platform.new(:osx).to_s.should == 'macOS'
+        Platform.new(:visionos).to_s.should == 'visionOS'
         Platform.new(:watchos).to_s.should == 'watchOS'
         Platform.new(:tvos).to_s.should == 'tvOS'
         Platform.new(:ios, '5.0.0').to_s.should == 'iOS 5.0.0'
         Platform.new(:osx, '10.7').to_s.should == 'macOS 10.7'
+        Platform.new(:visionos, '1.0').to_s.should == 'visionOS 1.0'
         Platform.new(:watchos, '2.0').to_s.should == 'watchOS 2.0'
         Platform.new(:tvos, '9.0').to_s.should == 'tvOS 9.0'
       end
@@ -110,6 +116,7 @@ module Pod
       it 'returns whether it requires legacy iOS architectures' do
         Platform.new(:ios, '4.0').requires_legacy_ios_archs?.should.be.true
         Platform.new(:ios, '5.0').requires_legacy_ios_archs?.should.be.false
+        Platform.new(:visionos, '1.0').requires_legacy_ios_archs?.should.be.false
         Platform.new(:watchos, '2.0').requires_legacy_ios_archs?.should.be.false
         Platform.new(:tvos, '9.0').requires_legacy_ios_archs?.should.be.false
       end
@@ -138,6 +145,11 @@ module Pod
           Platform.new(:ios, '7.0').should.not.supports_dynamic_frameworks
           Platform.new(:ios, '8.0').should.supports_dynamic_frameworks
           Platform.new(:ios, '8.1').should.supports_dynamic_frameworks
+        end
+
+        it 'supports dynamic frameworks on visionOS' do
+          Platform.visionos.should.supports_dynamic_frameworks
+          Platform.new(:visionos, '1.0').should.supports_dynamic_frameworks
         end
 
         it 'supports dynamic frameworks on watchOS' do

--- a/spec/specification/dsl_spec.rb
+++ b/spec/specification/dsl_spec.rb
@@ -169,6 +169,16 @@ module Pod
         e.message.should.match /declared only per platform/
       end
 
+      it 'allows to specify visionOS as supported platform' do
+        @spec.platform = :visionos
+        @spec.attributes_hash['platforms'].should == { 'visionos' => nil }
+      end
+
+      it 'allows to specify a deployment target for the visionOS platform' do
+        @spec.visionos.deployment_target = '1.0'
+        @spec.attributes_hash['platforms']['visionos'].should == '1.0'
+      end
+
       it 'allows to specify watchOS as supported platform' do
         @spec.platform = :watchos
         @spec.attributes_hash['platforms'].should == { 'watchos' => nil }

--- a/spec/specification/json_spec.rb
+++ b/spec/specification/json_spec.rb
@@ -14,6 +14,7 @@ module Pod
             'osx' => nil,
             'ios' => nil,
             'tvos' => nil,
+            'visionos'=> nil,
             'watchos' => nil,
           },
         }
@@ -53,6 +54,7 @@ module Pod
             'osx' => nil,
             'ios' => nil,
             'tvos' => nil,
+            'visionos'=> nil,
             'watchos' => nil,
           },
         }

--- a/spec/specification/linter_spec.rb
+++ b/spec/specification/linter_spec.rb
@@ -82,7 +82,7 @@ module Pod
         @linter.lint
         @linter.results.count.should == 1
         @linter.results.first.platforms.map(&:to_s).sort.should ==
-          %w(ios osx tvos watchos)
+          %w(ios osx tvos visionos watchos)
       end
 
       before do


### PR DESCRIPTION
This PR introduces `visionOS` as a supported platform in Core. This primarily involves making the DSL helpers accessible for this platform.  This lays the groundwork for supporting visionOS as a new platform in CocoaPods.


Related to https://github.com/CocoaPods/CocoaPods/issues/11961, https://github.com/CocoaPods/Xcodeproj/pull/913 and https://github.com/CocoaPods/CocoaPods/pull/11965

