### PR TITLE
Sometimes we don't actively rely on related components in order to pu…

### DIFF
--- a/lib/cocoapods-core/specification/consumer.rb
+++ b/lib/cocoapods-core/specification/consumer.rb
@@ -229,6 +229,12 @@ module Pod
       #
       def dependencies
         value = value_for_attribute(:dependencies)
+
+        # install/update will contain virtual_dependencies!!
+        if $*.first == "update" || $*.first == "install"
+          value_virtual = value_for_attribute(:virtual_dependencies)
+          value = value.merge(value_virtual) if value_virtual      
+        end
         value.map do |name, requirements|
           Dependency.new(name, requirements)
         end

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -666,6 +666,22 @@ module Pod
                 :container => Hash,
                 :inherited => true
 
+      #-----------------------------------------------------------------------#
+
+      #   if define virtual to 'ture', the virtual_dependencies will save it instead of dependencies；
+
+      # # @Target
+      #   This is to create a new virtual dependency that will be updated to the virtual dependency 
+      #   when pod install/update without affecting the component label push
+
+      #-----------------------------------------------------------------------#
+
+      # # @example
+      #   spec.ios.dependency 'MBProgressHUD', '~> 0.5', :virtual => 'true'
+      attribute :virtual_dependencies,
+                :container => Hash,
+                :inherited => true
+
       # Any dependency on other Pods or to a ‘sub-specification’.
       #
       # ---
@@ -734,8 +750,15 @@ module Pod
           raise Informative, "Unsupported version requirements. #{version_requirements.inspect} is not valid."
         end
 
-        attributes_hash['dependencies'] ||= {}
-        attributes_hash['dependencies'][name] = version_requirements
+        #store dependency to virtual_dependencies if has :virtual
+        virtual_option = (configurations_option&.delete(:virtual)&.to_s&.downcase == 'true') || false
+        if virtual_option == 'true'
+          attributes_hash['virtual_dependencies'] ||= {}
+          attributes_hash['virtual_dependencies'][name] = version_requirements
+        else
+          attributes_hash['dependencies'] ||= {}
+          attributes_hash['dependencies'][name] = version_requirements
+        end
 
         unless whitelisted_configurations.nil?
           if (extras = whitelisted_configurations - %w(debug release)) && !extras.empty?


### PR DESCRIPTION
Sometimes we don't actively rely on related components in order to push tags quickly, but indirectly through protocols! However, this disconnects references between components, which can be missed when a dependency is needed, so to avoid this, after the dependency, added: virtual => 'true' to mark as virtual dependency. The dependency is not associated with the component when the tag is pushed, but is imported in pod install/update and other cases. This allows for both quick push of the component tag and strong binding between components. Now, we can mark the virtual dependencies like this 'Spec.ios.dependency' MBProgressHUD', '~> 0.5', :virtual => 'true'; we really need this, please help merge into the code, thank you very much