### PR TITLE
Fix an issue that sometimes caused Pod::Version instances to be serialized as a hash inside the :source hash

### DIFF
--- a/lib/cocoapods-core/specification/json.rb
+++ b/lib/cocoapods-core/specification/json.rb
@@ -5,7 +5,7 @@ module Pod
       #
       def to_json(*a)
         require 'json'
-        to_hash.to_json(*a) << "\n"
+        JSON.dump(to_hash, *a) << "\n"
       end
 
       # @return [String] the pretty json representation of the specification.

--- a/spec/specification/json_spec.rb
+++ b/spec/specification/json_spec.rb
@@ -21,6 +21,33 @@ module Pod
         JSON.parse(spec.to_json).should == expected
       end
 
+      it 'serializes tags with Pod::Version correctly' do
+        spec = Specification.new(nil, 'BananaLib') do |spec|
+          spec.version = '1.0'
+          spec.version.class.should == Pod::Version
+          spec.source = {
+            :git => 'https://github.com/CocoaPods/CocoaPodsExampleLibrary.git',
+            :tag => spec.version,
+          }
+        end
+        expected = {
+          'name' => 'BananaLib',
+          'version' => '1.0',
+          'source' => {
+            'git' => 'https://github.com/CocoaPods/CocoaPodsExampleLibrary.git',
+            'tag' => '1.0',
+          },
+          'platforms' => {
+            'osx' => nil,
+            'ios' => nil,
+            'tvos' => nil,
+            'visionos'=> nil,
+            'watchos' => nil,
+          },
+        }
+        JSON.parse(spec.to_json).should == expected
+      end
+
       it 'terminates the json representation with a new line' do
         spec = Specification.new(nil, 'BananaLib')
         spec.to_json.should.end_with "\n"


### PR DESCRIPTION
Cherry pick of https://github.com/CocoaPods/Core/pull/759 onto master