### PR TITLE
fix missing spec repos

### DIFF
--- a/lib/cocoapods-core/lockfile.rb
+++ b/lib/cocoapods-core/lockfile.rb
@@ -496,8 +496,8 @@ module Pod
 
           value = specs.map { |s| s.root.name }
 
-          if output.has_key(key)
-            value.append(output[key])
+          if output.has_key?(key)
+            value = value + output[key]
           end
 
           if value.length > 0

--- a/lib/cocoapods-core/lockfile.rb
+++ b/lib/cocoapods-core/lockfile.rb
@@ -485,7 +485,8 @@ module Pod
       #           { "https://github.com/cocoapods/cocoapods.git" => ["Alamofire", "Moya"] }
       #
       def generate_spec_repos(spec_repos)
-        Hash[spec_repos.map do |source, specs|
+        output = Hash.new {|h, k| h[k] = Array.new(0)}
+        spec_repos.each do |source, specs|
           next unless source
           next if specs.empty?
           key = source.url || source.name
@@ -493,9 +494,18 @@ module Pod
           # save `trunk` as 'trunk' so that the URL itself can be changed without lockfile churn
           key = Pod::TrunkSource::TRUNK_REPO_NAME if source.name == Pod::TrunkSource::TRUNK_REPO_NAME
 
-          value = specs.map { |s| s.root.name }.uniq
-          [key, YAMLHelper.sorted_array(value)]
-        end.compact]
+          value = specs.map { |s| s.root.name }
+
+          if output.has_key(key)
+            value.append(output[key])
+          end
+
+          if value.length > 0
+            output[key] = YAMLHelper.sorted_array(value.uniq)
+          end
+        end
+
+        output.compact
       end
 
       # Generates the information of the external sources.

--- a/spec/lockfile_spec.rb
+++ b/spec/lockfile_spec.rb
@@ -617,6 +617,39 @@ module Pod
           spec_repos_data.should == { 'trunk' => %w(a b C) }
         end
       end
+
+      describe '#generate_spec_repos_with_duplicated_source' do
+        it 'merges specs if sources have same key' do
+          spec_repos = {
+            Source.new(fixture('spec-repos/trunk')) => [
+              Specification.new do |s|
+                s.name = 'a'
+                s.version = '1.0'
+              end,
+              Specification.new do |s|
+                s.name = 'b'
+                s.version = '1.0'
+              end,
+              Specification.new do |s|
+                s.name = 'C'
+                s.version = '1.0'
+              end,
+            ],
+            Source.new(fixture('spec-repos/trunk')) => [
+              Specification.new do |s|
+                s.name = 'd'
+                s.version = '1.0'
+              end,
+              Specification.new do |s|
+                s.name = 'E'
+                s.version = '1.0'
+              end,
+            ],
+          }
+          spec_repos_data = Lockfile.send(:generate_spec_repos, spec_repos)
+          spec_repos_data.should == { 'trunk' => %w(a b C d E) }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Probably not the best ruby code since I don't actively develop in ruby.

When doing pod install with a Podfile.lock already created, some of the spec repos might be skipped because the key already exists

Fixes #748 