### PR TITLE
Add support for always_out_of_date flag in script phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   [Gabriel Donadel](https://github.com/gabrieldonadel)
   [#745](https://github.com/CocoaPods/Core/pull/745)
 
+* Extend `script_phase` DSL to support `always_out_of_date` attribute.  
+  [Alvar Hansen](https://github.com/alvarhansen)
+  [#750](https://github.com/CocoaPods/Core/pull/750)
+
 ##### Bug Fixes
 
 * None.  

--- a/lib/cocoapods-core/podfile/dsl.rb
+++ b/lib/cocoapods-core/podfile/dsl.rb
@@ -455,6 +455,10 @@ module Pod
       # @option   options [String] :dependency_file
       #           specifies the dependency file to use for this script phase.
       #
+      # @option   options [String] :always_out_of_date
+      #           specifies whether or not this run script will be forced to
+      #           run even on incremental builds
+      #
       # @return   [void]
       #
       def script_phase(options)

--- a/lib/cocoapods-core/specification/dsl.rb
+++ b/lib/cocoapods-core/specification/dsl.rb
@@ -1075,7 +1075,7 @@ module Pod
       SCRIPT_PHASE_REQUIRED_KEYS = [:name, :script].freeze
 
       SCRIPT_PHASE_OPTIONAL_KEYS = [:shell_path, :input_files, :output_files, :input_file_lists, :output_file_lists,
-                                    :show_env_vars_in_log, :execution_position, :dependency_file].freeze
+                                    :show_env_vars_in_log, :execution_position, :dependency_file, :always_out_of_date].freeze
 
       EXECUTION_POSITION_KEYS = [:before_compile, :after_compile, :before_headers, :after_headers, :any].freeze
 

--- a/spec/podfile/target_definition_spec.rb
+++ b/spec/podfile/target_definition_spec.rb
@@ -482,7 +482,7 @@ module Pod
         e = lambda { @parent.store_script_phase(:name => 'PhaseName', :unknown => 'Unknown') }.should.raise Podfile::StandardError
         e.message.should == 'Unrecognized options `[:unknown]` in shell script `PhaseName` within `MyApp` target. ' \
           'Available options are `[:name, :script, :shell_path, :input_files, :output_files, :input_file_lists, ' \
-            ':output_file_lists, :show_env_vars_in_log, :execution_position, :dependency_file]`.'
+            ':output_file_lists, :show_env_vars_in_log, :execution_position, :dependency_file, :always_out_of_date]`.'
       end
 
       it 'raises if script phase includes an invalid execution position key' do

--- a/spec/specification/linter_spec.rb
+++ b/spec/specification/linter_spec.rb
@@ -543,7 +543,7 @@ module Pod
         @spec.script_phases = { :name => 'Hello World', :script => 'echo "Hello World"', :unknown => 'unknown' }
         result_should_include('script_phases', 'Unrecognized option(s) `unknown` in script phase `Hello World`. ' \
           'Available options are `name, script, shell_path, input_files, output_files, input_file_lists, ' \
-          'output_file_lists, show_env_vars_in_log, execution_position, dependency_file`.')
+          'output_file_lists, show_env_vars_in_log, execution_position, dependency_file, always_out_of_date`.')
       end
 
       it 'checks script phases include a valid execution position value' do


### PR DESCRIPTION
Exposes existing `PBXShellScriptBuildPhase` attribute for enabling it in cases where it input & output file(s) are not possible to be defined.
Without it, Xcode will always give build time warning about missing inputs & outputs.

Related to: https://github.com/CocoaPods/CocoaPods/pull/12055