### PR TITLE
Allow configuring CDN requests max concurrency to reduce flakiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ##### Enhancements
 
-* None.  
+* Add ability to configure max concurrency of CDN requests through environment variable.
+  [maikelvdh](https://github.com/maikelvdh)
+  [#773](https://github.com/CocoaPods/Core/pull/773)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods-core/cdn_source.rb
+++ b/lib/cocoapods-core/cdn_source.rb
@@ -10,6 +10,7 @@ module Pod
   class CDNSource < Source
     include Concurrent
 
+    MAX_CONCURRENCY = (ENV['COCOAPODS_CDN_MAX_CONCURRENCY'] || 200).to_i
     MAX_NUMBER_OF_RETRIES = (ENV['COCOAPODS_CDN_MAX_NUMBER_OF_RETRIES'] || 5).to_i
     # Single thread executor for all network activity.
     HYDRA_EXECUTOR = Concurrent::SingleThreadExecutor.new
@@ -489,7 +490,7 @@ module Pod
     end
 
     def queue_request(request)
-      @hydra ||= Typhoeus::Hydra.new
+      @hydra ||= Typhoeus::Hydra.new(max_concurrency: MAX_CONCURRENCY)
 
       # Queue the request into the Hydra (libcurl reactor).
       @hydra.queue(request)

--- a/lib/cocoapods-core/cdn_source.rb
+++ b/lib/cocoapods-core/cdn_source.rb
@@ -490,7 +490,7 @@ module Pod
     end
 
     def queue_request(request)
-      @hydra ||= Typhoeus::Hydra.new(max_concurrency: MAX_CONCURRENCY)
+      @hydra ||= Typhoeus::Hydra.new(:max_concurrency => MAX_CONCURRENCY)
 
       # Queue the request into the Hydra (libcurl reactor).
       @hydra.queue(request)


### PR DESCRIPTION
Introducing `COCOAPODS_CDN_MAX_CONCURRENCY` configuration point to reduce the maximum concurrency of Hydra. The default max concurrency (200) can lead to flakiness like DNS resolution failure being marked as DoS attack OR missing authorization headers. This flakiness is also remarked in the documentation of [typhoeus library](https://github.com/typhoeus/typhoeus?tab=readme-ov-file#specifying-max-concurrency).