### PR TITLE
Support multiple CDN sources

### DIFF
--- a/.github/workflows/Specs.yml
+++ b/.github/workflows/Specs.yml
@@ -8,7 +8,7 @@ jobs:
         os: [ubuntu-20.04]
         ruby: [2.6, 2.7, 3.0.0, 3.2.2]
         include:
-          - os: macos-11
+          - os: macos-13
             ruby: system
 
     name: ${{ matrix.os }} / Ruby ${{ matrix.ruby }}

--- a/lib/cocoapods-core/cdn_source.rb
+++ b/lib/cocoapods-core/cdn_source.rb
@@ -116,7 +116,7 @@ module Pod
       pod_path_actual = pod_path(name)
       pod_path_relative = relative_pod_path(name)
 
-      return nil if @version_arrays_by_fragment_by_name[fragment][name].nil?
+      return nil if @version_arrays_by_fragment_by_name[fragment].nil? || @version_arrays_by_fragment_by_name[fragment][name].nil?
 
       concurrent_requests_catching_errors do
         loaders = []
@@ -294,7 +294,7 @@ module Pod
           hash
         end
       else
-        debug "CDN: #{name} Relative path: #{partial_url} not available in this source set"
+        debug "CDN: #{name} Relative path: #{index_file_name} not available in this source set"
       end
     end
 

--- a/lib/cocoapods-core/cdn_source.rb
+++ b/lib/cocoapods-core/cdn_source.rb
@@ -116,7 +116,7 @@ module Pod
       pod_path_actual = pod_path(name)
       pod_path_relative = relative_pod_path(name)
 
-      return nil if @version_arrays_by_fragment_by_name[fragment].nil? || @version_arrays_by_fragment_by_name[fragment][name].nil?
+      return nil if @version_arrays_by_fragment_by_name.dig(fragment, name).nil?
 
       concurrent_requests_catching_errors do
         loaders = []

--- a/lib/cocoapods-core/cdn_source.rb
+++ b/lib/cocoapods-core/cdn_source.rb
@@ -282,14 +282,19 @@ module Pod
       # We use those because you can't get a directory listing from a CDN.
       index_file_name = index_file_name_for_fragment(fragment)
       download_file(index_file_name)
-      versions_raw = local_file(index_file_name, &:to_a).map(&:chomp)
-      @version_arrays_by_fragment_by_name[fragment] = versions_raw.reduce({}) do |hash, row|
-        row = row.split('/')
-        pod = row.shift
-        versions = row
+      file_okay = local_file_okay?(index_file_name)
+      if file_okay
+        versions_raw = local_file(index_file_name, &:to_a).map(&:chomp)
+        @version_arrays_by_fragment_by_name[fragment] = versions_raw.reduce({}) do |hash, row|
+          row = row.split('/')
+          pod = row.shift
+          versions = row
 
-        hash[pod] = versions
-        hash
+          hash[pod] = versions
+          hash
+        end
+      else
+        debug "CDN: #{name} Relative path: #{partial_url} not available in this source set"
       end
     end
 

--- a/spec/cdn_source_spec.rb
+++ b/spec/cdn_source_spec.rb
@@ -424,6 +424,7 @@ module Pod
       end
 
       it 'matches case' do
+        @source.expects(:debug).with { |cmd| cmd =~ /CDN: #{@source.name} Relative path: all_pods_versions_9_5_b\.txt not available in this source set/ }
         @source.expects(:debug).with { |cmd| cmd =~ /CDN: #{@source.name} Relative path downloaded: all_pods_versions_9_5_b\.txt, save ETag:/ }
         @source.search('bEacoNKIT').should.be.nil?
       end


### PR DESCRIPTION
Allows to declare multiple CDN sources in your Podfile, even if one of them does not fully mirror the trunk.
Removes the requirement to provide empty shards for the version metadata files of non-existing pods on a CDN repo.

Prevents errors like:
```
### Error

Errno::ENOENT - No such file or directory @ rb_sysopen - /Users/nathan/.cocoapods/repos/pods-private/all_pods_versions_4_0_1.txt
```


Fixes #768 
Fixes https://github.com/CocoaPods/CocoaPods/issues/12338